### PR TITLE
chore: release 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.1] - 2026-04-19
+
+### Fixed
+
+- Remove vestigial `optionalDependencies.node-rfc` from `package.json` and regenerate `package-lock.json`; RFC transport has been provided by `@mcp-abap-adt/sap-rfc-lite` via `@mcp-abap-adt/connection` for several releases, and the direct `node-rfc` entry was dead metadata. (#23, #24)
+
+### Documentation
+
+- Align `docs/usage/RFC_CONNECTION.md`, `docs/architecture/LEGACY.md`, and `CLAUDE.md` to reference `@mcp-abap-adt/sap-rfc-lite` instead of `node-rfc`. (#24)
+
 ## [5.2.0] - 2026-04-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Patch release bundling #24 (node-rfc cleanup + RFC docs alignment).

- Bump `package.json` version: 5.2.0 → 5.2.1
- Regenerate `package-lock.json`
- Promote CHANGELOG section to `## [5.2.1] - 2026-04-19` under **Fixed** and **Documentation**

Closes #23 (already closed by #24 merge).

## Test plan
- [x] `npm install --package-lock-only` — clean, 0 `"link": true` entries, 0 `node-rfc` references
- [x] Version alignment: package.json + CHANGELOG
- [x] Release assembles only merged, previously-reviewed PR (#24)

After merge: tag `v5.2.1` and `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)