### PR TITLE
fix: remove vestigial node-rfc dependency and align docs to sap-rfc-lite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ RFC connections are required for legacy SAP systems (BASIS < 7.50) where HTTP st
 
 **Prerequisites:**
 1. SAP NW RFC SDK installed (download from SAP Support Portal, requires S-user)
-2. `node-rfc` package installed (`npm install node-rfc`) — loaded dynamically at runtime
+2. RFC transport is provided by `@mcp-abap-adt/sap-rfc-lite` (transitive dependency via `@mcp-abap-adt/connection`) — nothing to install in this package
 3. SAP user has `S_RFC` authorization for `SADT_REST_RFC_ENDPOINT` (SAP Note 3569684)
 
 **Ensure `test-config.yaml` has `connection_type: "rfc"`:**

--- a/docs/architecture/LEGACY.md
+++ b/docs/architecture/LEGACY.md
@@ -19,7 +19,7 @@ Legacy systems do not support the `x-sap-adt-sessiontype: stateful` HTTP header 
 | Content negotiation | Standard HTTP Accept | Some endpoints only accept `*/*` |
 | sap-client | URL query parameter | Set in RFC connection params |
 | Authentication | Basic / JWT / XSUAA | Username + password only |
-| Dependencies | axios | node-rfc + SAP NW RFC SDK |
+| Dependencies | axios | @mcp-abap-adt/sap-rfc-lite + SAP NW RFC SDK |
 | Systems | Modern (>= 7.50) | All (primary use: legacy) |
 
 See [RFC_CONNECTION.md](../usage/RFC_CONNECTION.md) for setup and configuration.

--- a/docs/usage/RFC_CONNECTION.md
+++ b/docs/usage/RFC_CONNECTION.md
@@ -39,13 +39,11 @@ export LD_LIBRARY_PATH=$SAPNWRFC_HOME/lib:$LD_LIBRARY_PATH
 
 > **Note:** These variables must be set in the shell before running the application. They cannot be loaded from `.env` files because `dotenv` does not expand `$PATH`/`%PATH%` and does not modify the system PATH.
 
-### 2. node-rfc Package
+### 2. RFC transport
 
-```bash
-npm install node-rfc
-```
+RFC transport is provided by `@mcp-abap-adt/sap-rfc-lite`, which is pulled in automatically as a dependency of `@mcp-abap-adt/connection`. Nothing needs to be installed manually in this package — `adt-clients` consumes the `IAbapConnection` interface and does not depend on any RFC library directly.
 
-`node-rfc` is NOT a declared dependency of this package — it is loaded dynamically at runtime only when RFC connections are used.
+`@mcp-abap-adt/sap-rfc-lite` binds to the SAP NW RFC SDK at runtime; the SDK libraries must be on the shared-library path as shown in step 1.
 
 ### 3. SAP Authorization
 
@@ -110,7 +108,7 @@ If omitted, the library defaults to `text/plain; charset=utf-8` (unicode). Setti
 
 ## How It Works
 
-1. `RfcAbapConnection.connect()` opens an RFC connection via `node-rfc`
+1. `RfcAbapConnection.connect()` opens an RFC connection via `@mcp-abap-adt/sap-rfc-lite`
 2. Each `makeAdtRequest()` call invokes `SADT_REST_RFC_ENDPOINT` FM
 3. The FM proxies HTTP-like requests internally within the ABAP system
 4. The RFC session is inherently stateful — lock handles persist across calls
@@ -125,19 +123,19 @@ If omitted, the library defaults to `text/plain; charset=utf-8` (unicode). Setti
 | Content negotiation | Standard HTTP Accept | Some endpoints only accept `*/*` |
 | sap-client | Added to URL query | Not needed (set in RFC params) |
 | Authentication | Basic/JWT/XSUAA | Username/password only |
-| Dependencies | axios | node-rfc + SAP NW RFC SDK |
+| Dependencies | axios | @mcp-abap-adt/sap-rfc-lite + SAP NW RFC SDK |
 
 ## Troubleshooting
 
-### "node-rfc is not available"
+### "sap-rfc-lite is not available" / "RFC transport not loadable"
 
 SAP NW RFC SDK is not installed or not in PATH. Verify:
 ```bash
 # Check SAPNWRFC_HOME
 echo $SAPNWRFC_HOME
 
-# Check lib is in PATH
-node -e "try { require('node-rfc'); console.log('OK'); } catch(e) { console.log(e.message.substring(0, 200)); }"
+# Check the SDK loads (adjust the require() to the actual sap-rfc-lite entry point if needed)
+node -e "try { require('@mcp-abap-adt/sap-rfc-lite'); console.log('OK'); } catch(e) { console.log(e.message.substring(0, 200)); }"
 ```
 
 ### "The specified module could not be found: sapnwrfc.node"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,9 +30,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "node-rfc": "^3.3.1"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -22055,57 +22052,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/node-rfc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-rfc/-/node-rfc-3.3.1.tgz",
-      "integrity": "sha512-THRnmgG0+CNuZqt6p8lW9P+b95z4qx4821e/a0oFR5tfNh4Nj4PbhZ0LScxEOMZC+e/m0I58tTVUj3o9+OOLVg==",
-      "deprecated": "No longer supported, check https://github.com/SAP/node-rfc/issues/329",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bluebird": "^3.7.2",
-        "decimal.js": "^10.4.3",
-        "node-addon-api": "^6.1.0",
-        "node-gyp-build": "^4.6.0"
-      },
-      "engines": {
-        "node": "^18 || >= 20"
-      }
-    },
-    "node_modules/node-rfc/node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/node-rfc/node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/node-rfc/node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/node-rfc/node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -73,9 +73,6 @@
     "fast-xml-parser": "^5.4.1",
     "yaml": "^2.3.4"
   },
-  "optionalDependencies": {
-    "node-rfc": "^3.3.1"
-  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
     "@mcp-abap-adt/connection": "^1.8.0",


### PR DESCRIPTION
## Summary
Closes #23.

- Drop `optionalDependencies.node-rfc` from `package.json` (no runtime code in `src/` references it; RFC transport is now provided by `@mcp-abap-adt/sap-rfc-lite` as a transitive dependency of `@mcp-abap-adt/connection`).
- Regenerate `package-lock.json` — `node-rfc` fully removed from the lockfile (0 references).
- Update `docs/usage/RFC_CONNECTION.md`, `docs/architecture/LEGACY.md`, and `CLAUDE.md` to consistently reference `@mcp-abap-adt/sap-rfc-lite` instead of `node-rfc`.

## Test plan
- [x] `grep node-rfc` across `package.json`, `package-lock.json`, `CLAUDE.md`, `docs/` — zero hits
- [x] `npm install --package-lock-only` — clean, 0 `"link": true` entries
- [x] `npm run build` — Biome + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)