### PR TITLE
chore: release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.2.0] - 2026-04-19
 
 ### Added
 
 - **authorizationField** core module: SUSO / AUTH type handler with full CRUD + lifecycle. New `AdtClient.getAuthorizationField()` factory. Endpoint `/sap/bc/adt/aps/iam/auth/{name}`. Available on modern on-prem (E19+) and cloud MDD; absent on legacy systems. (#19)
 - **functionInclude** core module: FUGR/I source-bearing handler with full CRUD + lifecycle and dedicated `readSource()`. New `AdtClient.getFunctionInclude()` factory. Endpoint `/sap/bc/adt/functions/groups/{groupName}/includes/{includeName}`. Available on all systems (legacy, modern on-prem, cloud). (#19)
+
+### Documentation
+
+- README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, ADT_OBJECT_ENTITIES updated for the two new modules. (#21)
 
 ## [5.1.0] - 2026-04-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Release 5.2.0 bundling #19 (two new core modules) and #21 (user-facing docs).

- Bump `package.json` version: 5.1.0 → 5.2.0
- Regenerate `package-lock.json` (no `"link": true` entries)
- Promote `## [Unreleased]` CHANGELOG section to `## [5.2.0] - 2026-04-19`

## Test plan
- [x] `npm install --package-lock-only` — clean, 0 link entries
- [x] Version alignment: package.json + CHANGELOG
- [x] Release assembles only merged, previously-reviewed PRs (#19 + #21)

After merge: tag `v5.2.0` and `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)