### PR TITLE
feat(transport): add listTransports() to AdtRequest

### DIFF
--- a/src/__tests__/integration/core/transport/Transport.test.ts
+++ b/src/__tests__/integration/core/transport/Transport.test.ts
@@ -238,4 +238,45 @@ describe('AdtRequest', () => {
       getTimeout('test'),
     );
   });
+
+  describe('List transports', () => {
+    it(
+      'should list transport requests for current user',
+      async () => {
+        logTestStart(testsLogger, 'AdtRequest - list transports', {
+          name: 'list_transports',
+          params: {},
+        });
+
+        if (!hasConfig) {
+          logTestSkip(
+            testsLogger,
+            'AdtRequest - list transports',
+            'No SAP configuration',
+          );
+          return;
+        }
+
+        try {
+          logTestStep('list', testsLogger);
+          const listState = await client.getRequest().list({
+            user: process.env.SAP_USERNAME || '*',
+            status: 'D',
+          });
+
+          expect(listState).toBeDefined();
+          expect(listState.listResult).toBeDefined();
+          expect(listState.errors.length).toBe(0);
+
+          logTestSuccess(testsLogger, 'AdtRequest - list transports');
+        } catch (error: any) {
+          logTestError(testsLogger, 'AdtRequest - list transports', error);
+          throw error;
+        } finally {
+          logTestEnd(testsLogger, 'AdtRequest - list transports');
+        }
+      },
+      getTimeout('test'),
+    );
+  });
 });

--- a/src/clients/AdtClient.ts
+++ b/src/clients/AdtClient.ts
@@ -110,10 +110,6 @@ import {
   type ITableTypeState,
 } from '../core/tabletype';
 import { AdtRequest } from '../core/transport';
-import type {
-  ITransportConfig,
-  ITransportState,
-} from '../core/transport/types';
 import {
   AdtCdsUnitTest,
   AdtUnitTest,
@@ -421,7 +417,7 @@ export class AdtClient {
    * Get high-level operations for Request (Transport Request) objects
    * @returns IAdtObject instance for Request operations
    */
-  getRequest(): IAdtObject<ITransportConfig, ITransportState> {
+  getRequest(): AdtRequest {
     return new AdtRequest(this.connection, this.logger, this.systemContext);
   }
 

--- a/src/clients/AdtClientLegacy.ts
+++ b/src/clients/AdtClientLegacy.ts
@@ -39,7 +39,7 @@ import { AdtProgramLegacy } from '../core/program/AdtProgramLegacy';
 import type { AdtUtils } from '../core/shared/AdtUtils';
 import { AdtUtilsLegacy } from '../core/shared/AdtUtilsLegacy';
 import { AdtContentTypesBase } from '../core/shared/contentTypes';
-import type { ITransportConfig, ITransportState } from '../core/transport';
+import type { AdtRequest } from '../core/transport';
 import { AdtRequestLegacy } from '../core/transport/AdtRequestLegacy';
 import type { IUnitTestConfig, IUnitTestState } from '../core/unitTest';
 import { AdtUnitTestLegacy } from '../core/unitTest/AdtUnitTestLegacy';
@@ -146,7 +146,7 @@ export class AdtClientLegacy extends AdtClient {
 
   // --- Transport with legacy URL prefix ---
 
-  override getRequest(): IAdtObject<ITransportConfig, ITransportState> {
+  override getRequest(): AdtRequest {
     return new AdtRequestLegacy(
       this.connection,
       this.logger,

--- a/src/constants/contentTypes.ts
+++ b/src/constants/contentTypes.ts
@@ -44,6 +44,8 @@ export const ACCEPT_VALIDATION = 'application/vnd.sap.as+xml';
 // Transport
 export const ACCEPT_TRANSPORT =
   'application/vnd.sap.adt.transportorganizer.v1+xml';
+export const ACCEPT_TRANSPORT_LIST =
+  'application/vnd.sap.adt.transportorganizertree.v1+xml';
 export const ACCEPT_TRANSPORT_CHECK =
   'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.transport.service.checkData';
 export const CT_TRANSPORT_CHECK =

--- a/src/core/transport/AdtRequest.ts
+++ b/src/core/transport/AdtRequest.ts
@@ -29,6 +29,7 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import { createTransport } from './create';
+import { listTransports } from './list';
 import { getTransport } from './read';
 import type { ITransportConfig, ITransportState } from './types';
 
@@ -143,6 +144,27 @@ export class AdtRequest
       }
       throw error;
     }
+  }
+
+  /**
+   * List transport requests
+   */
+  async list(params: {
+    user: string;
+    status?: string;
+    dateRange?: string;
+    targetSystem?: string;
+    requestType?: string;
+  }): Promise<ITransportState> {
+    this.logger?.info?.('Listing transport requests for user:', params.user);
+    const response = await listTransports(this.connection, {
+      user: params.user,
+      status: params.status,
+      date_range: params.dateRange,
+      target_system: params.targetSystem,
+      request_type: params.requestType,
+    });
+    return { listResult: response, errors: [] };
   }
 
   /**

--- a/src/core/transport/index.ts
+++ b/src/core/transport/index.ts
@@ -7,7 +7,11 @@ import type { ITransportConfig, ITransportState } from './types';
 
 export { AdtRequest } from './AdtRequest';
 export { AdtRequestLegacy } from './AdtRequestLegacy';
-export type { ITransportConfig, ITransportState } from './types';
+export type {
+  IListTransportsParams,
+  ITransportConfig,
+  ITransportState,
+} from './types';
 
 // Type alias for AdtRequest
 export type AdtRequestType = IAdtObject<ITransportConfig, ITransportState>;

--- a/src/core/transport/list.ts
+++ b/src/core/transport/list.ts
@@ -1,0 +1,34 @@
+/**
+ * Transport list operations
+ */
+
+import type { IAbapConnection, IAdtResponse } from '@mcp-abap-adt/interfaces';
+import { ACCEPT_TRANSPORT_LIST } from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+import type { IListTransportsParams } from './types';
+
+/**
+ * List ABAP transport requests
+ *
+ * Calls GET /sap/bc/adt/cts/transportrequests with query parameters.
+ * Goes through standard connection.makeAdtRequest() so Accept negotiation works.
+ */
+export async function listTransports(
+  connection: IAbapConnection,
+  params: IListTransportsParams,
+): Promise<IAdtResponse> {
+  const query = new URLSearchParams({ user: params.user });
+  if (params.status) query.append('status', params.status);
+  if (params.date_range) query.append('dateRange', params.date_range);
+  if (params.target_system) query.append('targetSystem', params.target_system);
+  if (params.request_type) query.append('type', params.request_type);
+
+  const url = `/sap/bc/adt/cts/transportrequests?${query.toString()}`;
+
+  return connection.makeAdtRequest({
+    url,
+    method: 'GET',
+    timeout: getTimeout('default'),
+    headers: { Accept: ACCEPT_TRANSPORT_LIST },
+  });
+}

--- a/src/core/transport/types.ts
+++ b/src/core/transport/types.ts
@@ -2,7 +2,7 @@
  * Transport module type definitions
  */
 
-import type { IAdtObjectState } from '@mcp-abap-adt/interfaces';
+import type { IAdtObjectState, IAdtResponse } from '@mcp-abap-adt/interfaces';
 
 // Low-level function parameters (snake_case) - internal use only
 export interface ICreateTransportParams {
@@ -10,6 +10,15 @@ export interface ICreateTransportParams {
   description: string;
   target_system?: string;
   owner?: string;
+}
+
+// Low-level function parameters for listing transports (snake_case) - internal use only
+export interface IListTransportsParams {
+  user: string;
+  status?: string; // D = modifiable, R = released
+  date_range?: string; // e.g. "20260101-20260326"
+  target_system?: string;
+  request_type?: string; // K = workbench, T = customizing
 }
 
 // Transport request configuration (camelCase)
@@ -25,4 +34,5 @@ export interface ITransportConfig {
 export interface ITransportState extends IAdtObjectState {
   transportNumber?: string;
   taskNumber?: string;
+  listResult?: IAdtResponse;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,7 @@ export type {
 } from './core/tabletype';
 export type {
   AdtRequestType,
+  IListTransportsParams,
   ITransportConfig,
   ITransportState,
 } from './core/transport';


### PR DESCRIPTION
## Summary

- Add `list()` method to `AdtRequest` for querying transport requests via `GET /sap/bc/adt/cts/transportrequests`
- Proper `Accept` header (`transportorganizertree`) with negotiation support (406/415 retry)
- Supports query params: `user`, `status`, `dateRange`, `targetSystem`, `requestType`
- Exposed via `AdtClient.getRequest().list()`

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run test:check` passes
- [ ] Integration test: `npm test -- integration/core/transport`

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)