### PR TITLE
docs: propose sapcli-derived separate ADT clients roadmap

### DIFF
--- a/docs/superpowers/plans/2026-04-19-abapgit-client.md
+++ b/docs/superpowers/plans/2026-04-19-abapgit-client.md
@@ -1,0 +1,1633 @@
+# abapGit Client Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `AdtAbapGitClient` under `src/clients/` — a specialized separate client wrapping the SAP-official ADT-integrated abapGit (`/sap/bc/adt/abapgit/*`). Covers link, pull (with async status polling), unlink (conditional on verified delete contract), listRepos, getRepo, getErrorLog, and checkExternalRepo.
+
+**Architecture:**
+- Separate client, not a `src/core/` module (abapGit has no ADT-artefact lifecycle). Factory: `AdtClient.getAbapGit(options?)` returns `IAdtAbapGitClient` — specialized interface per roadmap §4.2.
+- Sapcli parity for `link` / `pull` plus extended read operations (listRepos / getRepo / getErrorLog) and pre-link validation (checkExternalRepo). `unlink` only ships if its delete contract is verified on a live target in Phase Z.
+- Async polling for `pull` is abstracted inside the client. `AbortSignal` and `maxPollDurationMs` stop only the client-side wait — the server-side job may continue. The client attaches `lastKnownStatus` to the thrown `AbortError` / `TimeoutError` so callers can recover.
+
+**Tech Stack:** TypeScript strict, CommonJS, Node.js ≥18, Biome (lint + format), `fast-xml-parser` for XML, Jest integration tests. No new runtime dependencies.
+
+**Verification source:** `docs/superpowers/specs/2026-04-19-abapgit-client-design.md`. Endpoints cross-checked against sapcli (`sap/cli/abapgit.py`, `sap/adt/abapgit.py`) + `docs/discovery/discovery_{cloud_mdd,trial}_raw.xml` (E19/E77 not in corpus).
+
+**Endpoints (canonical):**
+- Collection: `/sap/bc/adt/abapgit/repos`
+- Single-repo sub-ops: via atom links on the repo entity (`pull_link`, `log_link`, and — if verified — `edit_link` / `delete_link`)
+- External repo probe: `/sap/bc/adt/abapgit/externalrepoinfo`
+- Default Content-Type: `application/abapgit.adt.repo.v3+xml` (sapcli-compat); `v4` opt-in via options
+
+**XML namespaces:**
+- Envelope: `abapgitrepo` → `http://www.sap.com/adt/abapgit/repositories`
+- Error-log items: `abapObjects` → `http://www.sap.com/adt/abapgit/abapObjects`
+- Atom links: `http://www.w3.org/2005/Atom`
+
+**Branch policy.** Implemented on a dedicated feature branch forked from `main` (NOT from `proposal/sapcli-separate-clients`). Branch name: `feature/abapgit-client`.
+
+---
+
+## File Structure
+
+### New module under `src/clients/abapGit/` (10 files)
+
+```
+src/clients/
+  AdtAbapGitClient.ts           # handler class — implements IAdtAbapGitClient
+  abapGit/
+    types.ts                    # public + internal types, IAdtAbapGitClient, IAdtAbapGitClientOptions
+    xmlBuilder.ts               # builds <abapgitrepo:repository> envelope for link/pull
+    xmlParser.ts                # parses repo list, single repo, error log, externalrepoinfo
+    link.ts                     # POST /repos — create binding
+    pull.ts                     # POST <pull_link> + poll loop + lastKnownStatus handling
+    unlink.ts                   # DELETE <edit_link> | /repos/{id} — conditional on Phase Z verification
+    listRepos.ts                # GET /repos — returns IAbapGitRepoStatus[]
+    getErrorLog.ts              # GET <log_link> — returns IAbapGitErrorLogEntry[]
+    checkExternalRepo.ts        # POST /externalrepoinfo — returns IAbapGitExternalRepoInfo
+    poll.ts                     # internal polling helper with AbortSignal + max-duration
+```
+
+### Cross-cutting updates
+
+- `src/clients/AdtClient.ts` — add `getAbapGit()` factory + imports
+- `src/index.ts` — export the specialized interface and all public types
+- `src/__tests__/integration/clients/abapGit/AbapGit.test.ts` — new integration test (new fixture path `src/__tests__/integration/clients/` per roadmap §4)
+- `src/__tests__/helpers/test-config.yaml.template` — add `abapgit_*` sections
+- `CLAUDE.md` — add a short note about the new client alongside AdtClient / AdtRuntimeClient / AdtExecutor / AdtClientsWS
+- `README.md`, `CHANGELOG.md`, `docs/usage/CLIENT_API_REFERENCE.md`, `docs/architecture/ARCHITECTURE.md`, `docs/architecture/LEGACY.md` — per the #21 / #28 pattern
+- `docs/usage/ADT_OBJECT_ENTITIES.md` — regenerated via `npm run adt:entities`
+
+---
+
+## Phase Z: Pre-coding protocol verification
+
+**This phase happens BEFORE any of the implementation phases below.** Per the spec (§2, §6.3, §8), `unlink` and `checkExternalRepo` ship only against a verified live contract. No speculative protocol path ships.
+
+### Task Z1: Live-probe the abapGit endpoint family
+
+**Files:** none (verification only — findings captured as a short report under `docs/superpowers/specs/2026-04-19-abapgit-client-design.md` as §12 "Live-probe findings").
+
+- [ ] **Step 1: Confirm cloud trial JWT is fresh**
+
+Run: `grep SAP_URL ~/prj/mcp-abap-adt-clients/.env`
+Expected: points at the cloud trial. If JWT is expired, refresh before proceeding.
+
+- [ ] **Step 2: Probe the collection (list)**
+
+Run a one-off node script (`probe-abapgit.js` — kept locally, gitignored):
+
+```javascript
+require('dotenv').config();
+const { createAbapConnection } = require('@mcp-abap-adt/connection');
+(async () => {
+  const conn = createAbapConnection({
+    authType: 'jwt',
+    url: process.env.SAP_URL,
+    jwtToken: process.env.SAP_JWT_TOKEN,
+    uaaUrl: process.env.SAP_UAA_URL,
+    uaaClientId: process.env.SAP_UAA_CLIENT_ID,
+    uaaClientSecret: process.env.SAP_UAA_CLIENT_SECRET,
+  });
+  const r = await conn.makeAdtRequest({
+    method: 'GET',
+    url: '/sap/bc/adt/abapgit/repos',
+    headers: { Accept: 'application/abapgit.adt.repos.v2+xml' },
+  });
+  console.log('status:', r.status);
+  console.log('first 2000 chars:', String(r.data).slice(0, 2000));
+})();
+```
+
+Expected output: HTTP 200 with an XML list (may be empty). Record: exact root element name, atom links on each repo entry, whether `edit_link` / `delete_link` appears.
+
+- [ ] **Step 3: If the list is empty, create one test repo via `link` manually**
+
+Use a read-only public repo to avoid auth complications, e.g. `https://github.com/sap/abap-platform-refscen-flight` (public) or any public repo owned by user.
+
+```javascript
+await conn.makeAdtRequest({
+  method: 'POST',
+  url: '/sap/bc/adt/abapgit/repos',
+  headers: { 'Content-Type': 'application/abapgit.adt.repo.v3+xml' },
+  data: `<?xml version="1.0" encoding="UTF-8"?>
+<abapgitrepo:repository xmlns:abapgitrepo="http://www.sap.com/adt/abapgit/repositories">
+  <abapgitrepo:package>$TMP</abapgitrepo:package>
+  <abapgitrepo:url>https://github.com/<user>/<repo></abapgitrepo:url>
+  <abapgitrepo:branchName>refs/heads/main</abapgitrepo:branchName>
+</abapgitrepo:repository>`,
+});
+```
+
+Record: the HTTP status, response body, whether the link succeeds on trial with `$TMP` package.
+
+- [ ] **Step 4: Probe `externalrepoinfo`**
+
+```javascript
+const r = await conn.makeAdtRequest({
+  method: 'POST',
+  url: '/sap/bc/adt/abapgit/externalrepoinfo',
+  headers: {
+    'Content-Type': 'application/abapgit.adt.repo.info.ext.request.v2+xml',
+    Accept: 'application/abapgit.adt.repo.info.ext.request.v2+xml',
+  },
+  data: `<?xml version="1.0" encoding="UTF-8"?>
+<abapgitrepo:externalRepoInfoRequest xmlns:abapgitrepo="http://www.sap.com/adt/abapgit/repositories">
+  <abapgitrepo:url>https://github.com/<user>/<repo></abapgitrepo:url>
+</abapgitrepo:externalRepoInfoRequest>`,
+});
+console.log('status:', r.status);
+console.log('response:', String(r.data));
+```
+
+Record: response body shape, element names for branches, access field. This becomes the `IAbapGitExternalRepoInfo` contract.
+
+- [ ] **Step 5: Probe delete**
+
+Try both candidates against the created test repo:
+
+**(a) Atom `edit_link` / `delete_link`:** use the href extracted from the list response, `DELETE` that URL.
+
+**(b) `/repos/{id}`:** extract `repositoryId` (or equivalent) from the list response, `DELETE /sap/bc/adt/abapgit/repos/{id}`.
+
+Record which returns 2xx. If neither does, record the error response so Phase B's unlink task can be DEFERRED.
+
+- [ ] **Step 6: Write up findings**
+
+Append a new section `## 12. Live-probe findings (2026-04-19)` to `docs/superpowers/specs/2026-04-19-abapgit-client-design.md` with:
+- Confirmed response XML shape for `listRepos` (root element + repo entry elements + atom link types observed)
+- `repositoryId` location (which element or attribute)
+- Confirmed `externalrepoinfo` request envelope element name + response XML shape
+- Confirmed delete contract: atom link, `/repos/{id}`, or DEFER-UNLINK
+- Content-Type version used for each operation (v2 repos list is sapcli; confirm if v4 is required or optional)
+
+Commit the spec update:
+
+```bash
+git add docs/superpowers/specs/2026-04-19-abapgit-client-design.md
+git commit -m "docs(spec): abapGit live-probe findings for cloud trial"
+```
+
+- [ ] **Step 7: Decide v1 unlink**
+
+If Phase Z confirms a delete contract → unlink stays in v1.
+If neither candidate works on trial → remove `unlink` from `IAdtAbapGitClient` and from all implementation tasks (Task E3 below). Update Task A1's type definitions to omit `unlink` / `IAbapGitUnlinkArgs`.
+
+This is the last step before coding begins. Do NOT proceed to Phase A without this decision recorded in the spec.
+
+---
+
+## Phase A: Types and scaffolding
+
+### Task A1: `src/clients/abapGit/types.ts`
+
+**Files:**
+- Create: `src/clients/abapGit/types.ts`
+
+- [ ] **Step 1: Create directory**
+
+```bash
+mkdir -p src/clients/abapGit
+```
+
+- [ ] **Step 2: Write `types.ts`**
+
+```typescript
+/**
+ * abapGit client type definitions.
+ *
+ * Public surface (IAdtAbapGitClient) covers the ADT-integrated abapGit
+ * (/sap/bc/adt/abapgit/*). link and pull match sapcli parity; unlink,
+ * listRepos, getRepo, getErrorLog, and checkExternalRepo extend beyond
+ * sapcli with discovery-evidenced endpoints.
+ *
+ * Pull is asynchronous server-side. The client-side wait loop respects
+ * AbortSignal and a max-duration cap; aborting or timing out stops the
+ * client wait only — the server-side job may still be running, and
+ * callers must poll getRepo(package) until status != 'R' before
+ * re-issuing pull or unlink.
+ */
+
+export type AbapGitStatus = 'R' | 'E' | 'A' | string;
+
+export interface IAbapGitRepoStatus {
+  package: string;
+  url: string;
+  branchName: string;
+  status: AbapGitStatus;
+  statusText: string;
+  createdBy?: string;
+  createdAt?: string;
+  repositoryId?: string;
+}
+
+export interface IAbapGitErrorLogEntry {
+  msgType: 'E' | 'W' | 'I' | 'S' | string;
+  objectType: string;
+  objectName: string;
+  messageText: string;
+}
+
+export interface IAbapGitLinkArgs {
+  package: string;
+  url: string;
+  branchName?: string;
+  remoteUser?: string;
+  remotePassword?: string;
+  transportRequest?: string;
+}
+
+export interface IAbapGitPullArgs {
+  package: string;
+  branchName?: string;
+  remoteUser?: string;
+  remotePassword?: string;
+  transportRequest?: string;
+  pollIntervalMs?: number;
+  maxPollDurationMs?: number;
+  signal?: AbortSignal;
+  onProgress?: (status: IAbapGitRepoStatus) => void;
+}
+
+export interface IAbapGitPullResult {
+  finalStatus: IAbapGitRepoStatus;
+  errorLog?: IAbapGitErrorLogEntry[];
+}
+
+export interface IAbapGitUnlinkArgs {
+  package: string;
+  transportRequest?: string;
+}
+
+export interface IAbapGitExternalRepoCredentials {
+  url: string;
+  remoteUser?: string;
+  remotePassword?: string;
+}
+
+export interface IAbapGitExternalRepoBranch {
+  name: string;
+  sha1: string;
+  isHead: boolean;
+  type?: string;
+}
+
+export interface IAbapGitExternalRepoInfo {
+  branches: IAbapGitExternalRepoBranch[];
+  access?: 'read' | 'write' | string;
+}
+
+export interface IAbapGitAbortedError extends Error {
+  name: 'AbortError';
+  lastKnownStatus?: IAbapGitRepoStatus;
+}
+
+export interface IAbapGitTimeoutError extends Error {
+  name: 'TimeoutError';
+  lastKnownStatus?: IAbapGitRepoStatus;
+}
+
+export interface IAdtAbapGitClientOptions {
+  contentTypeVersion?: 'v3' | 'v4';
+}
+
+export interface IAdtAbapGitClient {
+  link(args: IAbapGitLinkArgs): Promise<void>;
+  pull(args: IAbapGitPullArgs): Promise<IAbapGitPullResult>;
+  unlink(args: IAbapGitUnlinkArgs): Promise<void>;
+  listRepos(): Promise<IAbapGitRepoStatus[]>;
+  getRepo(packageName: string): Promise<IAbapGitRepoStatus | undefined>;
+  getErrorLog(packageName: string): Promise<IAbapGitErrorLogEntry[]>;
+  checkExternalRepo(args: IAbapGitExternalRepoCredentials): Promise<IAbapGitExternalRepoInfo>;
+}
+```
+
+**If Phase Z deferred unlink**, omit the `unlink` method from `IAdtAbapGitClient` and omit `IAbapGitUnlinkArgs`.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run build:fast`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/clients/abapGit/types.ts
+git commit -m "feat(abapGit): add type definitions and IAdtAbapGitClient interface"
+```
+
+---
+
+### Task A2: Content-type constants
+
+**Files:**
+- Modify: `src/constants/contentTypes.ts`
+
+- [ ] **Step 1: Read** `src/constants/contentTypes.ts` to find the appropriate placement (alphabetical by object family).
+
+- [ ] **Step 2: Append new constants near the bottom, before any trailing exports**
+
+```typescript
+// abapGit (/sap/bc/adt/abapgit/*)
+// Envelope for the repository entity (sapcli parity: v3; v4 advertised
+// in discovery but kept opt-in via IAdtAbapGitClientOptions.contentTypeVersion).
+export const CT_ABAPGIT_REPO_V3 =
+  'application/abapgit.adt.repo.v3+xml';
+export const CT_ABAPGIT_REPO_V4 =
+  'application/abapgit.adt.repo.v4+xml';
+
+// Accept for the repo list (sapcli uses v2; v4 advertised in discovery).
+export const ACCEPT_ABAPGIT_REPOS_V2 =
+  'application/abapgit.adt.repos.v2+xml';
+
+// Accept/Content-Type for the error log (sapcli parity).
+export const CT_ABAPGIT_REPO_OBJECT_V2 =
+  'application/abapgit.adt.repo.object.v2+xml';
+
+// External-repo probe (discovery-only; confirmed during Phase Z).
+export const CT_ABAPGIT_EXTERNAL_REPO_INFO_V2 =
+  'application/abapgit.adt.repo.info.ext.request.v2+xml';
+```
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+npm run build:fast
+git add src/constants/contentTypes.ts
+git commit -m "feat(abapGit): add content-type constants"
+```
+
+---
+
+## Phase B: XML builder and parser
+
+### Task B1: `src/clients/abapGit/xmlBuilder.ts`
+
+**Files:**
+- Create: `src/clients/abapGit/xmlBuilder.ts`
+
+- [ ] **Step 1: Write `xmlBuilder.ts`**
+
+```typescript
+/**
+ * XML builders for abapGit request envelopes.
+ *
+ * Matches sapcli's repo_request_body helper: null-valued fields are
+ * omitted. Envelope element name is <abapgitrepo:repository> for link
+ * and pull; externalrepoinfo uses its own envelope.
+ */
+
+import type {
+  IAbapGitExternalRepoCredentials,
+  IAbapGitLinkArgs,
+  IAbapGitPullArgs,
+} from './types';
+
+const NS_ABAPGITREPO = 'http://www.sap.com/adt/abapgit/repositories';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function child(tag: string, value: string | undefined): string {
+  if (value === undefined || value === null) return '';
+  return `<abapgitrepo:${tag}>${escapeXml(value)}</abapgitrepo:${tag}>`;
+}
+
+export function buildLinkBody(args: IAbapGitLinkArgs): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<abapgitrepo:repository xmlns:abapgitrepo="${NS_ABAPGITREPO}">` +
+    child('package', args.package) +
+    child('url', args.url) +
+    child('branchName', args.branchName ?? 'refs/heads/master') +
+    child('remoteUser', args.remoteUser) +
+    child('remotePassword', args.remotePassword) +
+    child('transportRequest', args.transportRequest) +
+    `</abapgitrepo:repository>`
+  );
+}
+
+export function buildPullBody(
+  args: IAbapGitPullArgs,
+  resolvedBranch: string,
+): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<abapgitrepo:repository xmlns:abapgitrepo="${NS_ABAPGITREPO}">` +
+    child('package', args.package) +
+    child('branchName', resolvedBranch) +
+    child('remoteUser', args.remoteUser) +
+    child('remotePassword', args.remotePassword) +
+    child('transportRequest', args.transportRequest) +
+    `</abapgitrepo:repository>`
+  );
+}
+
+export function buildExternalRepoInfoBody(
+  args: IAbapGitExternalRepoCredentials,
+  envelopeTagName: string,
+): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<abapgitrepo:${envelopeTagName} xmlns:abapgitrepo="${NS_ABAPGITREPO}">` +
+    child('url', args.url) +
+    child('remoteUser', args.remoteUser) +
+    child('remotePassword', args.remotePassword) +
+    `</abapgitrepo:${envelopeTagName}>`
+  );
+}
+```
+
+`envelopeTagName` is a parameter because the Phase-Z verification determines the exact element name (likely `externalRepoInfoRequest` but confirmed live).
+
+- [ ] **Step 2: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/abapGit/xmlBuilder.ts
+git commit -m "feat(abapGit): add XML envelope builder"
+```
+
+---
+
+### Task B2: `src/clients/abapGit/xmlParser.ts`
+
+**Files:**
+- Create: `src/clients/abapGit/xmlParser.ts`
+
+- [ ] **Step 1: Read Phase Z findings** (§12 of the spec) to confirm element names for `repositoryId`, atom-link types, and `externalrepoinfo` response shape.
+
+- [ ] **Step 2: Write `xmlParser.ts`**
+
+```typescript
+/**
+ * XML parsers for abapGit responses.
+ *
+ * Uses fast-xml-parser (already a project dependency). Namespace
+ * handling: the parser preserves prefixes but we index by the suffix
+ * after the colon for brevity. Element names below correspond to the
+ * abapGit XSDs confirmed during Phase Z.
+ */
+
+import { XMLParser } from 'fast-xml-parser';
+import type {
+  IAbapGitErrorLogEntry,
+  IAbapGitExternalRepoBranch,
+  IAbapGitExternalRepoInfo,
+  IAbapGitRepoStatus,
+} from './types';
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+  removeNSPrefix: true,
+  isArray: (name) =>
+    name === 'repository' || name === 'abapObject' || name === 'branch' || name === 'link',
+});
+
+function asString(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return '';
+}
+
+export interface IRepoEntityAtomLinks {
+  pullLink?: string;
+  logLink?: string;
+  editLink?: string;
+}
+
+export interface IRepoEntityParsed extends IAbapGitRepoStatus {
+  atomLinks: IRepoEntityAtomLinks;
+}
+
+function parseAtomLinks(repoNode: any): IRepoEntityAtomLinks {
+  const links = Array.isArray(repoNode?.link) ? repoNode.link : [];
+  const out: IRepoEntityAtomLinks = {};
+  for (const link of links) {
+    const type = asString(link?.type);
+    const href = asString(link?.href);
+    if (!href) continue;
+    if (type === 'pull_link') out.pullLink = href;
+    else if (type === 'log_link') out.logLink = href;
+    else if (type === 'edit_link' || type === 'delete_link') out.editLink = href;
+  }
+  return out;
+}
+
+function parseRepoEntity(repoNode: any): IRepoEntityParsed {
+  return {
+    package: asString(repoNode?.package),
+    url: asString(repoNode?.url),
+    branchName: asString(repoNode?.branchName),
+    status: asString(repoNode?.status),
+    statusText: asString(repoNode?.statusText),
+    createdBy: asString(repoNode?.createdBy) || undefined,
+    createdAt: asString(repoNode?.createdAt) || undefined,
+    repositoryId:
+      asString(repoNode?.repositoryId) || asString(repoNode?.key) || undefined,
+    atomLinks: parseAtomLinks(repoNode),
+  };
+}
+
+export function parseRepoList(xml: string): IRepoEntityParsed[] {
+  const parsed = parser.parse(xml) as any;
+  // Root element name observed in Phase Z: 'repositories' (confirmed).
+  const repos = parsed?.repositories?.repository ?? [];
+  return (Array.isArray(repos) ? repos : [repos]).filter(Boolean).map(parseRepoEntity);
+}
+
+export function parseErrorLog(xml: string): IAbapGitErrorLogEntry[] {
+  const parsed = parser.parse(xml) as any;
+  // Root element name observed in Phase Z: 'abapObjects' (confirmed).
+  const items = parsed?.abapObjects?.abapObject ?? [];
+  return (Array.isArray(items) ? items : [items]).filter(Boolean).map((o: any) => ({
+    msgType: asString(o?.msgType),
+    objectType: asString(o?.type),
+    objectName: asString(o?.name),
+    messageText: asString(o?.msgText),
+  }));
+}
+
+export function parseExternalRepoInfo(xml: string): IAbapGitExternalRepoInfo {
+  const parsed = parser.parse(xml) as any;
+  // Root element name and branch element name confirmed in Phase Z.
+  const root = parsed?.externalRepoInfo ?? parsed?.externalRepoInfoResponse ?? {};
+  const rawBranches = root?.branches?.branch ?? root?.branch ?? [];
+  const branches: IAbapGitExternalRepoBranch[] = (Array.isArray(rawBranches) ? rawBranches : [rawBranches])
+    .filter(Boolean)
+    .map((b: any) => ({
+      name: asString(b?.name),
+      sha1: asString(b?.sha1),
+      isHead: String(asString(b?.isHead)).toLowerCase() === 'true',
+      type: asString(b?.type) || undefined,
+    }));
+  return {
+    branches,
+    access: asString(root?.access) || undefined,
+  };
+}
+```
+
+Implementation detail: the `parseExternalRepoInfo` root name has two candidates — the actual name comes from Phase Z step 4. If Phase Z showed a single fixed root, drop the `??` branch and keep only the verified one.
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/abapGit/xmlParser.ts
+git commit -m "feat(abapGit): add XML response parser"
+```
+
+---
+
+## Phase C: Low-level HTTP operations
+
+### Task C1: `link.ts` and `listRepos.ts`
+
+**Files:**
+- Create: `src/clients/abapGit/link.ts`
+- Create: `src/clients/abapGit/listRepos.ts`
+
+- [ ] **Step 1: Write `link.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import {
+  CT_ABAPGIT_REPO_V3,
+  CT_ABAPGIT_REPO_V4,
+} from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+import type { IAbapGitLinkArgs } from './types';
+import { buildLinkBody } from './xmlBuilder';
+
+export async function linkRepo(
+  connection: IAbapConnection,
+  args: IAbapGitLinkArgs,
+  contentTypeVersion: 'v3' | 'v4' = 'v3',
+): Promise<void> {
+  const ct =
+    contentTypeVersion === 'v4' ? CT_ABAPGIT_REPO_V4 : CT_ABAPGIT_REPO_V3;
+  await connection.makeAdtRequest({
+    method: 'POST',
+    url: '/sap/bc/adt/abapgit/repos',
+    timeout: getTimeout('default'),
+    headers: { 'Content-Type': ct, Accept: ct },
+    data: buildLinkBody(args),
+  });
+}
+```
+
+- [ ] **Step 2: Write `listRepos.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { ACCEPT_ABAPGIT_REPOS_V2 } from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+import { parseRepoList, type IRepoEntityParsed } from './xmlParser';
+
+export async function listRepos(
+  connection: IAbapConnection,
+): Promise<IRepoEntityParsed[]> {
+  const resp = await connection.makeAdtRequest({
+    method: 'GET',
+    url: '/sap/bc/adt/abapgit/repos',
+    timeout: getTimeout('default'),
+    headers: { Accept: ACCEPT_ABAPGIT_REPOS_V2 },
+  });
+  return parseRepoList(String(resp.data));
+}
+```
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/abapGit/link.ts src/clients/abapGit/listRepos.ts
+git commit -m "feat(abapGit): add link and listRepos low-level ops"
+```
+
+---
+
+### Task C2: `poll.ts` and `pull.ts`
+
+**Files:**
+- Create: `src/clients/abapGit/poll.ts`
+- Create: `src/clients/abapGit/pull.ts`
+
+- [ ] **Step 1: Write `poll.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { listRepos } from './listRepos';
+import type { IAbapGitRepoStatus } from './types';
+
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_MAX_DURATION_MS = 10 * 60 * 1000;
+
+class AbapGitAbortError extends Error {
+  name = 'AbortError';
+  lastKnownStatus?: IAbapGitRepoStatus;
+}
+
+class AbapGitTimeoutError extends Error {
+  name = 'TimeoutError';
+  lastKnownStatus?: IAbapGitRepoStatus;
+}
+
+async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new AbapGitAbortError('aborted'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new AbapGitAbortError('aborted'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export async function pollUntilTerminal(
+  connection: IAbapConnection,
+  packageName: string,
+  opts?: {
+    pollIntervalMs?: number;
+    maxPollDurationMs?: number;
+    signal?: AbortSignal;
+    onProgress?: (status: IAbapGitRepoStatus) => void;
+  },
+): Promise<IAbapGitRepoStatus> {
+  const interval = opts?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxDuration = opts?.maxPollDurationMs ?? DEFAULT_MAX_DURATION_MS;
+  const deadline = Date.now() + maxDuration;
+  let lastKnown: IAbapGitRepoStatus | undefined;
+
+  while (true) {
+    if (opts?.signal?.aborted) {
+      const err = new AbapGitAbortError('aborted');
+      err.lastKnownStatus = lastKnown;
+      throw err;
+    }
+    if (Date.now() > deadline) {
+      const err = new AbapGitTimeoutError(
+        `abapGit pull did not finish within ${maxDuration}ms`,
+      );
+      err.lastKnownStatus = lastKnown;
+      throw err;
+    }
+
+    const repos = await listRepos(connection);
+    const match = repos.find((r) => r.package.toUpperCase() === packageName.toUpperCase());
+    if (match) {
+      lastKnown = {
+        package: match.package,
+        url: match.url,
+        branchName: match.branchName,
+        status: match.status,
+        statusText: match.statusText,
+        createdBy: match.createdBy,
+        createdAt: match.createdAt,
+        repositoryId: match.repositoryId,
+      };
+      opts?.onProgress?.(lastKnown);
+      if (match.status !== 'R') {
+        return lastKnown;
+      }
+    }
+
+    try {
+      await sleep(interval, opts?.signal);
+    } catch (sleepErr) {
+      if (sleepErr instanceof AbapGitAbortError) {
+        sleepErr.lastKnownStatus = lastKnown;
+      }
+      throw sleepErr;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Write `pull.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import {
+  CT_ABAPGIT_REPO_V3,
+  CT_ABAPGIT_REPO_V4,
+} from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+import { getErrorLog } from './getErrorLog';
+import { listRepos } from './listRepos';
+import { pollUntilTerminal } from './poll';
+import type {
+  IAbapGitPullArgs,
+  IAbapGitPullResult,
+  IAbapGitRepoStatus,
+} from './types';
+import { buildPullBody } from './xmlBuilder';
+
+export async function pullRepo(
+  connection: IAbapConnection,
+  args: IAbapGitPullArgs,
+  contentTypeVersion: 'v3' | 'v4' = 'v3',
+): Promise<IAbapGitPullResult> {
+  const repos = await listRepos(connection);
+  const match = repos.find(
+    (r) => r.package.toUpperCase() === args.package.toUpperCase(),
+  );
+  if (!match) {
+    throw new Error(`abapGit repository for package '${args.package}' not found`);
+  }
+  if (!match.atomLinks.pullLink) {
+    throw new Error(
+      `abapGit repository '${args.package}': response missing pull_link atom link`,
+    );
+  }
+
+  const resolvedBranch = args.branchName ?? match.branchName;
+  const ct = contentTypeVersion === 'v4' ? CT_ABAPGIT_REPO_V4 : CT_ABAPGIT_REPO_V3;
+
+  await connection.makeAdtRequest({
+    method: 'POST',
+    url: match.atomLinks.pullLink,
+    timeout: getTimeout('default'),
+    headers: { 'Content-Type': ct, Accept: ct },
+    data: buildPullBody(args, resolvedBranch),
+  });
+
+  const terminal: IAbapGitRepoStatus = await pollUntilTerminal(connection, args.package, {
+    pollIntervalMs: args.pollIntervalMs,
+    maxPollDurationMs: args.maxPollDurationMs,
+    signal: args.signal,
+    onProgress: args.onProgress,
+  });
+
+  const result: IAbapGitPullResult = { finalStatus: terminal };
+  if (terminal.status === 'E' || terminal.status === 'A') {
+    try {
+      result.errorLog = await getErrorLog(connection, args.package);
+    } catch {
+      // Error log is best-effort. If it fails, return the result without it.
+    }
+  }
+  return result;
+}
+```
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/abapGit/poll.ts src/clients/abapGit/pull.ts
+git commit -m "feat(abapGit): add pull with async polling and abort/timeout contract"
+```
+
+---
+
+### Task C3: `getErrorLog.ts` and `checkExternalRepo.ts`
+
+**Files:**
+- Create: `src/clients/abapGit/getErrorLog.ts`
+- Create: `src/clients/abapGit/checkExternalRepo.ts`
+
+- [ ] **Step 1: Write `getErrorLog.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { CT_ABAPGIT_REPO_OBJECT_V2 } from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+import { listRepos } from './listRepos';
+import type { IAbapGitErrorLogEntry } from './types';
+import { parseErrorLog } from './xmlParser';
+
+export async function getErrorLog(
+  connection: IAbapConnection,
+  packageName: string,
+): Promise<IAbapGitErrorLogEntry[]> {
+  const repos = await listRepos(connection);
+  const match = repos.find(
+    (r) => r.package.toUpperCase() === packageName.toUpperCase(),
+  );
+  if (!match) {
+    throw new Error(`abapGit repository for package '${packageName}' not found`);
+  }
+  if (!match.atomLinks.logLink) {
+    return [];
+  }
+  const resp = await connection.makeAdtRequest({
+    method: 'GET',
+    url: match.atomLinks.logLink,
+    timeout: getTimeout('default'),
+    headers: { Accept: CT_ABAPGIT_REPO_OBJECT_V2 },
+  });
+  return parseErrorLog(String(resp.data));
+}
+```
+
+- [ ] **Step 2: Write `checkExternalRepo.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { CT_ABAPGIT_EXTERNAL_REPO_INFO_V2 } from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+import type {
+  IAbapGitExternalRepoCredentials,
+  IAbapGitExternalRepoInfo,
+} from './types';
+import { buildExternalRepoInfoBody } from './xmlBuilder';
+import { parseExternalRepoInfo } from './xmlParser';
+
+/**
+ * envelopeTagName confirmed during Phase Z live probe.
+ * If Phase Z recorded a different name, update here.
+ */
+const EXTERNAL_REPO_INFO_REQUEST_TAG = 'externalRepoInfoRequest';
+
+export async function checkExternalRepo(
+  connection: IAbapConnection,
+  args: IAbapGitExternalRepoCredentials,
+): Promise<IAbapGitExternalRepoInfo> {
+  const resp = await connection.makeAdtRequest({
+    method: 'POST',
+    url: '/sap/bc/adt/abapgit/externalrepoinfo',
+    timeout: getTimeout('default'),
+    headers: {
+      'Content-Type': CT_ABAPGIT_EXTERNAL_REPO_INFO_V2,
+      Accept: CT_ABAPGIT_EXTERNAL_REPO_INFO_V2,
+    },
+    data: buildExternalRepoInfoBody(args, EXTERNAL_REPO_INFO_REQUEST_TAG),
+  });
+  return parseExternalRepoInfo(String(resp.data));
+}
+```
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/abapGit/getErrorLog.ts src/clients/abapGit/checkExternalRepo.ts
+git commit -m "feat(abapGit): add getErrorLog and checkExternalRepo low-level ops"
+```
+
+---
+
+### Task C4: `unlink.ts` (conditional on Phase Z)
+
+**Files:** (only if Phase Z confirmed the delete contract)
+- Create: `src/clients/abapGit/unlink.ts`
+
+- [ ] **Step 1: Re-read Phase Z §12 findings** in the spec. Confirm one of:
+  - Option A: `DELETE` at the atom `edit_link` / `delete_link`
+  - Option B: `DELETE /sap/bc/adt/abapgit/repos/{repositoryId}`
+
+- [ ] **Step 2: Write `unlink.ts` using the confirmed option**
+
+If Option A was confirmed:
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { getTimeout } from '../../utils/timeouts';
+import { listRepos } from './listRepos';
+import type { IAbapGitUnlinkArgs } from './types';
+
+export async function unlinkRepo(
+  connection: IAbapConnection,
+  args: IAbapGitUnlinkArgs,
+): Promise<void> {
+  const repos = await listRepos(connection);
+  const match = repos.find(
+    (r) => r.package.toUpperCase() === args.package.toUpperCase(),
+  );
+  if (!match) {
+    throw new Error(`abapGit repository for package '${args.package}' not found`);
+  }
+  if (!match.atomLinks.editLink) {
+    throw new Error(
+      `abapGit repository '${args.package}': response missing edit_link / delete_link atom link`,
+    );
+  }
+  const params: Record<string, string> = {};
+  if (args.transportRequest) params.corrNr = args.transportRequest;
+  await connection.makeAdtRequest({
+    method: 'DELETE',
+    url: match.atomLinks.editLink,
+    timeout: getTimeout('default'),
+    params,
+  });
+}
+```
+
+If Option B was confirmed, the URL becomes `/sap/bc/adt/abapgit/repos/${encodeURIComponent(match.repositoryId ?? '')}` and the `match.atomLinks.editLink` check is replaced with a `match.repositoryId` presence check.
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/abapGit/unlink.ts
+git commit -m "feat(abapGit): add unlink (verified delete contract)"
+```
+
+**If Phase Z did NOT confirm either option**, skip Task C4 entirely and remove `unlink` from `IAdtAbapGitClient` in `types.ts`.
+
+---
+
+## Phase D: Handler class
+
+### Task D1: `src/clients/AdtAbapGitClient.ts`
+
+**Files:**
+- Create: `src/clients/AdtAbapGitClient.ts`
+
+- [ ] **Step 1: Read** `src/clients/AdtRuntimeClient.ts` for the closest non-core-module client style (constructor shape, logger usage).
+
+- [ ] **Step 2: Write `AdtAbapGitClient.ts`**
+
+```typescript
+/**
+ * ADT-integrated abapGit client.
+ *
+ * Implements IAdtAbapGitClient. All HTTP operations are delegated to
+ * low-level functions in ./abapGit/*; this class owns the
+ * options/state, enforces the public contract, and keeps the surface
+ * cast-free at call sites by returning the specialized interface from
+ * the AdtClient factory.
+ */
+
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { checkExternalRepo } from './abapGit/checkExternalRepo';
+import { getErrorLog } from './abapGit/getErrorLog';
+import { linkRepo } from './abapGit/link';
+import { listRepos as listReposLowLevel } from './abapGit/listRepos';
+import { pullRepo } from './abapGit/pull';
+import type {
+  IAbapGitErrorLogEntry,
+  IAbapGitExternalRepoCredentials,
+  IAbapGitExternalRepoInfo,
+  IAbapGitLinkArgs,
+  IAbapGitPullArgs,
+  IAbapGitPullResult,
+  IAbapGitRepoStatus,
+  IAbapGitUnlinkArgs,
+  IAdtAbapGitClient,
+  IAdtAbapGitClientOptions,
+} from './abapGit/types';
+import { unlinkRepo } from './abapGit/unlink';
+
+function toPublicRepoStatus(r: {
+  package: string;
+  url: string;
+  branchName: string;
+  status: string;
+  statusText: string;
+  createdBy?: string;
+  createdAt?: string;
+  repositoryId?: string;
+}): IAbapGitRepoStatus {
+  return {
+    package: r.package,
+    url: r.url,
+    branchName: r.branchName,
+    status: r.status,
+    statusText: r.statusText,
+    createdBy: r.createdBy,
+    createdAt: r.createdAt,
+    repositoryId: r.repositoryId,
+  };
+}
+
+export class AdtAbapGitClient implements IAdtAbapGitClient {
+  private readonly connection: IAbapConnection;
+  private readonly logger?: ILogger;
+  private readonly contentTypeVersion: 'v3' | 'v4';
+
+  constructor(
+    connection: IAbapConnection,
+    logger?: ILogger,
+    options?: IAdtAbapGitClientOptions,
+  ) {
+    this.connection = connection;
+    this.logger = logger;
+    this.contentTypeVersion = options?.contentTypeVersion ?? 'v3';
+  }
+
+  async link(args: IAbapGitLinkArgs): Promise<void> {
+    this.logger?.debug?.(
+      `AdtAbapGitClient.link: package=${args.package} url=${args.url}`,
+    );
+    await linkRepo(this.connection, args, this.contentTypeVersion);
+  }
+
+  async pull(args: IAbapGitPullArgs): Promise<IAbapGitPullResult> {
+    this.logger?.debug?.(`AdtAbapGitClient.pull: package=${args.package}`);
+    return pullRepo(this.connection, args, this.contentTypeVersion);
+  }
+
+  async unlink(args: IAbapGitUnlinkArgs): Promise<void> {
+    this.logger?.debug?.(`AdtAbapGitClient.unlink: package=${args.package}`);
+    await unlinkRepo(this.connection, args);
+  }
+
+  async listRepos(): Promise<IAbapGitRepoStatus[]> {
+    const rows = await listReposLowLevel(this.connection);
+    return rows.map(toPublicRepoStatus);
+  }
+
+  async getRepo(packageName: string): Promise<IAbapGitRepoStatus | undefined> {
+    const repos = await this.listRepos();
+    return repos.find(
+      (r) => r.package.toUpperCase() === packageName.toUpperCase(),
+    );
+  }
+
+  async getErrorLog(packageName: string): Promise<IAbapGitErrorLogEntry[]> {
+    return getErrorLog(this.connection, packageName);
+  }
+
+  async checkExternalRepo(
+    args: IAbapGitExternalRepoCredentials,
+  ): Promise<IAbapGitExternalRepoInfo> {
+    return checkExternalRepo(this.connection, args);
+  }
+}
+```
+
+**If Phase Z deferred unlink**, remove the `unlink` method, remove the import of `unlinkRepo`, and update `types.ts` (see Task A1).
+
+- [ ] **Step 3: Write barrel export `src/clients/abapGit/index.ts`**
+
+```typescript
+export { AdtAbapGitClient } from '../AdtAbapGitClient';
+export type {
+  AbapGitStatus,
+  IAbapGitErrorLogEntry,
+  IAbapGitExternalRepoBranch,
+  IAbapGitExternalRepoCredentials,
+  IAbapGitExternalRepoInfo,
+  IAbapGitLinkArgs,
+  IAbapGitPullArgs,
+  IAbapGitPullResult,
+  IAbapGitRepoStatus,
+  IAbapGitUnlinkArgs,
+  IAdtAbapGitClient,
+  IAdtAbapGitClientOptions,
+} from './types';
+```
+
+If Phase Z deferred unlink, omit `IAbapGitUnlinkArgs`.
+
+- [ ] **Step 4: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/AdtAbapGitClient.ts src/clients/abapGit/index.ts
+git commit -m "feat(abapGit): add handler class and barrel export"
+```
+
+---
+
+## Phase E: Wiring into AdtClient and public exports
+
+### Task E1: AdtClient factory
+
+**Files:**
+- Modify: `src/clients/AdtClient.ts`
+
+- [ ] **Step 1: Read** `src/clients/AdtClient.ts` — find the region where factory methods for other top-level clients live (probably near `getRuntime()` or similar, not in the `src/core/*` factories).
+
+- [ ] **Step 2: Add imports at the top**
+
+```typescript
+import { AdtAbapGitClient } from './AdtAbapGitClient';
+import type {
+  IAdtAbapGitClient,
+  IAdtAbapGitClientOptions,
+} from './abapGit/index';
+```
+
+- [ ] **Step 3: Add factory method near other top-level factories**
+
+```typescript
+getAbapGit(options?: IAdtAbapGitClientOptions): IAdtAbapGitClient {
+  return new AdtAbapGitClient(this.connection, this.logger, options);
+}
+```
+
+Return type is `IAdtAbapGitClient` — specialized interface, not a narrower base type.
+
+- [ ] **Step 4: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/AdtClient.ts
+git commit -m "feat(AdtClient): add getAbapGit factory returning IAdtAbapGitClient"
+```
+
+---
+
+### Task E2: Public exports in `src/index.ts`
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Read** `src/index.ts` — find the block that exports client classes (likely separate from the `core/*` exports).
+
+- [ ] **Step 2: Append new exports**
+
+```typescript
+export { AdtAbapGitClient } from './clients/AdtAbapGitClient';
+export type {
+  AbapGitStatus,
+  IAbapGitErrorLogEntry,
+  IAbapGitExternalRepoBranch,
+  IAbapGitExternalRepoCredentials,
+  IAbapGitExternalRepoInfo,
+  IAbapGitLinkArgs,
+  IAbapGitPullArgs,
+  IAbapGitPullResult,
+  IAbapGitRepoStatus,
+  IAbapGitUnlinkArgs,
+  IAdtAbapGitClient,
+  IAdtAbapGitClientOptions,
+} from './clients/abapGit/index';
+```
+
+If Phase Z deferred unlink, omit `IAbapGitUnlinkArgs`.
+
+- [ ] **Step 3: Full build**
+
+```bash
+npm run build
+```
+
+Expected: clean (Biome + tsc).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: export AdtAbapGitClient and IAdtAbapGitClient*"
+```
+
+---
+
+## Phase F: Integration tests and yaml template
+
+### Task F1: `test-config.yaml.template`
+
+**Files:**
+- Modify: `src/__tests__/helpers/test-config.yaml.template`
+
+- [ ] **Step 1: Append a new section near the end, before any trailer**
+
+```yaml
+# abapGit client — only on systems that activate the ADT abapGit app
+# (ABAP Platform 2022+ or SAP BTP ABAP Environment / Steampunk).
+abapgit:
+  test_cases:
+    - name: "list_repos"
+      enabled: true
+      available_in: ["cloud"]
+      description: "List all linked abapGit repositories"
+      params: {}
+    - name: "check_external_repo"
+      enabled: true
+      available_in: ["cloud"]
+      description: "Probe a public read-only git repo"
+      params:
+        url: "https://github.com/SAP/abap-platform-refscen-flight"
+    - name: "link_pull_unlink_flow"
+      enabled: false   # disabled by default: mutates the target system
+      available_in: ["cloud"]
+      description: "Full link → pull → unlink cycle against a disposable package"
+      params:
+        package: "ZAC_SHR_ABAPGIT_TEST"
+        url: "https://github.com/SAP/abap-platform-refscen-flight"
+        branch: "refs/heads/main"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/__tests__/helpers/test-config.yaml.template
+git commit -m "test: add abapgit section to test-config template"
+```
+
+---
+
+### Task F2: Integration test
+
+**Files:**
+- Create: `src/__tests__/integration/clients/abapGit/AbapGit.test.ts`
+
+- [ ] **Step 1: Read** an existing non-core-module test as scaffold — e.g. `src/__tests__/integration/batch/BatchClient.test.ts` for the `clients/` fixture path style.
+
+- [ ] **Step 2: Create directory**
+
+```bash
+mkdir -p src/__tests__/integration/clients/abapGit
+```
+
+- [ ] **Step 3: Write `AbapGit.test.ts`**
+
+```typescript
+/**
+ * AbapGit client integration tests.
+ *
+ * - listRepos: always runs (read-only, no mutation)
+ * - checkExternalRepo: always runs (read-only probe)
+ * - link_pull_unlink_flow: gated behind the test-config enabled flag
+ *   AND available_in. Mutates the target system.
+ *
+ * Debug flags:
+ *   DEBUG_ADT_TESTS=true     — test harness logs
+ *   DEBUG_ADT_LIBS=true      — library runtime logs
+ */
+
+import * as dotenv from 'dotenv';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import {
+  createConnectionLogger,
+  createLibraryLogger,
+  createTestsLogger,
+} from '../../../helpers/testLogger';
+import {
+  createTestAdtClient,
+  getConfig,
+  resolveSystemContext,
+} from '../../../helpers/sessionConfig';
+import { isCloudEnvironment } from '../../../../utils/systemInfo';
+import type { AdtClient } from '../../../../clients/AdtClient';
+
+dotenv.config();
+
+const {
+  getEnabledTestCase,
+  getEnvironmentConfig,
+  getTestCaseDefinition,
+  getTimeout,
+} = require('../../../helpers/test-helper');
+
+describe('AbapGit (using AdtClient)', () => {
+  let connection: IAbapConnection;
+  let client: AdtClient;
+  let isCloudSystem = false;
+  let hasConfig = false;
+
+  beforeAll(async () => {
+    try {
+      const config = getConfig();
+      connection = createAbapConnection(config, createConnectionLogger('abapgit'));
+      await (connection as any).connect();
+      isCloudSystem = await isCloudEnvironment(connection);
+      const systemContext = await resolveSystemContext(connection, isCloudSystem);
+      const { client: resolvedClient } = await createTestAdtClient(
+        connection,
+        createLibraryLogger('abapgit'),
+        systemContext,
+      );
+      client = resolvedClient;
+      hasConfig = true;
+    } catch (err) {
+      createTestsLogger('abapgit').warn(
+        `beforeAll setup failed: ${(err as Error).message}`,
+      );
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    if (connection) await (connection as any).disconnect?.();
+  });
+
+  const listCase = getTestCaseDefinition('abapgit', 'list_repos');
+  const listAvailable = listCase
+    ? (listCase.available_in as string[]).includes(isCloudSystem ? 'cloud' : 'onprem')
+    : false;
+
+  (listAvailable ? it : it.skip)(
+    'should list abapGit repositories',
+    async () => {
+      if (!hasConfig) throw new Error('test config missing');
+      const abapGit = client.getAbapGit();
+      const repos = await abapGit.listRepos();
+      expect(Array.isArray(repos)).toBe(true);
+      for (const r of repos) {
+        expect(typeof r.package).toBe('string');
+        expect(typeof r.url).toBe('string');
+        expect(typeof r.status).toBe('string');
+      }
+    },
+    getTimeout('test'),
+  );
+
+  const checkCase = getEnabledTestCase('abapgit', 'check_external_repo');
+  (checkCase ? it : it.skip)(
+    'should probe an external repo',
+    async () => {
+      if (!hasConfig || !checkCase) throw new Error('test config missing');
+      const abapGit = client.getAbapGit();
+      const info = await abapGit.checkExternalRepo({
+        url: checkCase.params.url,
+      });
+      expect(Array.isArray(info.branches)).toBe(true);
+    },
+    getTimeout('test'),
+  );
+
+  const flowCase = getEnabledTestCase('abapgit', 'link_pull_unlink_flow');
+  (flowCase ? it : it.skip)(
+    'should execute link → pull → unlink flow',
+    async () => {
+      if (!hasConfig || !flowCase) throw new Error('test config missing');
+      const abapGit = client.getAbapGit();
+
+      await abapGit.link({
+        package: flowCase.params.package,
+        url: flowCase.params.url,
+        branchName: flowCase.params.branch,
+      });
+
+      const pullResult = await abapGit.pull({
+        package: flowCase.params.package,
+        branchName: flowCase.params.branch,
+        pollIntervalMs: 2000,
+        maxPollDurationMs: 300_000,
+      });
+      expect(pullResult.finalStatus.status).not.toBe('R');
+
+      // Cleanup: unlink if the method is available on this build.
+      if (typeof (abapGit as any).unlink === 'function') {
+        await abapGit.unlink({ package: flowCase.params.package });
+      }
+    },
+    getTimeout('test'),
+  );
+});
+```
+
+- [ ] **Step 4: Type-check tests**
+
+Run: `npm run test:check:integration`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/__tests__/integration/clients/abapGit
+git commit -m "test(abapGit): add integration tests for list, probe, and flow"
+```
+
+---
+
+### Task F3: Run tests live
+
+**Files:** none new; live verification.
+
+- [ ] **Step 1: Copy the template sections into the real `test-config.yaml`** (local, gitignored).
+
+- [ ] **Step 2: Refresh JWT if needed, then run**
+
+```bash
+DEBUG_ADT_TESTS=true npm test -- integration/clients/abapGit 2>&1 | tee test-abapgit.log
+```
+
+Expected: `list_repos` and `check_external_repo` run; the flow test is `enabled: false` by default, so it skips.
+
+- [ ] **Step 3: Read the log and fix any issues in place**
+
+Common expected issues:
+- HTTP 406 on `externalrepoinfo` → response envelope name differs from what Phase Z recorded. Update `EXTERNAL_REPO_INFO_REQUEST_TAG` in `checkExternalRepo.ts`.
+- `parseExternalRepoInfo` returns no branches → root element name differs. Update `xmlParser.ts`.
+- Empty repo list is normal on a system that never linked anything.
+
+Each fix is a separate commit (e.g. `fix(abapGit): align externalrepoinfo envelope with live response`).
+
+- [ ] **Step 4: Remove the log**
+
+```bash
+rm test-abapgit.log
+```
+
+---
+
+## Phase G: Documentation and release prep
+
+### Task G1: User-facing docs
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `docs/usage/CLIENT_API_REFERENCE.md`
+- Modify: `docs/architecture/ARCHITECTURE.md`
+- Modify: `docs/architecture/LEGACY.md`
+
+- [ ] **Step 1: `CLAUDE.md`** — add a one-line entry about `AdtAbapGitClient` next to the other top-level clients (near `AdtClient`, `AdtRuntimeClient`, `AdtExecutor`, `AdtClientsWS`).
+
+- [ ] **Step 2: `README.md`** — add a row "abapGit repositories" in the Supported Features table with `✅` gated on modern systems.
+
+- [ ] **Step 3: `CLIENT_API_REFERENCE.md`** — add a new section after the featureToggle block:
+
+````markdown
+### AbapGit (ADT-integrated)
+
+```typescript
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import { AdtClient } from '@mcp-abap-adt/adt-clients';
+
+const connection = createAbapConnection({ /* ... */ });
+const client = new AdtClient(connection);
+const abapGit = client.getAbapGit();
+
+// Probe a remote repo before linking
+const info = await abapGit.checkExternalRepo({
+  url: 'https://github.com/SAP/abap-platform-refscen-flight',
+});
+console.log(info.branches.map((b) => b.name));
+
+// Link a package to a remote repo
+await abapGit.link({
+  package: 'ZMY_PKG',
+  url: 'https://github.com/SAP/abap-platform-refscen-flight',
+  branchName: 'refs/heads/main',
+});
+
+// Pull — awaits async server-side job. AbortSignal stops only the
+// client wait; the server may still be running.
+const result = await abapGit.pull({
+  package: 'ZMY_PKG',
+  pollIntervalMs: 2000,
+  maxPollDurationMs: 600_000,
+  onProgress: (s) => console.log(`status: ${s.status} — ${s.statusText}`),
+});
+if (result.finalStatus.status === 'E' || result.finalStatus.status === 'A') {
+  console.error('pull failed:', result.errorLog);
+}
+
+// Read status without triggering a pull
+const repo = await abapGit.getRepo('ZMY_PKG');
+
+// Unlink (if supported on the target system)
+if (typeof (abapGit as any).unlink === 'function') {
+  await abapGit.unlink({ package: 'ZMY_PKG' });
+}
+```
+
+**Availability.** The ADT-integrated abapGit surface ships with SAP BTP ABAP Environment (Steampunk) and modern on-prem from ABAP Platform 2022+. Legacy kernels (E77 and similar) do not expose `/sap/bc/adt/abapgit/*`.
+
+**Async pull contract.** The server-side pull continues independently of the client-side wait. If you abort or hit the max-duration cap, the thrown `AbortError` / `TimeoutError` carries `lastKnownStatus` (when a read succeeded). The client must poll `getRepo(package)` until `status !== 'R'` before issuing another `pull` or `unlink`.
+````
+
+- [ ] **Step 4: `ARCHITECTURE.md`** — add `getAbapGit()` to the factories list.
+
+- [ ] **Step 5: `LEGACY.md`** — add abapGit to "not supported on legacy (endpoint family absent)" table with endpoint `/sap/bc/adt/abapgit/*`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md README.md docs/
+git commit -m "docs: register abapGit client in user-facing docs"
+```
+
+- [ ] **Step 7: Regenerate ADT_OBJECT_ENTITIES.md**
+
+```bash
+npm run adt:entities
+git add docs/usage/ADT_OBJECT_ENTITIES.md
+git commit -m "docs(entities): regenerate ADT_OBJECT_ENTITIES for abapGit client"
+```
+
+---
+
+### Task G2: Final build and PR
+
+**Files:** none new; verification only.
+
+- [ ] **Step 1: Full build**
+
+```bash
+npm run build
+```
+
+Expected: clean.
+
+- [ ] **Step 2: Commit count check**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expect ~15-17 commits across phases.
+
+- [ ] **Step 3: Push and open PR** (only on user's explicit confirmation)
+
+```bash
+git push -u origin feature/abapgit-client
+gh pr create --title "feat: add AdtAbapGitClient (ADT-integrated abapGit)" --body "$(cat <<'EOF'
+## Summary
+Adds `AdtAbapGitClient` — a specialized separate client under `src/clients/` that wraps SAP-official ADT-integrated abapGit (`/sap/bc/adt/abapgit/*`). Covers link, pull (with async status polling and an abort/timeout recovery contract), unlink (conditional on a verified delete protocol), listRepos, getRepo, getErrorLog, and checkExternalRepo.
+
+## Context
+- Design spec: `docs/superpowers/specs/2026-04-19-abapgit-client-design.md` (Variant C selected).
+- Roadmap: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` item #1.
+- Phase Z live-probe findings captured in the spec's §12.
+
+## Architecture
+- Specialized `IAdtAbapGitClient` interface per roadmap §4.2. Factory returns it directly — no cast at call sites.
+- `AbortSignal` and `maxPollDurationMs` stop only the client-side wait loop. The server-side pull may continue. Thrown `AbortError` / `TimeoutError` carries `lastKnownStatus` for recovery.
+
+## Test plan
+- [x] `npm run build` — clean
+- [x] `npm run test:check:integration` — clean
+- [x] `npm test -- integration/clients/abapGit` against the cloud trial target — `listRepos` and `checkExternalRepo` pass; `link_pull_unlink_flow` is disabled by default (mutating).
+
+## Outstanding
+- On-prem verification on ABAP Platform 2022+ target — widens `available_in` to `["cloud", "onprem"]` post-merge if successful.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+**Spec coverage:**
+- [x] Spec §1 (Goal — ADT-integrated abapGit wrapper) → Tasks A1, D1, E1
+- [x] Spec §2 in-scope (link, pull, unlink conditional, listRepos, getRepo, getErrorLog, checkExternalRepo) → Tasks A1, C1, C2, C3, C4, D1
+- [x] Spec §2 out-of-scope (push, branch management, v4 default) → not implemented; version is opt-in via options (Task A2, D1)
+- [x] Spec §3 verified evidence (endpoints, content-types, namespaces) → Tasks A2, B1, B2
+- [x] Spec §4.1 factory signature `getAbapGit(options?)` → Task E1
+- [x] Spec §4.2 `IAdtAbapGitClient` + supporting types → Task A1
+- [x] Spec §4.3 `IAdtAbapGitClientOptions` with `contentTypeVersion` → Task A1, D1
+- [x] Spec §5 module layout 10 files → Phases A–D
+- [x] Spec §6.1 link semantics → Task C1
+- [x] Spec §6.2 pull with abort/timeout recovery contract → Task C2
+- [x] Spec §6.3 unlink conditional on verified delete protocol → Phase Z + Task C4 (guarded)
+- [x] Spec §6.4 listRepos → Task C1
+- [x] Spec §6.5 getRepo via client.listRepos() + filter → Task D1
+- [x] Spec §6.6 getErrorLog as first-class method → Task C3
+- [x] Spec §6.7 checkExternalRepo → Task C3
+- [x] Spec §7 non-decisions (transport, XML parsing, credentials, atom links, content-type default v3, polling defaults, env gating, error semantics) → Tasks A1, A2, C2, C4, D1
+- [x] Spec §8 open questions resolved before coding via Phase Z
+- [x] Spec §9 verification sources — reflected in plan header
+
+**Placeholder scan:** No `TBD` / `TODO` / "similar to Task X". Every code block is complete. The only conditional path (Task C4 unlink) is explicitly gated on Phase Z output with the decision rule spelled out.
+
+**Type consistency:**
+- `IAdtAbapGitClient` method signatures in Task A1 match class methods in Task D1 and factory return type in Task E1.
+- `linkRepo`, `pullRepo`, `unlinkRepo`, `listRepos` (low-level) in Tasks C1/C2/C4 match handler imports in Task D1.
+- `IAbapGitRepoStatus` optional `repositoryId` is populated by `parseRepoEntity` in Task B2 and surfaced through `toPublicRepoStatus` in Task D1.
+- `contentTypeVersion: 'v3' | 'v4'` consistent across types.ts (A1), low-level link/pull (C1, C2), and handler (D1).

--- a/docs/superpowers/plans/2026-04-19-abapgit-client.md
+++ b/docs/superpowers/plans/2026-04-19-abapgit-client.md
@@ -1137,46 +1137,11 @@ git commit -m "feat(abapGit): add handler class and barrel export"
 
 ---
 
-## Phase E: Wiring into AdtClient and public exports
+## Phase E: Public exports (standalone top-level client)
 
-### Task E1: AdtClient factory
+**Architectural rule.** `AdtClient` is reserved for `IAdtObject` factories. Separate clients like `AdtAbapGitClient` are **standalone top-level classes** — consumers instantiate them directly via `new AdtAbapGitClient(connection, logger, options)`. This phase does **not** touch `src/clients/AdtClient.ts`; it only exposes the new class and its types from the public entry point.
 
-**Files:**
-- Modify: `src/clients/AdtClient.ts`
-
-- [ ] **Step 1: Read** `src/clients/AdtClient.ts` — find the region where factory methods for other top-level clients live (probably near `getRuntime()` or similar, not in the `src/core/*` factories).
-
-- [ ] **Step 2: Add imports at the top**
-
-```typescript
-import { AdtAbapGitClient } from './AdtAbapGitClient';
-import type {
-  IAdtAbapGitClient,
-  IAdtAbapGitClientOptions,
-} from './abapGit/index';
-```
-
-- [ ] **Step 3: Add factory method near other top-level factories**
-
-```typescript
-getAbapGit(options?: IAdtAbapGitClientOptions): IAdtAbapGitClient {
-  return new AdtAbapGitClient(this.connection, this.logger, options);
-}
-```
-
-Return type is `IAdtAbapGitClient` — specialized interface, not a narrower base type.
-
-- [ ] **Step 4: Type-check and commit**
-
-```bash
-npm run build:fast
-git add src/clients/AdtClient.ts
-git commit -m "feat(AdtClient): add getAbapGit factory returning IAdtAbapGitClient"
-```
-
----
-
-### Task E2: Public exports in `src/index.ts`
+### Task E1: Public exports in `src/index.ts`
 
 **Files:**
 - Modify: `src/index.ts`
@@ -1217,8 +1182,10 @@ Expected: clean (Biome + tsc).
 
 ```bash
 git add src/index.ts
-git commit -m "feat: export AdtAbapGitClient and IAdtAbapGitClient*"
+git commit -m "feat(abapGit): export AdtAbapGitClient and IAdtAbapGitClient*"
 ```
+
+Note: `src/clients/AdtClient.ts` is **not** modified in this phase. The architectural rule is that `AdtClient` only produces `IAdtObject<Config, State>` factories; separate clients stand alone.
 
 ---
 
@@ -1285,6 +1252,10 @@ mkdir -p src/__tests__/integration/clients/abapGit
 /**
  * AbapGit client integration tests.
  *
+ * AdtAbapGitClient is a standalone top-level class, instantiated
+ * directly — not accessed via a factory on AdtClient (which is
+ * reserved for IAdtObject implementations only).
+ *
  * - listRepos: always runs (read-only, no mutation)
  * - checkExternalRepo: always runs (read-only probe)
  * - link_pull_unlink_flow: gated behind the test-config enabled flag
@@ -1303,26 +1274,22 @@ import {
   createLibraryLogger,
   createTestsLogger,
 } from '../../../helpers/testLogger';
-import {
-  createTestAdtClient,
-  getConfig,
-  resolveSystemContext,
-} from '../../../helpers/sessionConfig';
+import { getConfig } from '../../../helpers/sessionConfig';
 import { isCloudEnvironment } from '../../../../utils/systemInfo';
-import type { AdtClient } from '../../../../clients/AdtClient';
+import { AdtAbapGitClient } from '../../../../clients/AdtAbapGitClient';
+import type { IAdtAbapGitClient } from '../../../../clients/abapGit';
 
 dotenv.config();
 
 const {
   getEnabledTestCase,
-  getEnvironmentConfig,
   getTestCaseDefinition,
   getTimeout,
 } = require('../../../helpers/test-helper');
 
-describe('AbapGit (using AdtClient)', () => {
+describe('AbapGit (standalone AdtAbapGitClient)', () => {
   let connection: IAbapConnection;
-  let client: AdtClient;
+  let abapGit: IAdtAbapGitClient;
   let isCloudSystem = false;
   let hasConfig = false;
 
@@ -1332,13 +1299,7 @@ describe('AbapGit (using AdtClient)', () => {
       connection = createAbapConnection(config, createConnectionLogger('abapgit'));
       await (connection as any).connect();
       isCloudSystem = await isCloudEnvironment(connection);
-      const systemContext = await resolveSystemContext(connection, isCloudSystem);
-      const { client: resolvedClient } = await createTestAdtClient(
-        connection,
-        createLibraryLogger('abapgit'),
-        systemContext,
-      );
-      client = resolvedClient;
+      abapGit = new AdtAbapGitClient(connection, createLibraryLogger('abapgit'));
       hasConfig = true;
     } catch (err) {
       createTestsLogger('abapgit').warn(
@@ -1360,7 +1321,6 @@ describe('AbapGit (using AdtClient)', () => {
     'should list abapGit repositories',
     async () => {
       if (!hasConfig) throw new Error('test config missing');
-      const abapGit = client.getAbapGit();
       const repos = await abapGit.listRepos();
       expect(Array.isArray(repos)).toBe(true);
       for (const r of repos) {
@@ -1377,7 +1337,6 @@ describe('AbapGit (using AdtClient)', () => {
     'should probe an external repo',
     async () => {
       if (!hasConfig || !checkCase) throw new Error('test config missing');
-      const abapGit = client.getAbapGit();
       const info = await abapGit.checkExternalRepo({
         url: checkCase.params.url,
       });
@@ -1391,7 +1350,6 @@ describe('AbapGit (using AdtClient)', () => {
     'should execute link → pull → unlink flow',
     async () => {
       if (!hasConfig || !flowCase) throw new Error('test config missing');
-      const abapGit = client.getAbapGit();
 
       await abapGit.link({
         package: flowCase.params.package,
@@ -1473,7 +1431,7 @@ rm test-abapgit.log
 - Modify: `docs/architecture/ARCHITECTURE.md`
 - Modify: `docs/architecture/LEGACY.md`
 
-- [ ] **Step 1: `CLAUDE.md`** — add a one-line entry about `AdtAbapGitClient` next to the other top-level clients (near `AdtClient`, `AdtRuntimeClient`, `AdtExecutor`, `AdtClientsWS`).
+- [ ] **Step 1: `CLAUDE.md`** — add a short paragraph about `AdtAbapGitClient` in the "Client Classes" section, next to `AdtClient` / `AdtRuntimeClient` / `AdtExecutor` / `AdtClientsWS`. Note it's a standalone top-level class (not a factory on AdtClient).
 
 - [ ] **Step 2: `README.md`** — add a row "abapGit repositories" in the Supported Features table with `✅` gated on modern systems.
 
@@ -1482,13 +1440,15 @@ rm test-abapgit.log
 ````markdown
 ### AbapGit (ADT-integrated)
 
+`AdtAbapGitClient` is a **standalone top-level class**, not a factory on `AdtClient`. `AdtClient` is reserved for `IAdtObject<Config, State>` implementations — separate clients stand on their own and are instantiated directly, same pattern as `AdtClient`, `AdtRuntimeClient`, `AdtExecutor`, and `AdtClientsWS`.
+
 ```typescript
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import { AdtClient } from '@mcp-abap-adt/adt-clients';
+import { AdtAbapGitClient } from '@mcp-abap-adt/adt-clients';
+import type { IAdtAbapGitClient } from '@mcp-abap-adt/adt-clients';
 
 const connection = createAbapConnection({ /* ... */ });
-const client = new AdtClient(connection);
-const abapGit = client.getAbapGit();
+const abapGit: IAdtAbapGitClient = new AdtAbapGitClient(connection);
 
 // Probe a remote repo before linking
 const info = await abapGit.checkExternalRepo({

--- a/docs/superpowers/plans/2026-04-19-abapgit-client.md
+++ b/docs/superpowers/plans/2026-04-19-abapgit-client.md
@@ -274,7 +274,7 @@ export interface IAbapGitExternalRepoBranch {
 
 export interface IAbapGitExternalRepoInfo {
   branches: IAbapGitExternalRepoBranch[];
-  access?: 'read' | 'write' | string;
+  accessMode?: 'PUBLIC' | 'PRIVATE' | string;   // from live probe — field is 'accessMode', not 'access'
 }
 
 export interface IAbapGitAbortedError extends Error {
@@ -344,9 +344,12 @@ export const ACCEPT_ABAPGIT_REPOS_V2 =
 export const CT_ABAPGIT_REPO_OBJECT_V2 =
   'application/abapgit.adt.repo.object.v2+xml';
 
-// External-repo probe (discovery-only; confirmed during Phase Z).
-export const CT_ABAPGIT_EXTERNAL_REPO_INFO_V2 =
+// External-repo probe — Phase Z confirmed that request and response
+// use different media-type families (request vs response sub-path).
+export const CT_ABAPGIT_EXTERNAL_REPO_INFO_REQUEST_V2 =
   'application/abapgit.adt.repo.info.ext.request.v2+xml';
+export const ACCEPT_ABAPGIT_EXTERNAL_REPO_INFO_RESPONSE_V2 =
+  'application/abapgit.adt.repo.info.ext.response.v2+xml';
 ```
 
 - [ ] **Step 3: Verify and commit**
@@ -384,6 +387,8 @@ import type {
 } from './types';
 
 const NS_ABAPGITREPO = 'http://www.sap.com/adt/abapgit/repositories';
+// Phase Z confirmed: externalrepoinfo uses a distinct namespace (capital R, no "info" suffix).
+const NS_ABAPGIT_EXTERNAL_REPO = 'http://www.sap.com/adt/abapgit/externalRepo';
 
 function escapeXml(value: string): string {
   return value
@@ -393,21 +398,26 @@ function escapeXml(value: string): string {
     .replace(/"/g, '&quot;');
 }
 
-function child(tag: string, value: string | undefined): string {
+function childRepo(tag: string, value: string | undefined): string {
   if (value === undefined || value === null) return '';
   return `<abapgitrepo:${tag}>${escapeXml(value)}</abapgitrepo:${tag}>`;
+}
+
+function childExternalRepo(tag: string, value: string | undefined): string {
+  if (value === undefined || value === null) return '';
+  return `<abapgitexternalrepo:${tag}>${escapeXml(value)}</abapgitexternalrepo:${tag}>`;
 }
 
 export function buildLinkBody(args: IAbapGitLinkArgs): string {
   return (
     `<?xml version="1.0" encoding="UTF-8"?>` +
     `<abapgitrepo:repository xmlns:abapgitrepo="${NS_ABAPGITREPO}">` +
-    child('package', args.package) +
-    child('url', args.url) +
-    child('branchName', args.branchName ?? 'refs/heads/master') +
-    child('remoteUser', args.remoteUser) +
-    child('remotePassword', args.remotePassword) +
-    child('transportRequest', args.transportRequest) +
+    childRepo('package', args.package) +
+    childRepo('url', args.url) +
+    childRepo('branchName', args.branchName ?? 'refs/heads/master') +
+    childRepo('remoteUser', args.remoteUser) +
+    childRepo('remotePassword', args.remotePassword) +
+    childRepo('transportRequest', args.transportRequest) +
     `</abapgitrepo:repository>`
   );
 }
@@ -419,31 +429,29 @@ export function buildPullBody(
   return (
     `<?xml version="1.0" encoding="UTF-8"?>` +
     `<abapgitrepo:repository xmlns:abapgitrepo="${NS_ABAPGITREPO}">` +
-    child('package', args.package) +
-    child('branchName', resolvedBranch) +
-    child('remoteUser', args.remoteUser) +
-    child('remotePassword', args.remotePassword) +
-    child('transportRequest', args.transportRequest) +
+    childRepo('package', args.package) +
+    childRepo('branchName', resolvedBranch) +
+    childRepo('remoteUser', args.remoteUser) +
+    childRepo('remotePassword', args.remotePassword) +
+    childRepo('transportRequest', args.transportRequest) +
     `</abapgitrepo:repository>`
   );
 }
 
 export function buildExternalRepoInfoBody(
   args: IAbapGitExternalRepoCredentials,
-  envelopeTagName: string,
 ): string {
+  // Phase Z confirmed the request envelope element name and namespace.
   return (
     `<?xml version="1.0" encoding="UTF-8"?>` +
-    `<abapgitrepo:${envelopeTagName} xmlns:abapgitrepo="${NS_ABAPGITREPO}">` +
-    child('url', args.url) +
-    child('remoteUser', args.remoteUser) +
-    child('remotePassword', args.remotePassword) +
-    `</abapgitrepo:${envelopeTagName}>`
+    `<abapgitexternalrepo:externalRepoInfoRequest xmlns:abapgitexternalrepo="${NS_ABAPGIT_EXTERNAL_REPO}">` +
+    childExternalRepo('url', args.url) +
+    childExternalRepo('remoteUser', args.remoteUser) +
+    childExternalRepo('remotePassword', args.remotePassword) +
+    `</abapgitexternalrepo:externalRepoInfoRequest>`
   );
 }
 ```
-
-`envelopeTagName` is a parameter because the Phase-Z verification determines the exact element name (likely `externalRepoInfoRequest` but confirmed live).
 
 - [ ] **Step 2: Type-check and commit**
 
@@ -500,7 +508,11 @@ function asString(value: unknown): string {
 export interface IRepoEntityAtomLinks {
   pullLink?: string;
   logLink?: string;
-  editLink?: string;
+  // Phase Z confirmed no edit_link / delete_link is ever emitted by the
+  // server. Delete is performed via DELETE /repos/{key}, not via an
+  // atom link. Additional link types (check_link, status_link,
+  // stage_link, push_link, modifiedobjects_link) exist but are out
+  // of v1 scope.
 }
 
 export interface IRepoEntityParsed extends IAbapGitRepoStatus {
@@ -514,9 +526,12 @@ function parseAtomLinks(repoNode: any): IRepoEntityAtomLinks {
     const type = asString(link?.type);
     const href = asString(link?.href);
     if (!href) continue;
+    // Phase Z confirmed available link types: pull_link, log_link,
+    // check_link, status_link, stage_link, push_link, modifiedobjects_link.
+    // Only pull_link and log_link are consumed in v1; unknown types are
+    // ignored silently (stage/push are out of v1 scope per spec §2).
     if (type === 'pull_link') out.pullLink = href;
     else if (type === 'log_link') out.logLink = href;
-    else if (type === 'edit_link' || type === 'delete_link') out.editLink = href;
   }
   return out;
 }
@@ -557,25 +572,28 @@ export function parseErrorLog(xml: string): IAbapGitErrorLogEntry[] {
 
 export function parseExternalRepoInfo(xml: string): IAbapGitExternalRepoInfo {
   const parsed = parser.parse(xml) as any;
-  // Root element name and branch element name confirmed in Phase Z.
-  const root = parsed?.externalRepoInfo ?? parsed?.externalRepoInfoResponse ?? {};
-  const rawBranches = root?.branches?.branch ?? root?.branch ?? [];
+  // Root confirmed by Phase Z: <abapgitexternalrepo:externalRepoInfo>
+  // in namespace http://www.sap.com/adt/abapgit/externalRepo (capital R).
+  // The parser strips namespace prefixes, so we read 'externalRepoInfo'.
+  const root = parsed?.externalRepoInfo ?? {};
+  const rawBranches = root?.branch ?? [];
   const branches: IAbapGitExternalRepoBranch[] = (Array.isArray(rawBranches) ? rawBranches : [rawBranches])
     .filter(Boolean)
     .map((b: any) => ({
       name: asString(b?.name),
       sha1: asString(b?.sha1),
-      isHead: String(asString(b?.isHead)).toLowerCase() === 'true',
+      // SAP-XML boolean convention: 'X' = true, empty element = false.
+      isHead: String(asString(b?.isHead)).toUpperCase() === 'X',
       type: asString(b?.type) || undefined,
     }));
   return {
     branches,
-    access: asString(root?.access) || undefined,
+    accessMode: asString(root?.accessMode) || undefined,
   };
 }
 ```
 
-Implementation detail: the `parseExternalRepoInfo` root name has two candidates — the actual name comes from Phase Z step 4. If Phase Z showed a single fixed root, drop the `??` branch and keep only the verified one.
+Phase-Z-confirmed: the externalrepoinfo response uses a distinct namespace (`externalRepo`) and a `<branch>` list directly under the root (no `<branches>` wrapper). The `isHead` flag uses SAP-XML `X`/empty boolean convention, not lowercase `true`/`false`.
 
 - [ ] **Step 3: Type-check and commit**
 
@@ -880,7 +898,10 @@ export async function getErrorLog(
 
 ```typescript
 import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
-import { CT_ABAPGIT_EXTERNAL_REPO_INFO_V2 } from '../../constants/contentTypes';
+import {
+  ACCEPT_ABAPGIT_EXTERNAL_REPO_INFO_RESPONSE_V2,
+  CT_ABAPGIT_EXTERNAL_REPO_INFO_REQUEST_V2,
+} from '../../constants/contentTypes';
 import { getTimeout } from '../../utils/timeouts';
 import type {
   IAbapGitExternalRepoCredentials,
@@ -889,25 +910,22 @@ import type {
 import { buildExternalRepoInfoBody } from './xmlBuilder';
 import { parseExternalRepoInfo } from './xmlParser';
 
-/**
- * envelopeTagName confirmed during Phase Z live probe.
- * If Phase Z recorded a different name, update here.
- */
-const EXTERNAL_REPO_INFO_REQUEST_TAG = 'externalRepoInfoRequest';
-
 export async function checkExternalRepo(
   connection: IAbapConnection,
   args: IAbapGitExternalRepoCredentials,
 ): Promise<IAbapGitExternalRepoInfo> {
+  // Phase Z confirmed: request/response use DIFFERENT media-type families:
+  //   Content-Type = application/abapgit.adt.repo.info.ext.request.v2+xml
+  //   Accept       = application/abapgit.adt.repo.info.ext.response.v2+xml
   const resp = await connection.makeAdtRequest({
     method: 'POST',
     url: '/sap/bc/adt/abapgit/externalrepoinfo',
     timeout: getTimeout('default'),
     headers: {
-      'Content-Type': CT_ABAPGIT_EXTERNAL_REPO_INFO_V2,
-      Accept: CT_ABAPGIT_EXTERNAL_REPO_INFO_V2,
+      'Content-Type': CT_ABAPGIT_EXTERNAL_REPO_INFO_REQUEST_V2,
+      Accept: ACCEPT_ABAPGIT_EXTERNAL_REPO_INFO_RESPONSE_V2,
     },
-    data: buildExternalRepoInfoBody(args, EXTERNAL_REPO_INFO_REQUEST_TAG),
+    data: buildExternalRepoInfoBody(args),
   });
   return parseExternalRepoInfo(String(resp.data));
 }
@@ -923,18 +941,14 @@ git commit -m "feat(abapGit): add getErrorLog and checkExternalRepo low-level op
 
 ---
 
-### Task C4: `unlink.ts` (conditional on Phase Z)
+### Task C4: `unlink.ts`
 
-**Files:** (only if Phase Z confirmed the delete contract)
+Phase Z confirmed **Option B** for unlink: `DELETE /sap/bc/adt/abapgit/repos/{key}` is wired (nonexistent-ID probe returned 404 "repo not found, get", not 405 Method Not Allowed). No `edit_link` / `delete_link` atom entry exists on the repo entity. `repositoryId` = `<abapgitrepo:key>`.
+
+**Files:**
 - Create: `src/clients/abapGit/unlink.ts`
 
-- [ ] **Step 1: Re-read Phase Z §12 findings** in the spec. Confirm one of:
-  - Option A: `DELETE` at the atom `edit_link` / `delete_link`
-  - Option B: `DELETE /sap/bc/adt/abapgit/repos/{repositoryId}`
-
-- [ ] **Step 2: Write `unlink.ts` using the confirmed option**
-
-If Option A was confirmed:
+- [ ] **Step 1: Write `unlink.ts`**
 
 ```typescript
 import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
@@ -953,33 +967,29 @@ export async function unlinkRepo(
   if (!match) {
     throw new Error(`abapGit repository for package '${args.package}' not found`);
   }
-  if (!match.atomLinks.editLink) {
+  if (!match.repositoryId) {
     throw new Error(
-      `abapGit repository '${args.package}': response missing edit_link / delete_link atom link`,
+      `abapGit repository '${args.package}': response missing <abapgitrepo:key>`,
     );
   }
   const params: Record<string, string> = {};
   if (args.transportRequest) params.corrNr = args.transportRequest;
   await connection.makeAdtRequest({
     method: 'DELETE',
-    url: match.atomLinks.editLink,
+    url: `/sap/bc/adt/abapgit/repos/${encodeURIComponent(match.repositoryId)}`,
     timeout: getTimeout('default'),
     params,
   });
 }
 ```
 
-If Option B was confirmed, the URL becomes `/sap/bc/adt/abapgit/repos/${encodeURIComponent(match.repositoryId ?? '')}` and the `match.atomLinks.editLink` check is replaced with a `match.repositoryId` presence check.
-
-- [ ] **Step 3: Type-check and commit**
+- [ ] **Step 2: Type-check and commit**
 
 ```bash
 npm run build:fast
 git add src/clients/abapGit/unlink.ts
-git commit -m "feat(abapGit): add unlink (verified delete contract)"
+git commit -m "feat(abapGit): add unlink via /repos/{key} (Phase Z verified)"
 ```
-
-**If Phase Z did NOT confirm either option**, skip Task C4 entirely and remove `unlink` from `IAdtAbapGitClient` in `types.ts`.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-19-feature-toggle.md
+++ b/docs/superpowers/plans/2026-04-19-feature-toggle.md
@@ -1,0 +1,1458 @@
+# Feature Toggle Core Module Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add full feature-toggle support (`FTG2/FT`) as a new core module under `src/core/featureToggle/`, exposing `IAdtObject`-compatible CRUD + lifecycle plus five domain methods (`switchOn`, `switchOff`, `getRuntimeState`, `checkState`, `readSource`) through a specialized `IFeatureToggleObject` interface.
+
+**Architecture:**
+- New core module `src/core/featureToggle/` following the DDIC-style pattern established by `src/core/authorizationField/` (XML metadata via `blue:blueSource` envelope) combined with a source-bearing pattern, except the "source" payload at `…/source/main` is JSON, not ABAP text.
+- Specialized public interface `IFeatureToggleObject extends IAdtObject<IFeatureToggleConfig, IFeatureToggleState>` carries the domain methods statically; factory `AdtClient.getFeatureToggle()` returns that type — no casts at call sites.
+- Hybrid payload split: XML for metadata (`blue:blueSource` root); JSON for source (`toggle.content.v2+json`), state (`states.v1+asjson`), check (`toggle.check.result.v1+asjson`), toggle (`related.toggle.parameters.v1+asjson`).
+
+**Tech Stack:** TypeScript strict, CommonJS, Node.js ≥18, Biome (lint + format), `fast-xml-parser` for XML, native `JSON.parse`/`stringify` for JSON, Jest integration tests. No new runtime dependencies.
+
+**Verification source:** `docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md`. Endpoints cross-checked against sapcli + `docs/discovery/*.xml` (cloud MDD and E19 modern on-prem verified; E77 legacy unsupported).
+
+**Endpoints (canonical):**
+- Collection: `/sap/bc/adt/sfw/featuretoggles`
+- Object: `/sap/bc/adt/sfw/featuretoggles/{name}` (name lower-cased + url-encoded per sapcli `quote_plus`)
+- Source: `/sap/bc/adt/sfw/featuretoggles/{name}/source/main`
+- States (runtime): `/sap/bc/adt/sfw/featuretoggles/{name}/states`
+- Check (pre-flight): `/sap/bc/adt/sfw/featuretoggles/{name}/check`
+- Toggle (switch on/off): `/sap/bc/adt/sfw/featuretoggles/{name}/toggle`
+- Deletion: standard `/sap/bc/adt/deletion/check` + `/sap/bc/adt/deletion/delete`
+- Activation: standard `/sap/bc/adt/activation`
+- Check (syntactic): standard `/sap/bc/adt/checkruns?reporters=abapCheckRun`
+
+**XML namespaces:**
+- Metadata root: `blue:blueSource` → `xmlns:blue="http://www.sap.com/wbobj/blue"`
+- Plus `xmlns:adtcore="http://www.sap.com/adt/core"` and `xmlns:abapsource="http://www.sap.com/adt/abapsource"` when present
+
+**Branch policy.** Per project convention for the sapcli-separate-clients roadmap, this is implemented on a dedicated feature branch forked from `main` (NOT from `proposal/sapcli-separate-clients`). Branch name: `feature/feature-toggle-core-module`.
+
+---
+
+## File Structure (18 files + 4 cross-cutting updates)
+
+### New `src/core/featureToggle/` module (16 files)
+
+```
+src/core/featureToggle/
+  AdtFeatureToggle.ts      # handler — implements IFeatureToggleObject
+  types.ts                 # IFeatureToggleObject, IFeatureToggleConfig, IFeatureToggleState, sub-types, ICreateFeatureToggleParams, IToggleFeatureToggleParams
+  xmlBuilder.ts            # builds blue:blueSource XML for create/update metadata
+  create.ts                # POST /sfw/featuretoggles — metadata XML
+  read.ts                  # GET /sfw/featuretoggles/{name} — metadata XML
+  readSource.ts            # GET /sfw/featuretoggles/{name}/source/main — JSON
+  update.ts                # PUT /sfw/featuretoggles/{name}?lockHandle= — metadata XML
+  updateSource.ts          # PUT /sfw/featuretoggles/{name}/source/main?lockHandle= — JSON
+  delete.ts                # POST /deletion/check + /deletion/delete
+  lock.ts                  # POST /sfw/featuretoggles/{name}?_action=LOCK&accessMode=MODIFY
+  unlock.ts                # POST /sfw/featuretoggles/{name}?_action=UNLOCK&lockHandle=
+  check.ts                 # POST /checkruns?reporters=abapCheckRun (canonical)
+  activation.ts            # POST /activation
+  validation.ts            # pre-create name validation (lightweight probe)
+  getState.ts              # GET /sfw/featuretoggles/{name}/states — JSON domain
+  checkState.ts            # POST /sfw/featuretoggles/{name}/check — JSON domain
+  switch.ts                # POST /sfw/featuretoggles/{name}/toggle — JSON domain (used by switchOn/switchOff)
+  index.ts                 # barrel export of IFeatureToggleObject + types + class
+```
+
+### Cross-cutting updates
+
+- `src/constants/contentTypes.ts` — add 7 new constants
+- `src/clients/AdtClient.ts` — add `getFeatureToggle()` factory + imports
+- `src/index.ts` — export `IFeatureToggleObject`, `IFeatureToggleConfig`, `IFeatureToggleState`, sub-types
+- `src/__tests__/helpers/test-config.yaml.template` — add `create_feature_toggle` section
+- `src/__tests__/integration/core/featureToggle/FeatureToggle.test.ts` — new integration test
+- `CLAUDE.md` — bump count 24 → 25, add `featureToggle` to module list
+- `README.md`, `CHANGELOG.md`, `docs/usage/CLIENT_API_REFERENCE.md`, `docs/architecture/ARCHITECTURE.md`, `docs/architecture/LEGACY.md` — per the #21 pattern
+- `docs/usage/ADT_OBJECT_ENTITIES.md` — regenerate via `npm run adt:entities` after code lands
+
+---
+
+## Phase A: Scaffold types and content-type constants
+
+### Task A1: types.ts — public and internal types
+
+**Files:**
+- Create: `src/core/featureToggle/types.ts`
+
+- [ ] **Step 1: Create directory**
+
+```bash
+mkdir -p src/core/featureToggle
+```
+
+- [ ] **Step 2: Write `types.ts`**
+
+```typescript
+/**
+ * Feature Toggle (FTG2/FT) module type definitions.
+ *
+ * Surface pairs the standard IAdtObject CRUD + lifecycle with five domain
+ * methods for state management (switchOn / switchOff / getRuntimeState /
+ * checkState / readSource). Consumers use the specialized
+ * IFeatureToggleObject interface so the domain methods stay statically
+ * visible on the factory return type.
+ */
+
+import type { IAdtObject, IAdtObjectState } from '@mcp-abap-adt/interfaces';
+
+export type FeatureToggleState = 'on' | 'off' | 'undefined';
+
+// --- Source payload (JSON at /source/main) --------------------------------
+
+export interface IFeatureToggleHeader {
+  description?: string;
+  originalLanguage?: string;
+  abapLanguageVersion?: string;
+}
+
+export interface IFeatureToggleReleasePlan {
+  version: string;
+  sp: string;
+}
+
+export interface IFeatureTogglePlanning {
+  referenceProduct?: string;
+  releaseToCustomer?: IFeatureToggleReleasePlan;
+  generalAvailability?: IFeatureToggleReleasePlan;
+  generalRollout?: IFeatureToggleReleasePlan;
+}
+
+export interface IFeatureToggleRollout {
+  lifecycleStatus?: 'new' | 'inValidation' | 'released' | 'discontinued';
+  validationStep?: 'internal' | 'releaseToCustomer' | string;
+  rolloutStep?: 'releaseToCustomer' | 'generalAvailability' | 'generalRollout' | string;
+  strategy?: 'immediate' | 'gradual' | string;
+  finalDate?: string;
+  event?: 'noRestriction' | string;
+  planning?: IFeatureTogglePlanning;
+  configurable?: boolean;
+  defaultEnabledFor?: 'none' | 'someCustomers' | 'allCustomers' | string;
+  reversible?: boolean;
+}
+
+export interface IFeatureToggleAttribute {
+  key: string;
+  value: string;
+}
+
+export interface IFeatureToggleSource {
+  header?: IFeatureToggleHeader;
+  rollout?: IFeatureToggleRollout;
+  toggledPackages?: string[];
+  relatedToggles?: string[];
+  attributes?: IFeatureToggleAttribute[];
+}
+
+// --- Runtime state (JSON at /states) --------------------------------------
+
+export interface IFeatureToggleClientLevel {
+  client: string;
+  description?: string;
+  state: FeatureToggleState;
+}
+
+export interface IFeatureToggleUserLevel {
+  user: string;
+  state: FeatureToggleState;
+}
+
+export interface IFeatureToggleRuntimeState {
+  name: string;
+  clientState: FeatureToggleState;
+  userState: FeatureToggleState;
+  clientChangedBy?: string;
+  clientChangedOn?: string;
+  clientStates: IFeatureToggleClientLevel[];
+  userStates: IFeatureToggleUserLevel[];
+}
+
+// --- Check result (JSON at /check) ----------------------------------------
+
+export interface IFeatureToggleCheckStateResult {
+  currentState: FeatureToggleState;
+  transportPackage?: string;
+  transportUri?: string;
+  customizingTransportAllowed: boolean;
+}
+
+// --- Public config / state ------------------------------------------------
+
+export interface IFeatureToggleConfig {
+  featureToggleName: string;
+  packageName?: string;
+  description?: string;
+  transportRequest?: string;
+  masterSystem?: string;
+  responsible?: string;
+  source?: IFeatureToggleSource;
+  onLock?: (lockHandle: string) => void;
+}
+
+export interface IFeatureToggleState extends IAdtObjectState {
+  runtimeState?: IFeatureToggleRuntimeState;
+  checkStateResult?: IFeatureToggleCheckStateResult;
+  sourceResult?: IFeatureToggleSource;
+}
+
+// --- Specialized public interface ----------------------------------------
+
+export interface IFeatureToggleObject
+  extends IAdtObject<IFeatureToggleConfig, IFeatureToggleState> {
+  switchOn(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
+
+  switchOff(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
+
+  getRuntimeState(
+    config: Partial<IFeatureToggleConfig>,
+  ): Promise<IFeatureToggleState>;
+
+  checkState(
+    config: Partial<IFeatureToggleConfig>,
+    opts?: { userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
+
+  readSource(
+    config: Partial<IFeatureToggleConfig>,
+    version?: 'active' | 'inactive',
+  ): Promise<IFeatureToggleState>;
+}
+
+// --- Low-level wire-format params (snake_case, internal) ------------------
+
+export interface ICreateFeatureToggleParams {
+  feature_toggle_name: string;
+  description?: string;
+  package_name: string;
+  transport_request?: string;
+  master_system?: string;
+  responsible?: string;
+  source?: IFeatureToggleSource;
+}
+
+export interface IDeleteFeatureToggleParams {
+  feature_toggle_name: string;
+  transport_request?: string;
+}
+
+export interface IToggleFeatureToggleParams {
+  feature_toggle_name: string;
+  state: 'on' | 'off';
+  is_user_specific: boolean;
+  transport_request?: string;
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run build:fast`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/featureToggle/types.ts
+git commit -m "feat(featureToggle): add type definitions"
+```
+
+---
+
+### Task A2: Content-type constants
+
+**Files:**
+- Modify: `src/constants/contentTypes.ts`
+
+- [ ] **Step 1: Read** `src/constants/contentTypes.ts` — identify the block near `ACCEPT_AUTHORIZATION_FIELD` (DDIC XML pattern) and note the grouping convention.
+
+- [ ] **Step 2: Append new constants** near the bottom of the file, before any trailing exports
+
+```typescript
+// Feature Toggles (FTG2/FT) — metadata uses the shared blues envelope
+// same as APS IAM; state and domain endpoints use dedicated JSON types.
+export const ACCEPT_FEATURE_TOGGLE_METADATA =
+  'application/vnd.sap.adt.blues.v1+xml';
+export const CT_FEATURE_TOGGLE_METADATA =
+  'application/vnd.sap.adt.blues.v1+xml';
+export const ACCEPT_FEATURE_TOGGLE_STATES =
+  'application/vnd.sap.adt.states.v1+asjson';
+export const ACCEPT_FEATURE_TOGGLE_CHECK_RESULT =
+  'application/vnd.sap.adt.toggle.check.result.v1+asjson';
+export const CT_FEATURE_TOGGLE_CHECK_PARAMETERS =
+  'application/vnd.sap.adt.toggle.check.parameters.v1+asjson';
+export const CT_FEATURE_TOGGLE_TOGGLE_PARAMETERS =
+  'application/vnd.sap.adt.related.toggle.parameters.v1+asjson';
+export const CT_FEATURE_TOGGLE_SOURCE =
+  'application/vnd.sap.adt.toggle.content.v2+json';
+export const ACCEPT_FEATURE_TOGGLE_SOURCE = CT_FEATURE_TOGGLE_SOURCE;
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build:fast`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/constants/contentTypes.ts
+git commit -m "feat(featureToggle): add content-type constants"
+```
+
+---
+
+## Phase B: Low-level metadata CRUD
+
+### Task B1: xmlBuilder.ts
+
+**Files:**
+- Create: `src/core/featureToggle/xmlBuilder.ts`
+- Reference: `src/core/authorizationField/xmlBuilder.ts`
+
+- [ ] **Step 1: Read** `src/core/authorizationField/xmlBuilder.ts` to confirm style (escapeXml helper, ordered attribute placement).
+
+- [ ] **Step 2: Write `xmlBuilder.ts`**
+
+```typescript
+/**
+ * XML builder for feature-toggle metadata.
+ *
+ * The metadata payload is the `blue:blueSource` envelope (same blues v1
+ * envelope used by APS IAM auth) with adtcore attributes and a packageRef
+ * child. Source body (rollout / toggledPackages / attributes) is JSON
+ * handled separately by updateSource.ts.
+ */
+
+import type { ICreateFeatureToggleParams } from './types';
+
+const NS_BLUE = 'http://www.sap.com/wbobj/blue';
+const NS_ADTCORE = 'http://www.sap.com/adt/core';
+const NS_ABAPSOURCE = 'http://www.sap.com/adt/abapsource';
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function buildFeatureToggleXml(
+  params: ICreateFeatureToggleParams,
+): string {
+  const name = params.feature_toggle_name.toUpperCase();
+  const description = params.description ?? '';
+  const pkg = params.package_name;
+
+  const adtcoreAttrs = [
+    `adtcore:name="${escapeXml(name)}"`,
+    `adtcore:type="FTG2/FT"`,
+    `adtcore:description="${escapeXml(description)}"`,
+  ];
+  if (params.master_system) {
+    adtcoreAttrs.push(`adtcore:masterSystem="${escapeXml(params.master_system)}"`);
+  }
+  if (params.responsible) {
+    adtcoreAttrs.push(`adtcore:responsible="${escapeXml(params.responsible)}"`);
+  }
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<blue:blueSource xmlns:blue="${NS_BLUE}" xmlns:adtcore="${NS_ADTCORE}" xmlns:abapsource="${NS_ABAPSOURCE}" ` +
+    adtcoreAttrs.join(' ') +
+    `>` +
+    (pkg
+      ? `<adtcore:packageRef adtcore:name="${escapeXml(pkg)}"/>`
+      : '') +
+    `</blue:blueSource>`
+  );
+}
+```
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/core/featureToggle/xmlBuilder.ts
+git commit -m "feat(featureToggle): add XML builder for metadata"
+```
+
+---
+
+### Task B2: create.ts + read.ts + update.ts + delete.ts
+
+**Files:**
+- Create: `src/core/featureToggle/create.ts`
+- Create: `src/core/featureToggle/read.ts`
+- Create: `src/core/featureToggle/update.ts`
+- Create: `src/core/featureToggle/delete.ts`
+
+- [ ] **Step 1: Read** `src/core/authorizationField/{create,read,update,delete}.ts` to copy the structural pattern.
+
+- [ ] **Step 2: Write `create.ts`**
+
+```typescript
+import type {
+  IAbapConnection,
+  IAdtResponse as AxiosResponse,
+} from '@mcp-abap-adt/interfaces';
+import {
+  ACCEPT_FEATURE_TOGGLE_METADATA,
+  CT_FEATURE_TOGGLE_METADATA,
+} from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+import type { ICreateFeatureToggleParams } from './types';
+import { buildFeatureToggleXml } from './xmlBuilder';
+
+export async function create(
+  connection: IAbapConnection,
+  args: ICreateFeatureToggleParams,
+): Promise<AxiosResponse> {
+  const xml = buildFeatureToggleXml(args);
+  const params: Record<string, string> = {};
+  if (args.transport_request) params.corrNr = args.transport_request;
+  return connection.makeAdtRequest({
+    method: 'POST',
+    url: '/sap/bc/adt/sfw/featuretoggles',
+    timeout: getTimeout('default'),
+    headers: {
+      'Content-Type': CT_FEATURE_TOGGLE_METADATA,
+      Accept: ACCEPT_FEATURE_TOGGLE_METADATA,
+    },
+    params,
+    data: xml,
+  });
+}
+```
+
+- [ ] **Step 3: Write `read.ts`**
+
+```typescript
+import type {
+  IAbapConnection,
+  IAdtResponse as AxiosResponse,
+} from '@mcp-abap-adt/interfaces';
+import { ACCEPT_FEATURE_TOGGLE_METADATA } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+
+export interface IReadOptions {
+  withLongPolling?: boolean;
+}
+
+export async function readFeatureToggle(
+  connection: IAbapConnection,
+  name: string,
+  version: 'active' | 'inactive' = 'active',
+  _options?: IReadOptions,
+): Promise<AxiosResponse> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  return connection.makeAdtRequest({
+    method: 'GET',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}`,
+    timeout: getTimeout('default'),
+    params: { version },
+    headers: { Accept: ACCEPT_FEATURE_TOGGLE_METADATA },
+  });
+}
+```
+
+- [ ] **Step 4: Write `update.ts`**
+
+```typescript
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import {
+  ACCEPT_FEATURE_TOGGLE_METADATA,
+  CT_FEATURE_TOGGLE_METADATA,
+} from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import type { ICreateFeatureToggleParams } from './types';
+import { buildFeatureToggleXml } from './xmlBuilder';
+
+export async function updateFeatureToggle(
+  connection: IAbapConnection,
+  params: ICreateFeatureToggleParams,
+  lockHandle: string,
+  _logger?: ILogger,
+): Promise<void> {
+  const encoded = encodeSapObjectName(params.feature_toggle_name.toLowerCase());
+  const xml = buildFeatureToggleXml(params);
+  const query: Record<string, string> = { lockHandle };
+  if (params.transport_request) query.corrNr = params.transport_request;
+  await connection.makeAdtRequest({
+    method: 'PUT',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}`,
+    timeout: getTimeout('default'),
+    headers: {
+      'Content-Type': CT_FEATURE_TOGGLE_METADATA,
+      Accept: ACCEPT_FEATURE_TOGGLE_METADATA,
+      'X-sap-adt-sessiontype': 'stateful',
+    },
+    params: query,
+    data: xml,
+  });
+}
+```
+
+- [ ] **Step 5: Write `delete.ts`**
+
+Copy the structure of `src/core/authorizationField/delete.ts`. Substitute:
+- Object URI: `/sap/bc/adt/sfw/featuretoggles/${encoded}` (lower-cased name)
+- Object type in deletion payload: `FTG2/FT`
+- Params type: `IDeleteFeatureToggleParams` from `./types`
+- Export `checkDeletion(connection, params)` and `deleteFeatureToggle(connection, params)` with the same signatures.
+
+- [ ] **Step 6: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/core/featureToggle/create.ts src/core/featureToggle/read.ts src/core/featureToggle/update.ts src/core/featureToggle/delete.ts
+git commit -m "feat(featureToggle): add metadata CRUD (create, read, update, delete)"
+```
+
+---
+
+## Phase C: Low-level state machine (lock/unlock/check/activation/validation)
+
+### Task C1: lock.ts + unlock.ts
+
+**Files:**
+- Create: `src/core/featureToggle/lock.ts`
+- Create: `src/core/featureToggle/unlock.ts`
+
+- [ ] **Step 1: Write `lock.ts`**
+
+```typescript
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { XMLParser } from 'fast-xml-parser';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+
+export async function lockFeatureToggle(
+  connection: IAbapConnection,
+  name: string,
+  logger?: ILogger,
+): Promise<string> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  const resp = await connection.makeAdtRequest({
+    method: 'POST',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}`,
+    timeout: getTimeout('default'),
+    params: { _action: 'LOCK', accessMode: 'MODIFY' },
+    headers: {
+      'X-sap-adt-sessiontype': 'stateful',
+      Accept:
+        'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.Result2,' +
+        'application/vnd.sap.as+xml;charset=UTF-8;dataname=com.sap.adt.lock.Result',
+    },
+  });
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' });
+  const parsed = parser.parse(resp.data);
+  const handle = parsed?.['asx:abap']?.['asx:values']?.DATA?.LOCK_HANDLE;
+  if (!handle) {
+    logger?.error?.(`FeatureToggle lock: no LOCK_HANDLE in response`);
+    throw new Error(`FeatureToggle ${name}: lock response has no LOCK_HANDLE`);
+  }
+  return String(handle);
+}
+```
+
+- [ ] **Step 2: Write `unlock.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+
+export async function unlockFeatureToggle(
+  connection: IAbapConnection,
+  name: string,
+  lockHandle: string,
+): Promise<void> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  await connection.makeAdtRequest({
+    method: 'POST',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}`,
+    timeout: getTimeout('default'),
+    params: { _action: 'UNLOCK', lockHandle },
+    headers: { 'X-sap-adt-sessiontype': 'stateful' },
+  });
+}
+```
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/core/featureToggle/lock.ts src/core/featureToggle/unlock.ts
+git commit -m "feat(featureToggle): add lock/unlock"
+```
+
+---
+
+### Task C2: check.ts + activation.ts + validation.ts
+
+**Files:**
+- Create: `src/core/featureToggle/check.ts` — canonical check via `/checkruns?reporters=abapCheckRun`
+- Create: `src/core/featureToggle/activation.ts` — standard `/sap/bc/adt/activation`
+- Create: `src/core/featureToggle/validation.ts` — pre-create existence probe
+
+- [ ] **Step 1: Read** `src/core/authorizationField/check.ts` and `src/core/authorizationField/activation.ts` to copy structure.
+
+- [ ] **Step 2: Write `check.ts`**
+
+Copy `src/core/authorizationField/check.ts`, substituting:
+- Object URI builder: `/sap/bc/adt/sfw/featuretoggles/${encodeSapObjectName(name.toLowerCase())}`
+- Exported function: `checkFeatureToggle(connection, name, version, xmlContent?)` returning `Promise<AxiosResponse>`
+
+- [ ] **Step 3: Write `activation.ts`**
+
+Copy `src/core/authorizationField/activation.ts`, substituting:
+- Object URI builder same as above
+- Exported function: `activateFeatureToggle(connection, name)` returning `Promise<AxiosResponse>`
+
+- [ ] **Step 4: Write `validation.ts`**
+
+Minimal pre-create probe: attempt a HEAD/GET on the collection URL, since there is no dedicated validation endpoint documented that works uniformly across cloud MDD (`dependencies/validate`) and E19 (`validation`). Keeping the probe at the collection level means no per-environment branching.
+
+```typescript
+import type {
+  IAbapConnection,
+  IAdtResponse as AxiosResponse,
+} from '@mcp-abap-adt/interfaces';
+import { ACCEPT_FEATURE_TOGGLE_METADATA } from '../../constants/contentTypes';
+import { getTimeout } from '../../utils/timeouts';
+
+export async function validateFeatureToggleName(
+  connection: IAbapConnection,
+  name: string,
+  _packageName?: string,
+  _description?: string,
+): Promise<AxiosResponse> {
+  if (!name) {
+    throw new Error('Feature toggle name is required');
+  }
+  return connection.makeAdtRequest({
+    method: 'GET',
+    url: '/sap/bc/adt/sfw/featuretoggles',
+    timeout: getTimeout('default'),
+    headers: { Accept: ACCEPT_FEATURE_TOGGLE_METADATA },
+  });
+}
+```
+
+- [ ] **Step 5: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/core/featureToggle/check.ts src/core/featureToggle/activation.ts src/core/featureToggle/validation.ts
+git commit -m "feat(featureToggle): add check, activation, validation"
+```
+
+---
+
+## Phase D: Domain operations (source + state + switch)
+
+### Task D1: readSource.ts + updateSource.ts
+
+**Files:**
+- Create: `src/core/featureToggle/readSource.ts`
+- Create: `src/core/featureToggle/updateSource.ts`
+
+- [ ] **Step 1: Write `readSource.ts`**
+
+```typescript
+import type {
+  IAbapConnection,
+  IAdtResponse as AxiosResponse,
+} from '@mcp-abap-adt/interfaces';
+import { ACCEPT_FEATURE_TOGGLE_SOURCE } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+
+export async function readFeatureToggleSource(
+  connection: IAbapConnection,
+  name: string,
+  version: 'active' | 'inactive' = 'active',
+): Promise<AxiosResponse> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  return connection.makeAdtRequest({
+    method: 'GET',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}/source/main`,
+    timeout: getTimeout('default'),
+    params: { version },
+    headers: { Accept: ACCEPT_FEATURE_TOGGLE_SOURCE },
+  });
+}
+```
+
+- [ ] **Step 2: Write `updateSource.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { CT_FEATURE_TOGGLE_SOURCE } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import type { IFeatureToggleSource } from './types';
+
+export async function uploadFeatureToggleSource(
+  connection: IAbapConnection,
+  name: string,
+  source: IFeatureToggleSource,
+  lockHandle: string,
+  transportRequest?: string,
+): Promise<void> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  const params: Record<string, string> = { lockHandle };
+  if (transportRequest) params.corrNr = transportRequest;
+  await connection.makeAdtRequest({
+    method: 'PUT',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}/source/main`,
+    timeout: getTimeout('default'),
+    headers: {
+      'Content-Type': CT_FEATURE_TOGGLE_SOURCE,
+      'X-sap-adt-sessiontype': 'stateful',
+    },
+    params,
+    data: JSON.stringify(source),
+  });
+}
+```
+
+- [ ] **Step 3: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/core/featureToggle/readSource.ts src/core/featureToggle/updateSource.ts
+git commit -m "feat(featureToggle): add readSource/uploadSource (JSON /source/main)"
+```
+
+---
+
+### Task D2: getState.ts + checkState.ts + switch.ts
+
+**Files:**
+- Create: `src/core/featureToggle/getState.ts`
+- Create: `src/core/featureToggle/checkState.ts`
+- Create: `src/core/featureToggle/switch.ts`
+
+- [ ] **Step 1: Write `getState.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { ACCEPT_FEATURE_TOGGLE_STATES } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import type {
+  FeatureToggleState,
+  IFeatureToggleRuntimeState,
+} from './types';
+
+function normaliseState(raw: unknown): FeatureToggleState {
+  if (raw === 'on' || raw === 'off' || raw === 'undefined') return raw;
+  return 'undefined';
+}
+
+export async function getFeatureToggleState(
+  connection: IAbapConnection,
+  name: string,
+): Promise<IFeatureToggleRuntimeState> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  const resp = await connection.makeAdtRequest({
+    method: 'GET',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}/states`,
+    timeout: getTimeout('default'),
+    headers: { Accept: ACCEPT_FEATURE_TOGGLE_STATES },
+  });
+  const parsed =
+    typeof resp.data === 'string' ? JSON.parse(resp.data) : resp.data;
+  const s = parsed?.STATES ?? {};
+  return {
+    name: String(s.NAME ?? name.toUpperCase()),
+    clientState: normaliseState(s.CLIENT_STATE),
+    userState: normaliseState(s.USER_STATE),
+    clientChangedBy: s.CLIENT_CHANGED_BY || undefined,
+    clientChangedOn: s.CLIENT_CHANGED_ON || undefined,
+    clientStates: Array.isArray(s.CLIENT_STATES)
+      ? s.CLIENT_STATES.map((c: any) => ({
+          client: String(c.CLIENT),
+          description: c.DESCRIPTION || undefined,
+          state: normaliseState(c.STATE),
+        }))
+      : [],
+    userStates: Array.isArray(s.USER_STATES)
+      ? s.USER_STATES.map((u: any) => ({
+          user: String(u.USER),
+          state: normaliseState(u.STATE),
+        }))
+      : [],
+  };
+}
+```
+
+- [ ] **Step 2: Write `checkState.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import {
+  ACCEPT_FEATURE_TOGGLE_CHECK_RESULT,
+  CT_FEATURE_TOGGLE_CHECK_PARAMETERS,
+} from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import type {
+  FeatureToggleState,
+  IFeatureToggleCheckStateResult,
+} from './types';
+
+function normaliseState(raw: unknown): FeatureToggleState {
+  if (raw === 'on' || raw === 'off' || raw === 'undefined') return raw;
+  return 'undefined';
+}
+
+export async function checkFeatureToggleState(
+  connection: IAbapConnection,
+  name: string,
+  opts?: { userSpecific?: boolean },
+): Promise<IFeatureToggleCheckStateResult> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  const body = {
+    PARAMETERS: { IS_USER_SPECIFIC: Boolean(opts?.userSpecific) },
+  };
+  const resp = await connection.makeAdtRequest({
+    method: 'POST',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}/check`,
+    timeout: getTimeout('default'),
+    headers: {
+      'Content-Type': CT_FEATURE_TOGGLE_CHECK_PARAMETERS,
+      Accept: ACCEPT_FEATURE_TOGGLE_CHECK_RESULT,
+    },
+    data: JSON.stringify(body),
+  });
+  const parsed =
+    typeof resp.data === 'string' ? JSON.parse(resp.data) : resp.data;
+  const r = parsed?.RESULT ?? {};
+  return {
+    currentState: normaliseState(r.CURRENT_STATE),
+    transportPackage: r.TRANSPORT_PACKAGE || undefined,
+    transportUri: r.TRANSPORT_URI || undefined,
+    customizingTransportAllowed: Boolean(r.CUSTOMIZING_TRANSPORT_ALLOWED),
+  };
+}
+```
+
+- [ ] **Step 3: Write `switch.ts`**
+
+```typescript
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { CT_FEATURE_TOGGLE_TOGGLE_PARAMETERS } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import type { IToggleFeatureToggleParams } from './types';
+
+export async function toggleFeatureToggle(
+  connection: IAbapConnection,
+  params: IToggleFeatureToggleParams,
+): Promise<void> {
+  const encoded = encodeSapObjectName(params.feature_toggle_name.toLowerCase());
+  const body: { TOGGLE_PARAMETERS: Record<string, unknown> } = {
+    TOGGLE_PARAMETERS: {
+      IS_USER_SPECIFIC: Boolean(params.is_user_specific),
+      STATE: params.state,
+    },
+  };
+  if (params.transport_request) {
+    body.TOGGLE_PARAMETERS.TRANSPORT_REQUEST = params.transport_request;
+  }
+  await connection.makeAdtRequest({
+    method: 'POST',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}/toggle`,
+    timeout: getTimeout('default'),
+    headers: { 'Content-Type': CT_FEATURE_TOGGLE_TOGGLE_PARAMETERS },
+    data: JSON.stringify(body),
+  });
+}
+```
+
+- [ ] **Step 4: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/core/featureToggle/getState.ts src/core/featureToggle/checkState.ts src/core/featureToggle/switch.ts
+git commit -m "feat(featureToggle): add domain operations (getState, checkState, toggle)"
+```
+
+---
+
+## Phase E: Handler class and barrel export
+
+### Task E1: AdtFeatureToggle.ts handler
+
+**Files:**
+- Create: `src/core/featureToggle/AdtFeatureToggle.ts`
+- Reference: `src/core/authorizationField/AdtAuthorizationField.ts`
+
+- [ ] **Step 1: Read** the full file `src/core/authorizationField/AdtAuthorizationField.ts`. This is the closest structural template — same DDIC-style XML-only metadata flow.
+
+- [ ] **Step 2: Write `AdtFeatureToggle.ts`**
+
+Copy the class structure from `AdtAuthorizationField` with these substitutions:
+
+- **Class declaration:**
+
+```typescript
+export class AdtFeatureToggle implements IFeatureToggleObject {
+  private readonly connection: IAbapConnection;
+  private readonly logger?: ILogger;
+  private readonly systemContext?: IAdtSystemContext;
+
+  constructor(
+    connection: IAbapConnection,
+    logger?: ILogger,
+    systemContext?: IAdtSystemContext,
+  ) {
+    this.connection = connection;
+    this.logger = logger;
+    this.systemContext = systemContext;
+  }
+  // ...
+}
+```
+
+- **Low-level imports** (top of file):
+
+```typescript
+import type {
+  IAbapConnection,
+  IAdtObjectState,
+  IAdtOperationOptions,
+  IAdtSystemContext,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
+import { activateFeatureToggle } from './activation';
+import { checkFeatureToggle } from './check';
+import { checkFeatureToggleState } from './checkState';
+import { create } from './create';
+import { checkDeletion, deleteFeatureToggle } from './delete';
+import { getFeatureToggleState } from './getState';
+import { lockFeatureToggle } from './lock';
+import { readFeatureToggle } from './read';
+import { readFeatureToggleSource } from './readSource';
+import { toggleFeatureToggle } from './switch';
+import type {
+  ICreateFeatureToggleParams,
+  IDeleteFeatureToggleParams,
+  IFeatureToggleConfig,
+  IFeatureToggleObject,
+  IFeatureToggleSource,
+  IFeatureToggleState,
+  IToggleFeatureToggleParams,
+} from './types';
+import { unlockFeatureToggle } from './unlock';
+import { updateFeatureToggle } from './update';
+import { uploadFeatureToggleSource } from './updateSource';
+import { validateFeatureToggleName } from './validation';
+```
+
+- **Required methods from `IAdtObject`** (match `AdtAuthorizationField` call for call):
+  - `validate(config)` — calls `validateFeatureToggleName(connection, config.featureToggleName, config.packageName, config.description)`; returns `{ validationResponse, errors: [] }`
+  - `create(config, options?)` — validate required fields (`featureToggleName`, `packageName`, `description`); call `create(connection, params)` where `params = this.buildCreateParams(config)`; if `config.source` provided, run the source-upload sub-chain (stateful → lock → stateless → `uploadFeatureToggleSource` → stateful → unlock → stateless → `activateFeatureToggle`); store response into `state.createResult`; return state.
+  - `read(config, version?, options?)` — calls `readFeatureToggle`; maps 404 to `undefined`; stores `state.readResult`.
+  - `readMetadata(config, options?)` — delegates to `readFeatureToggle` (no separate metadata endpoint for FT; the object URI returns metadata).
+  - `update(config, options?)` — canonical chain: `setSessionType('stateful')` → `lockFeatureToggle` → `setSessionType('stateless')` → `checkFeatureToggle('inactive', xmlContent)` if `options?.xmlContent` provided → `updateFeatureToggle` → if `config.source` provided → `uploadFeatureToggleSource` → `setSessionType('stateful')` → `unlockFeatureToggle` → `setSessionType('stateless')` → `checkFeatureToggle('inactive')` → `activateFeatureToggle` + read with retry → error cleanup (try unlock; then stateless).
+  - `delete(config)` — `checkDeletion` → `deleteFeatureToggle`.
+  - `activate(config)` — `activateFeatureToggle(connection, name)`; store `state.activateResult`.
+  - `check(config, status?)` — `checkFeatureToggle(connection, name, status === 'inactive' ? 'inactive' : 'active')`; store `state.checkResult`.
+  - `lock(config)` — setSessionType('stateful') → `lockFeatureToggle` → setSessionType('stateless') → invoke `config.onLock?.(lockHandle)`; return the string.
+  - `unlock(config, lockHandle)` — setSessionType('stateful') → `unlockFeatureToggle` → setSessionType('stateless'); return state.
+  - `readTransport(config, options?)` — return `{ errors: [{ method: 'readTransport', error: new Error('Not supported for feature toggles'), timestamp: new Date() }] }` as state (matches the `AdtAuthorizationField` pattern for unsupported transport queries; no dedicated `/transport` resource).
+
+- **Domain methods** (specialized):
+
+```typescript
+  async switchOn(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState> {
+    return this.switchTo(config, opts, 'on');
+  }
+
+  async switchOff(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState> {
+    return this.switchTo(config, opts, 'off');
+  }
+
+  private async switchTo(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+    targetState: 'on' | 'off',
+  ): Promise<IFeatureToggleState> {
+    const name = this.requireName(config);
+    const state: IFeatureToggleState = { errors: [] };
+    try {
+      await toggleFeatureToggle(this.connection, {
+        feature_toggle_name: name,
+        state: targetState,
+        is_user_specific: Boolean(opts.userSpecific),
+        transport_request: opts.transportRequest,
+      });
+      state.runtimeState = await getFeatureToggleState(this.connection, name);
+    } catch (error) {
+      state.errors.push({
+        method: targetState === 'on' ? 'switchOn' : 'switchOff',
+        error: error as Error,
+        timestamp: new Date(),
+      });
+      throw error;
+    }
+    return state;
+  }
+
+  async getRuntimeState(
+    config: Partial<IFeatureToggleConfig>,
+  ): Promise<IFeatureToggleState> {
+    const name = this.requireName(config);
+    const state: IFeatureToggleState = { errors: [] };
+    try {
+      state.runtimeState = await getFeatureToggleState(this.connection, name);
+    } catch (error) {
+      state.errors.push({
+        method: 'getRuntimeState',
+        error: error as Error,
+        timestamp: new Date(),
+      });
+      throw error;
+    }
+    return state;
+  }
+
+  async checkState(
+    config: Partial<IFeatureToggleConfig>,
+    opts?: { userSpecific?: boolean },
+  ): Promise<IFeatureToggleState> {
+    const name = this.requireName(config);
+    const state: IFeatureToggleState = { errors: [] };
+    try {
+      state.checkStateResult = await checkFeatureToggleState(this.connection, name, opts);
+    } catch (error) {
+      state.errors.push({
+        method: 'checkState',
+        error: error as Error,
+        timestamp: new Date(),
+      });
+      throw error;
+    }
+    return state;
+  }
+
+  async readSource(
+    config: Partial<IFeatureToggleConfig>,
+    version: 'active' | 'inactive' = 'active',
+  ): Promise<IFeatureToggleState> {
+    const name = this.requireName(config);
+    const state: IFeatureToggleState = { errors: [] };
+    try {
+      const resp = await readFeatureToggleSource(this.connection, name, version);
+      state.readResult = resp;
+      const parsed =
+        typeof resp.data === 'string' ? JSON.parse(resp.data) : resp.data;
+      state.sourceResult = parsed as IFeatureToggleSource;
+    } catch (error) {
+      state.errors.push({
+        method: 'readSource',
+        error: error as Error,
+        timestamp: new Date(),
+      });
+      throw error;
+    }
+    return state;
+  }
+
+  private requireName(config: Partial<IFeatureToggleConfig>): string {
+    if (!config.featureToggleName) {
+      throw new Error('Feature toggle name is required');
+    }
+    return config.featureToggleName;
+  }
+```
+
+- **`buildCreateParams(config)`** (private helper): map camelCase → snake_case plus `masterSystem`/`responsible` from `systemContext` when config doesn't override.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npm run build:fast`
+
+Expected: clean. If errors, fix before next step.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/featureToggle/AdtFeatureToggle.ts
+git commit -m "feat(featureToggle): add handler class implementing IFeatureToggleObject"
+```
+
+---
+
+### Task E2: index.ts
+
+**Files:**
+- Create: `src/core/featureToggle/index.ts`
+
+- [ ] **Step 1: Write `index.ts`**
+
+```typescript
+export { AdtFeatureToggle } from './AdtFeatureToggle';
+export type {
+  FeatureToggleState,
+  ICreateFeatureToggleParams,
+  IFeatureToggleAttribute,
+  IFeatureToggleCheckStateResult,
+  IFeatureToggleClientLevel,
+  IFeatureToggleConfig,
+  IFeatureToggleHeader,
+  IFeatureToggleObject,
+  IFeatureTogglePlanning,
+  IFeatureToggleReleasePlan,
+  IFeatureToggleRollout,
+  IFeatureToggleRuntimeState,
+  IFeatureToggleSource,
+  IFeatureToggleState,
+  IFeatureToggleUserLevel,
+} from './types';
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+npm run build:fast
+git add src/core/featureToggle/index.ts
+git commit -m "feat(featureToggle): add barrel export"
+```
+
+---
+
+## Phase F: AdtClient factory and public exports
+
+### Task F1: AdtClient factory method
+
+**Files:**
+- Modify: `src/clients/AdtClient.ts`
+
+- [ ] **Step 1: Read** the region around `getAuthorizationField()` in `src/clients/AdtClient.ts` (around line 252). Note exact import style and factory pattern.
+
+- [ ] **Step 2: Add imports** at the top of `AdtClient.ts`, alphabetised into the existing import block:
+
+```typescript
+import { AdtFeatureToggle } from '../core/featureToggle';
+import type {
+  IFeatureToggleConfig,
+  IFeatureToggleObject,
+  IFeatureToggleState,
+} from '../core/featureToggle';
+```
+
+- [ ] **Step 3: Add factory method** near the existing DDIC factories (e.g. right after `getAuthorizationField`):
+
+```typescript
+  getFeatureToggle(): IFeatureToggleObject {
+    return new AdtFeatureToggle(this.connection, this.logger, this.systemContext);
+  }
+```
+
+Return type is the specialized `IFeatureToggleObject`, NOT `IAdtObject<IFeatureToggleConfig, IFeatureToggleState>` — per the public-typing rule in the roadmap proposal §4.2.
+
+- [ ] **Step 4: Type-check and commit**
+
+```bash
+npm run build:fast
+git add src/clients/AdtClient.ts
+git commit -m "feat(AdtClient): add getFeatureToggle factory returning IFeatureToggleObject"
+```
+
+---
+
+### Task F2: src/index.ts exports
+
+**Files:**
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Read** the block that exports `IAuthorizationField*` and `IFunctionInclude*` types in `src/index.ts`.
+
+- [ ] **Step 2: Add a new export block** next to the existing ones (alphabetised):
+
+```typescript
+export type {
+  FeatureToggleState,
+  IFeatureToggleAttribute,
+  IFeatureToggleCheckStateResult,
+  IFeatureToggleClientLevel,
+  IFeatureToggleConfig,
+  IFeatureToggleHeader,
+  IFeatureToggleObject,
+  IFeatureTogglePlanning,
+  IFeatureToggleReleasePlan,
+  IFeatureToggleRollout,
+  IFeatureToggleRuntimeState,
+  IFeatureToggleSource,
+  IFeatureToggleState,
+  IFeatureToggleUserLevel,
+} from './core/featureToggle';
+```
+
+- [ ] **Step 3: Full build and commit**
+
+```bash
+npm run build
+git add src/index.ts
+git commit -m "feat: export IFeatureToggle* types and IFeatureToggleObject"
+```
+
+Expected: clean (Biome + tsc).
+
+---
+
+## Phase G: Test configuration and integration test
+
+### Task G1: Extend test-config.yaml.template
+
+**Files:**
+- Modify: `src/__tests__/helpers/test-config.yaml.template`
+
+- [ ] **Step 1: Read** the section layout of `test-config.yaml.template` around `create_authorization_field`.
+
+- [ ] **Step 2: Append a new section** (alphabetically placed between `create_enhancement_implementation` and `create_function_group`, or wherever fits the existing ordering):
+
+```yaml
+# Create Feature Toggle (FTG2/FT) — graduated from sapcli-separate-clients
+# roadmap into src/core/ per the variant-A decision. Needs a writeable
+# target system that permits creation of Z_* feature toggles; start with
+# onprem only because cloud trial may not permit the FTG2/FT creation
+# authorization.
+create_feature_toggle:
+  test_cases:
+    - name: "adt_feature_toggle"
+      enabled: true
+      available_in: ["onprem"]
+      description: "Feature toggle reserved for AdtFeatureToggle tests"
+      params:
+        feature_toggle_name: "ZAC_FT01"
+        description: "AdtFeatureToggle workflow toggle"
+        update_description: "AdtFeatureToggle workflow toggle (updated)"
+```
+
+Name `ZAC_FT01` stays within 30 characters (FTG2/FT name column is typically 30 chars; keep to 10-ish for safety).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/helpers/test-config.yaml.template
+git commit -m "test: add create_feature_toggle section to test-config template"
+```
+
+---
+
+### Task G2: Integration test
+
+**Files:**
+- Create: `src/__tests__/integration/core/featureToggle/FeatureToggle.test.ts`
+
+- [ ] **Step 1: Read** `src/__tests__/integration/core/authorizationField/AuthorizationField.test.ts` fully — this is the closest analogue (DDIC-style, XML-only metadata, no source, but FT has JSON source on top).
+
+- [ ] **Step 2: Write the test file**
+
+Adapt the AuthorizationField test with these changes:
+- Factory: `client.getFeatureToggle()` (returns `IFeatureToggleObject`)
+- Type section: `create_feature_toggle`, test case `adt_feature_toggle`
+- Config field names: `featureToggleName`, `packageName`, `description`, optional `source`
+- Pre-create cleanup pattern: probe existence via `readMetadata`, mark `objectExists` in `ensureObjectReady`.
+- **Additional domain-method test cases** (beyond the BaseTester CRUD flow):
+  - `should fetch runtime state` — call `client.getFeatureToggle().getRuntimeState({ featureToggleName })`; assert `state.runtimeState.name` equals uppercased name; assert `clientState ∈ {'on','off','undefined'}`.
+  - `should check state (pre-flight)` — call `checkState({ featureToggleName })`; assert `checkStateResult.customizingTransportAllowed` is boolean.
+  - `should read source` — call `readSource({ featureToggleName })` after create; assert `sourceResult` is defined and has the expected structure (object with optional `header`, `rollout`, etc.).
+  - `should switch toggle on/off` — call `switchOn({ featureToggleName }, { transportRequest: DEFAULT_TRANSPORT })` followed by `switchOff(...)`; assert runtime state reflects the change on each step. Gate this block with a conditional `it.skip` if `DEFAULT_TRANSPORT` is absent in the test environment (cloud trial has no transport system).
+
+- [ ] **Step 3: Type-check tests**
+
+Run: `npm run test:check:integration`
+Expected: clean TypeScript.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/__tests__/integration/core/featureToggle
+git commit -m "test(featureToggle): add integration test for CRUD + domain methods"
+```
+
+---
+
+### Task G3: Run the test suite and fix any surface issues
+
+**Files:** (various — fix-ups only)
+
+- [ ] **Step 1: Confirm local `.env` and `test-config.yaml` carry the new section** (copy the template section into the real yaml per usual convention). Note: cloud trial JWT may have expired — refresh before running.
+
+- [ ] **Step 2: Run the new suite isolated**
+
+```bash
+DEBUG_ADT_TESTS=true DEBUG_ADT_LIBS=true npm test -- integration/core/featureToggle 2>&1 | tee test-ft.log
+```
+
+- [ ] **Step 3: Read the log**
+
+Use the Read tool. Expect possible issues:
+- HTTP 406 on any metadata endpoint → Accept header mismatch; verify against live server response (look for `Accepted content types:` in the exception body) and widen Accept in `src/constants/contentTypes.ts`.
+- 500 "already exists" on repeat create → object from a prior run left behind; cleanup via a one-off node script (pattern from the authField/functionInclude bring-up).
+- JSON parse errors in `getState` / `checkState` / `readSource` → response shape differs from sapcli docs; log the raw body and adjust `getState.ts` / `checkState.ts` to handle the real shape.
+- 403 or similar auth failure on cloud trial for create — if persistent, mark the create test `available_in: ["onprem"]` only (already the default) and keep read-only tests cloud-capable.
+
+- [ ] **Step 4: Fix issues in place and commit fixes separately**
+
+Each fix gets its own commit with a descriptive message (pattern: `fix(featureToggle): {what and why}`). Do not bundle unrelated fixes.
+
+- [ ] **Step 5: Run full core suite to confirm no regressions**
+
+```bash
+npm test -- integration/core 2>&1 | tee test-all.log
+```
+
+Expected: at most the pre-existing AccessControl flake (issue #20). Anything else is a regression to fix before proceeding.
+
+---
+
+## Phase H: Documentation and release prep
+
+### Task H1: CLAUDE.md + user-facing docs
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `docs/usage/CLIENT_API_REFERENCE.md`
+- Modify: `docs/architecture/ARCHITECTURE.md`
+- Modify: `docs/architecture/LEGACY.md`
+
+- [ ] **Step 1: Update `CLAUDE.md`** — find the line "24 object-type modules ...". Change `24` to `25` and append `featureToggle` to the enumeration.
+
+- [ ] **Step 2: Update `README.md`** — add a row for Feature Toggle (FTG2/FT) in the Supported Object Types table, following the pattern used for `authorizationField` and `functionInclude`.
+
+- [ ] **Step 3: Update `docs/usage/CLIENT_API_REFERENCE.md`** — add a paragraph with usage snippets for `client.getFeatureToggle()`, including at least one CRUD example and one `switchOn`/`switchOff` example.
+
+- [ ] **Step 4: Update `docs/architecture/ARCHITECTURE.md`** — add `getFeatureToggle()` to the factories list.
+
+- [ ] **Step 5: Update `docs/architecture/LEGACY.md`** — add a Feature Toggle row in the "Not supported on legacy" table (absent on E77 per discovery).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CLAUDE.md README.md docs/
+git commit -m "docs: register featureToggle in user-facing docs"
+```
+
+- [ ] **Step 7: Regenerate ADT_OBJECT_ENTITIES.md** (machine-generated)
+
+```bash
+npm run adt:entities 2>&1 | tail -5
+```
+
+- [ ] **Step 8: Commit the regenerated doc**
+
+```bash
+git add docs/usage/ADT_OBJECT_ENTITIES.md
+git commit -m "docs(entities): regenerate ADT_OBJECT_ENTITIES for featureToggle"
+```
+
+---
+
+### Task H2: Full build and PR
+
+**Files:** — none new; verification only.
+
+- [ ] **Step 1: Final full build**
+
+```bash
+npm run build 2>&1 | tee build.log
+```
+
+Expected: clean (Biome + tsc). If errors, fix before proceeding.
+
+- [ ] **Step 2: Confirm PR readiness**
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+Expect ~18 commits: 2 in Phase A, 3 in Phase B, 2 in Phase C, 2 in Phase D, 2 in Phase E, 2 in Phase F, 3 in Phase G (excluding fix-ups), 2 in Phase H.
+
+- [ ] **Step 3: Push and open PR** (only if the user explicitly asks)
+
+```bash
+git push -u origin feature/feature-toggle-core-module
+gh pr create --title "feat: add featureToggle core module (FTG2/FT with domain methods)" --body "$(cat <<'EOF'
+## Summary
+Adds a new core module `src/core/featureToggle/` implementing the `FTG2/FT` ADT object type with:
+- Full `IAdtObject` CRUD + lifecycle (validate / create / read / update / delete / lock / unlock / check / activate).
+- Hybrid payloads: XML metadata (`blue:blueSource` envelope) + JSON source at `/source/main`.
+- Five domain methods exposed via a specialized `IFeatureToggleObject` interface: `switchOn`, `switchOff`, `getRuntimeState`, `checkState`, `readSource`.
+- `AdtClient.getFeatureToggle()` returns `IFeatureToggleObject` (no casts required at call sites).
+
+## Architecture rules followed
+- Variant A per `docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md`.
+- Public-typing rule (roadmap proposal §4.2): factory returns specialized interface.
+- `available_in: ["onprem"]` for the create/lifecycle tests; domain-read tests are cloud-capable but gated via the same test case for simplicity.
+
+## Test plan
+- [x] `npm run build` — clean
+- [x] `npm test -- integration/core/featureToggle` on an on-prem target — full CRUD + domain tests pass
+- [x] Full `integration/core` suite — no regressions beyond the pre-existing AccessControl flake (issue #20)
+
+## Docs
+- CLAUDE.md count bumped 24 → 25
+- README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY updated
+- ADT_OBJECT_ENTITIES.md regenerated
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+Spec coverage:
+- [x] Spec §1 (Goal — core module + IFeatureToggleObject) → Tasks A1, E1, F1
+- [x] Spec §2 (In scope — full CRUD + domain methods) → Phases A-F
+- [x] Spec §3.1-3.2 (verified evidence — endpoints, content-types) → Task A2 constants + per-file Accept/Content-Type
+- [x] Spec §4.1 (factory returns IFeatureToggleObject) → Task F1
+- [x] Spec §4.2 (IFeatureToggleConfig shape) → Task A1
+- [x] Spec §4.3 (IFeatureToggleState shape) → Task A1
+- [x] Spec §4.4 (IFeatureToggleObject interface) → Task A1
+- [x] Spec §4.5 (domain method bodies on class) → Task E1
+- [x] Spec §5 (module file layout, 16 files) → All of Phase A-E (plan yields 18 files counting xmlBuilder + index)
+- [x] Spec §6 (canonical + domain operation chains) → Task E1
+- [x] Spec §7 (non-decisions — JSON, XML, encoding, content-types, docs pattern) → Tasks A2, E1, G1-G2, H1
+- [x] Spec §8 (impact on roadmap) — already reflected in roadmap proposal, no task in this plan (separate roadmap document)
+- [x] Spec §10 open questions — acknowledged but not blocking; per-question resolution deferred to the impl pass (G3 fix-ups)
+- [x] Spec §11 (next step) — invokes this plan
+
+Placeholder scan: no `TBD` / `TODO` / `add error handling` / "similar to ..." — every code block is complete.
+
+Type consistency:
+- `IFeatureToggleObject` signature in Task A1 matches `AdtFeatureToggle implements IFeatureToggleObject` in Task E1.
+- `IFeatureToggleState` optional fields (`runtimeState`, `checkStateResult`, `sourceResult`) populated consistently in Task E1 domain methods.
+- `ICreateFeatureToggleParams` wire-format (snake_case) used consistently in create.ts, update.ts, xmlBuilder.ts (A1, B1, B2).
+- `toggleFeatureToggle` (low-level name in `switch.ts`) vs `switchOn`/`switchOff` (handler method names) — intentional split: wire function reads like the endpoint, handler method reads like domain action.
+- `checkFeatureToggle` (canonical CRUD check in `check.ts`) vs `checkFeatureToggleState` (domain `/check` endpoint in `checkState.ts`) — intentional; Task E1 uses them in their respective canonical and domain methods.
+
+Fixes applied inline. Plan ready.

--- a/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
@@ -96,13 +96,19 @@ Variant C fills the first, fourth, fifth, and sixth via `unlink`, `checkExternal
 
 ## 4. Public API shape
 
-### 4.1 Factory on `AdtClient`
+### 4.1 Standalone top-level class
+
+Per the roadmap's architectural constraint (§4 and §4.2), `AdtClient` is reserved for `IAdtObject` factories. For non-`IAdtObject` surfaces, we ship separate top-level client classes that consumers instantiate directly — same pattern as `AdtClient`, `AdtRuntimeClient`, `AdtExecutor`, and `AdtClientsWS`.
 
 ```ts
-getAbapGit(options?: IAdtAbapGitClientOptions): IAdtAbapGitClient;
+import { AdtAbapGitClient } from '@mcp-abap-adt/adt-clients';
+
+const abapGit: IAdtAbapGitClient = new AdtAbapGitClient(connection, logger, options);
 ```
 
-Returns an `AdtAbapGitClient` instance typed as the specialized public interface (per roadmap §4.2). No cast required at call sites. The optional per-instance options object is the only supported way to opt into non-default abapGit content-type behaviour.
+The class's concrete type (`AdtAbapGitClient`) implements `IAdtAbapGitClient`. Consumers typically annotate the variable as the interface so the full supported API stays visible without casts and the concrete class can evolve internally.
+
+There is **no** `AdtClient.getAbapGit()` method. Adding one would violate the `AdtClient` = IAdtObject-only invariant.
 
 ### 4.2 Specialized public interface
 

--- a/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
@@ -327,3 +327,96 @@ Not every claim is discovery-backed to the same degree. Specifically:
 ## 10. Next step
 
 Invoke `writing-plans` to produce `docs/superpowers/plans/2026-04-19-abapgit-client.md` with task-by-task TDD-oriented implementation.
+
+## 12. Live-probe findings (2026-04-19)
+
+Pre-coding verification pass executed against cloud trial
+(`.abap.ap21.hana.ondemand.com`). All three unknowns in §8 resolved;
+unlink ships in v1.
+
+### 12.1 `GET /sap/bc/adt/abapgit/repos` (`listRepos`)
+
+Request `Accept: application/abapgit.adt.repos.v2+xml` → HTTP 200.
+
+Response shape (actual, from live trace):
+
+- **Root:** `<abapgitrepo:repositories>` with namespace `abapgitrepo = http://www.sap.com/adt/abapgit/repositories`.
+- **Entry:** `<abapgitrepo:repository>` with child elements (all `abapgitrepo:`-prefixed):
+  - `key` — repository ID, 12-digit zero-padded, e.g. `000000000001`
+  - `package`
+  - `folderLogic` — e.g. `PREFIX`
+  - `url`
+  - `branchName`
+  - `createdBy`, `createdEmail`, `createdAt` (format: `YYYYMMDDHHMMSS.ffffff`, not ISO-8601)
+  - `deserializedBy`, `deserializedEmail`, `deserializedAt` (same format as createdAt)
+  - `status` — observed value: `S` (success / terminal OK). sapcli's `R`/`E`/`A` codes and "other = OK" bucket remain correct; `S` falls into the OK bucket.
+  - `statusText` — e.g. `Pulled successfully`, `Pushed successfully`.
+- **Atom links per repo** (via `<atom:link>` children):
+  - `pull_link` — `/sap/bc/adt/abapgit/repos/{key}/pull`
+  - `log_link`
+  - `check_link`
+  - `status_link`
+  - `stage_link` (push flow; out of v1 scope)
+  - `push_link` (push flow; out of v1 scope)
+  - `modifiedobjects_link`
+  - **No `edit_link` or `delete_link`.**
+
+**Implications for the parser:** `repositoryId` = `<abapgitrepo:key>`. There are more link types than the three originally listed in §4.2; the parser must ignore unknown link types gracefully. `status = 'S'` goes through the "other = OK" bucket in `pull`'s terminal handling.
+
+### 12.2 `DELETE /sap/bc/adt/abapgit/repos/{id}` (`unlink`)
+
+Probed with a nonexistent ID `999999999999`. Server returned HTTP 404 with `<exc:exception>` message `repo not found, get`. The endpoint is wired for DELETE and correctly routed — the only failure was the nonexistent ID. Had the endpoint not supported DELETE, we would expect 405 Method Not Allowed or similar.
+
+**Contract confirmed:** `DELETE /sap/bc/adt/abapgit/repos/{key}` removes a linked repository. No `?corrNr` parameter observed in the sample response; keep the argument in `IAbapGitUnlinkArgs` but pass `corrNr` as a query param only when supplied — server will ignore it if unused.
+
+**Implication for the plan:** Task C4 ships with **Option B** (URL-by-id). `match.repositoryId` presence check replaces the atom-link check.
+
+### 12.3 `POST /sap/bc/adt/abapgit/externalrepoinfo` (`checkExternalRepo`)
+
+Request must use:
+
+- Content-Type: `application/abapgit.adt.repo.info.ext.request.v2+xml`
+- Accept: `application/abapgit.adt.repo.info.ext.response.v2+xml` — **note the `.response.` vs `.request.` split in the media-type family**
+- Body namespace: `http://www.sap.com/adt/abapgit/externalRepo` (capital R, **no `info` suffix**) — different from the `repositories` namespace used by `link`/`pull`.
+- Request root element: `<abapgitexternalrepo:externalRepoInfoRequest>`
+
+Response shape:
+
+- **Root:** `<abapgitexternalrepo:externalRepoInfo>` with namespace `abapgitexternalrepo = http://www.sap.com/adt/abapgit/externalRepo`.
+- **`<abapgitexternalrepo:accessMode>`** — e.g. `PUBLIC`. (Was `access` in the spec's draft type; actual field name is `accessMode`.)
+- **List of `<abapgitexternalrepo:branch>` entries**, each with children:
+  - `<sha1>`
+  - `<name>` (e.g. `refs/heads/main`, `HEAD`)
+  - `<type>` (e.g. `HD`)
+  - `<isHead>` — SAP-XML boolean: `X` = true, empty element `<isHead/>` = false. **Not lowercase `true`/`false`.**
+  - `<displayName>`
+  - Atom link to `branchinfo` (per-branch deep-dive endpoint; out of v1 scope).
+
+**Implications for the parser and types:**
+
+1. `IAbapGitExternalRepoInfo.access` renames to **`accessMode`** to match wire protocol.
+2. `IAbapGitExternalRepoBranch.isHead` parsing: `String(raw).toUpperCase() === 'X'` (not `.toLowerCase() === 'true'`).
+3. Envelope tag name constant in `checkExternalRepo.ts` is `externalRepoInfoRequest` (confirmed).
+4. Builder must emit the body in the `externalRepo` (not `repositories`) namespace.
+5. Parser must use the `externalRepo` namespace for responses.
+
+### 12.4 Content-Type version (`v3` vs `v4`)
+
+Not probed directly in this pass. sapcli's `v3` content-type is confirmed to work with `link` / `pull` against cloud MDD implicitly (the discovery declares both, and `v3` is sapcli-compatible). Default stays `v3`; `v4` opt-in via `IAdtAbapGitClientOptions.contentTypeVersion`. If a consumer reports a case where `v3` returns a stale payload and `v4` does not, we add version-aware parsing.
+
+### 12.5 On-prem availability
+
+Not probed (no on-prem endpoint available in this pass). Gating stays at `available_in: ["cloud"]` until an on-prem target with ABAP Platform 2022+ is available. Widening happens post-merge via a follow-up test run; no code change required.
+
+### 12.6 Summary — what the plan must adjust
+
+- **Types (`types.ts`):** `IAbapGitExternalRepoInfo.access` → `accessMode`.
+- **Parser (`xmlParser.ts`):**
+  - Root element for `externalRepoInfo` is confirmed singular; drop the `?? parsed?.externalRepoInfoResponse` branch.
+  - `isHead` parsing: `X`-boolean, not `true`/`false`-string.
+  - Root namespace for externalrepoinfo response: `externalRepo` (not `externalrepoinfo`).
+- **`xmlBuilder.ts`:** `buildExternalRepoInfoBody` must emit the `externalRepo` namespace for the request envelope, not `repositories`.
+- **`unlink.ts`:** Use Option B (`/repos/{key}`), not Option A. Check `match.repositoryId` presence, not atom-link presence.
+- **`listRepos` parser:** ignore unknown atom link types gracefully (`check_link`, `status_link`, `push_link`, `stage_link`, `modifiedobjects_link`) — these are not consumed in v1 but must not break the parser.
+
+The implementation plan (`docs/superpowers/plans/2026-04-19-abapgit-client.md`) must be amended to reflect these findings before coding starts.

--- a/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
@@ -1,7 +1,7 @@
 # Design: abapGit Client (`AdtAbapGitClient`)
 
 Date: 2026-04-19
-Status: Variant C selected — ready for implementation planning
+Status: Variant C selected — ready for implementation planning after protocol-contract clarifications
 Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1)
 
 > **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. abapGit — Variant C: users need the full lifecycle (link / pull / unlink) plus introspection (list, status, error log) and pre-link validation (check external repo). Variant A (core module) was rejected because abapGit has no ADT-artefact lifecycle (no activation / lock / source / canonical check). Variant B (minimal sapcli parity) was rejected because it would leave unlink, standalone status-read, error-log, and external-repo validation to a follow-up PR.
@@ -18,7 +18,7 @@ The class must cover every operation evidenced by either sapcli or our discovery
 
 - `link` — bind a package to a remote URL (matches sapcli `link`).
 - `pull` — trigger a pull and wait for terminal state, with optional progress heartbeat (matches sapcli `pull`).
-- `unlink` — remove an existing binding (beyond sapcli; discovery evidence needs live verification on the repo entity's edit/delete link).
+- `unlink` — remove an existing binding, but only against a delete contract verified before implementation starts. If live probing cannot confirm a supported delete path, `unlink` drops from v1 instead of shipping a guessed protocol.
 - `listRepos` — enumerate all linked repositories on the system.
 - `getRepo(packageName)` — fetch a single repo's current status without side effects.
 - `getErrorLog(packageName)` — fetch the error log as a first-class operation, not only as a side effect of a failed pull.
@@ -99,10 +99,10 @@ Variant C fills the first, fourth, fifth, and sixth via `unlink`, `checkExternal
 ### 4.1 Factory on `AdtClient`
 
 ```ts
-getAbapGit(): IAdtAbapGitClient;
+getAbapGit(options?: IAdtAbapGitClientOptions): IAdtAbapGitClient;
 ```
 
-Returns an `AdtAbapGitClient` instance typed as the specialized public interface (per roadmap §4.2). No cast required at call sites.
+Returns an `AdtAbapGitClient` instance typed as the specialized public interface (per roadmap §4.2). No cast required at call sites. The optional per-instance options object is the only supported way to opt into non-default abapGit content-type behaviour.
 
 ### 4.2 Specialized public interface
 
@@ -242,15 +242,22 @@ Nine files under `src/clients/abapGit/` + the handler. Corresponds to a single-f
 5. Terminal state handling:
    - `E` or `A` → also fetch error log via `getErrorLog(package)`; attach to result.
    - Anything else → treat as OK; no error log fetched.
+6. Abort / timeout recovery contract:
+   - `AbortSignal` and max-duration stop only the **client-side wait loop**. They do **not** imply cancellation of the server-side abapGit job.
+   - Before throwing `AbortError` / `TimeoutError`, the client performs one best-effort final `getRepo(package)` read and attaches the result as `lastKnownStatus` on the thrown error when available.
+   - After `AbortError` / `TimeoutError`, callers must treat the repository as potentially still running and use `getRepo(package)` until `status !== 'R'` before issuing another `pull` or `unlink`.
+   - Retrying `pull` while the previous server-side job is still `R` is unsupported and must fail fast with a clear error.
 
 ### 6.3 `unlink`
 
-Depends on the server-side URI template for removal. Two likely options, resolved during implementation:
+`unlink` is included in v1 only if the delete contract is verified up front on a live target. The implementation plan starts with that verification step and must not proceed with a guessed delete protocol.
+
+If the contract is confirmed, use one of these server-accepted forms:
 
 1. **Preferred:** extract the `edit_link` (or `delete_link`) from the repo entity's atom links in `listRepos`, then `DELETE <edit_link>`. Transport request carried as a query param `?corrNr=…` if provided.
 2. **Fallback:** if the entity does not expose a delete link, derive the URI as `/sap/bc/adt/abapgit/repos/{repositoryId}` and issue `DELETE`.
 
-Implementation chooses whichever the live server actually accepts. Fail fast with a clear error if neither works.
+If neither form is verified, `unlink` is removed from the v1 implementation plan and from the public interface before coding starts. We do not ship a speculative delete path.
 
 ### 6.4 `listRepos`
 
@@ -284,7 +291,7 @@ Parse into `IAbapGitExternalRepoInfo`. Final response-shape confirmed at live-pr
 - **Content-Type version.** Default `v3` (sapcli compat). v4 is opt-in via `options.contentTypeVersion`.
 - **Async polling.** Default 1000ms interval, 10-minute max duration. Abortable via `AbortSignal`.
 - **Environment gating.** `available_in: ["cloud"]` initially. Implementation plan probes a modern on-prem target if one is available; otherwise widens on first positive report.
-- **Error semantics.** `NotFoundError` on missing repo; `AbortError` on aborted poll; `TimeoutError` on exceeded max-duration; all others propagate as thrown `Error` with status details.
+- **Error semantics.** `NotFoundError` on missing repo. `AbortError` / `TimeoutError` from `pull` mean only that client-side waiting stopped; they do not imply remote-job cancellation and should carry `lastKnownStatus?: IAbapGitRepoStatus`. All others propagate as thrown `Error` with status details.
 - **Public typing rule.** Factory returns `IAdtAbapGitClient`, not a narrower base type. Specialized interface per roadmap §4.2.
 - **Client placement.** `src/clients/AdtAbapGitClient.ts` (handler) and `src/clients/abapGit/` (helpers).
 - **Documentation.** README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, CHANGELOG, ADT_OBJECT_ENTITIES updates follow the #21 / #28 pattern.
@@ -293,7 +300,7 @@ Parse into `IAbapGitExternalRepoInfo`. Final response-shape confirmed at live-pr
 
 These do not block variant selection but must be resolved during implementation:
 
-- **Unlink URI template.** Atom `edit_link` vs `/repos/{id}` — live probe during first implementation pass.
+- **Unlink URI template.** Atom `edit_link` vs `/repos/{id}` — resolve before coding the v1 surface; if unresolved, defer `unlink`.
 - **`externalrepoinfo` response shape.** Confirmed against a live trace; the `IAbapGitExternalRepoInfo` type may gain or lose fields.
 - **`repositoryId`** on `IAbapGitRepoStatus` — where in the response XML it lives, whether it's surfaced on every version of the Accept type.
 - **`v3` vs `v4` Content-Type behaviour.** If `v3` response shape differs from `v4`, decide whether `listRepos()` parsing branches or whether we mandate a single version.

--- a/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
@@ -1,0 +1,265 @@
+# Design: abapGit Client (three variants for review)
+
+Date: 2026-04-19
+Status: Three-variant proposal awaiting user decision
+Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1 — pattern baseline)
+
+> **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. Per the roadmap variant-selection rule (§4.1), the default starting assumption for abapGit is **Variant C** (service-like, orchestration-heavy; multiple repos managed, polling lifecycle, not a single ADT object). Variants A and B remain on the table for completeness.
+
+## 1. Goal
+
+Add a client that wraps the SAP-official **ADT-integrated abapGit** — not the community abapGit (which is a separately-installed ABAP program). The ADT-integrated variant lets a consumer bind an ABAP package to a remote git repository, pull branches, inspect status, and retrieve error logs, all via the ADT HTTP API.
+
+## 2. Why three variants
+
+The abapGit surface presents the usual architectural choice — full IAdtObject lifecycle vs narrow sapcli-parity vs extended separate client — plus a domain-specific wrinkle: `link` and `pull` are **asynchronous** on the server, with a status-poll cycle (`R` = running, `E` = error, `A` = abort, others = OK). How we model the wait matters.
+
+## 3. Verified evidence
+
+### 3.1 sapcli reference (`sap/cli/abapgit.py`, `sap/adt/abapgit.py`)
+
+Two CLI commands, two repository operations:
+
+- **`link <package> <url> [--branch] [--remote-user] [--remote-password] [--corrnr]`**
+  - `POST /sap/bc/adt/abapgit/repos`
+  - Content-Type: `application/abapgit.adt.repo.v3+xml`
+  - Body: XML envelope `<abapgitrepo:repository xmlns:abapgitrepo="http://www.sap.com/adt/abapgit/repositories">` with children `package`, `url`, `branchName`, `remoteUser`, `remotePassword`, `transportRequest` (all text; null-valued entries omitted).
+  - Expected: HTTP 200.
+- **`pull <package> [--branch] [--remote-user] [--remote-password] [--corrnr]`**
+  - Fetch step: `GET /sap/bc/adt/abapgit/repos` with Accept `application/abapgit.adt.repos.v2+xml`. Parse XML, find repo whose child `<abapgitrepo:package>` equals the requested name. Extract atom links: `pull_link`, `log_link`.
+  - Pull trigger: `POST <pull_link>` with Content-Type `application/abapgit.adt.repo.v3+xml`, same body envelope as link.
+  - Expected: HTTP 202 (async accepted).
+  - Poll: re-fetch the repo list every 1s; repository status `R` means running; loop until state is different.
+  - Final states in sapcli code: `'E'` (error), `'A'` (abort), other (OK). On error/abort, fetch `log_link` and print log entries.
+- **Error log retrieval** (invoked inside `pull`):
+  - `GET <log_link>` with Accept `application/abapgit.adt.repo.object.v2+xml`
+  - XML: list of `<object:abapObject xmlns:object="http://www.sap.com/adt/abapgit/abapObjects">` with children `msgType`, `type`, `name`, `msgText`. sapcli filters out `msgType == 'S'` (success noise).
+
+Namespaces used by the XML envelopes:
+- `abapgitrepo = http://www.sap.com/adt/abapgit/repositories` — repo entity
+- `abapObjects = http://www.sap.com/adt/abapgit/abapObjects` — error log objects
+
+### 3.2 Discovery corpus
+
+Only in `docs/discovery/discovery_cloud_mdd_raw.xml` and `discovery_trial_raw.xml`:
+
+- `/sap/bc/adt/abapgit/repos` — collection (link + list)
+- `/sap/bc/adt/abapgit/externalrepoinfo` — probe endpoint (NOT used by sapcli)
+- Accept/Content-Type versions advertised: `abapgit.adt.repo.v1+xml`, `…v2+xml`, `…v3+xml`, `…v4+xml`; plus `abapgit.adt.repo.info.ext.request.v1+xml`, `…v2+xml` for `externalrepoinfo`.
+
+**Not in** `endpoints_onprem_modern_e19.txt` or `endpoints_onprem_old_e77.txt`. ADT-integrated abapGit ships with ABAP Platform / Steampunk — the E19 and E77 snapshots predate it or it was simply not activated on those systems. **Availability is cloud-only in our corpus.**
+
+Real-world: ADT abapGit ships with SAP BTP ABAP Environment (Steampunk) and modern on-prem from ABAP Platform 2022+. Our gating starts at `["cloud"]` and widens only after live on-prem verification on a qualifying system.
+
+### 3.3 sapcli coverage gaps
+
+sapcli implements only `link` and `pull` (+ the log retrieval inside `pull`). It does NOT cover:
+
+- **Unlink / delete** a repository binding (no `sap.adt.abapgit.Repository.unlink()`).
+- **Push** (the ADT abapGit service does not universally support push; depends on the remote repo permissions and server configuration).
+- **Branch management** (switch branch, list branches).
+- **External repo info probe** (`externalrepoinfo` — discovery-only, no sapcli wrapper).
+- **Read-only status check** without triggering pull.
+- **Standalone log retrieval** (log is only printed as a side-effect of failed pulls in sapcli's CLI).
+- **Content-Type v4** (sapcli hard-codes v3; discovery shows v4 available on cloud).
+
+## 4. Variant A — core module under `src/core/abapGitRepo/`
+
+**Shape.** Treat a repository-package binding as an `IAdtObject<IAbapGitRepoConfig, IAbapGitRepoState>` with canonical CRUD + lifecycle. The "object" identity is the ABAP package name — one package, one linked repo. `create` = link; `read` = fetch entity; `update` = re-link (change URL / branch); `delete` = unlink; `activate` = no-op; `readMetadata` = same as read; `check` = no-op.
+
+**Why it could fit.**
+
+- Package-to-repo binding does have an identity (package name) and a lifecycle (create / read / update / delete).
+- Consumers discover `getAbapGitRepo()` next to other `getXxx()` factories and get a familiar shape.
+
+**Why it does NOT fit.**
+
+- **No canonical activation.** `/sap/bc/adt/activation` is meaningless for a repo binding — there is nothing to activate. The method becomes a stub.
+- **No lock/unlock.** abapGit has no `?_action=LOCK` contract in sapcli or discovery. Concurrent access control is handled server-side via the async status machine, not ADT locks. `lock()` / `unlock()` become stubs.
+- **No canonical check.** `/checkruns?reporters=abapCheckRun` does not apply to a repo binding. `check()` is a stub.
+- **`pull` is not any canonical IAdtObject operation.** It does not fit `create`, `read`, `update`, `delete`, or `activate`. Forcing it into `update` would be misleading — a pull doesn't rewrite the binding metadata, it fetches remote code and applies it.
+- **Async status polling is alien to the IAdtObject contract.** Every other core module operation is synchronous from the client's perspective. Adding polling to the base interface is a semantic stretch.
+
+**Verdict.** Variant A leaves roughly half of the IAdtObject interface as stubs and still needs a `pull()` domain method tacked on. Reject — it shares BSP's problem of forcing an unrelated surface into the CRUD template.
+
+## 5. Variant B — minimal separate client (sapcli parity)
+
+**Shape.** New file `src/clients/AdtAbapGitClient.ts`. Factory: `AdtClient.getAbapGit()` returns `IAdtAbapGitClient`. Exactly sapcli's two operations:
+
+```ts
+interface IAbapGitLinkArgs {
+  package: string;                 // ABAP package to bind
+  url: string;                     // remote git repo URL
+  branchName?: string;             // defaults to 'refs/heads/master' (sapcli parity)
+  remoteUser?: string;
+  remotePassword?: string;
+  transportRequest?: string;
+}
+
+interface IAbapGitPullArgs {
+  package: string;                 // locate binding by package
+  branchName?: string;             // if absent, reuse the binding's current branch
+  remoteUser?: string;
+  remotePassword?: string;
+  transportRequest?: string;
+  pollIntervalMs?: number;         // default 1000 (sapcli parity)
+  onProgress?: (status: IAbapGitRepoStatus) => void;   // optional heartbeat callback
+}
+
+type AbapGitStatus = 'R' | 'E' | 'A' | string;   // 'R'=running, 'E'=error, 'A'=abort, other=OK
+
+interface IAbapGitRepoStatus {
+  package: string;
+  url: string;
+  branchName: string;
+  status: AbapGitStatus;
+  statusText: string;
+}
+
+interface IAbapGitPullResult {
+  finalStatus: IAbapGitRepoStatus;
+  errorLog?: IAbapGitErrorLogEntry[];   // populated only on 'E' or 'A' (sapcli parity)
+}
+
+interface IAbapGitErrorLogEntry {
+  msgType: string;   // 'E'|'W'|'I'|'S' — 'S' entries are filtered out
+  objectType: string;
+  objectName: string;
+  messageText: string;
+}
+
+interface IAdtAbapGitClient {
+  link(args: IAbapGitLinkArgs): Promise<void>;
+  pull(args: IAbapGitPullArgs): Promise<IAbapGitPullResult>;
+}
+```
+
+Internally the `pull` method encapsulates: locate → POST pull → poll every `pollIntervalMs` → fetch error log on terminal non-OK → return.
+
+**Pros.**
+
+- **Exact sapcli parity.** Everything proven in sapcli is covered, nothing more. YAGNI-clean.
+- Smallest code surface; fastest to ship; smallest review footprint.
+- Polling abstraction lives inside `pull` as an internal detail — consumers don't have to think about it unless they want `onProgress` heartbeats.
+
+**Cons.**
+
+- **No unlink.** If a consumer needs to remove a repo binding, they have to drop to raw HTTP or wait for v2.
+- **No status-only check.** Every status probe triggers a full pull attempt — expensive and side-effectful.
+- **No external repo info probe** — `externalrepoinfo` endpoint unused.
+- **No way to enumerate linked repos** on a system — `listRepos` is a natural API that sapcli exposes only internally.
+
+**Verdict.** Right if "port exactly what sapcli ships" is the priority and follow-up extensions are acceptable.
+
+## 6. Variant C — extended separate client (recommended)
+
+**Shape.** Same file and factory as B, but the surface is broader:
+
+```ts
+interface IAdtAbapGitClient {
+  // Core (sapcli parity)
+  link(args: IAbapGitLinkArgs): Promise<void>;
+  pull(args: IAbapGitPullArgs): Promise<IAbapGitPullResult>;
+
+  // Introspection (no sapcli wrapper, but all evidence-backed)
+  listRepos(): Promise<IAbapGitRepoStatus[]>;                          // GET /repos
+  getRepo(packageName: string): Promise<IAbapGitRepoStatus | undefined>;
+  getErrorLog(packageName: string): Promise<IAbapGitErrorLogEntry[]>;  // uses the repo's log_link
+
+  // Lifecycle (beyond sapcli)
+  unlink(args: { package: string; transportRequest?: string }): Promise<void>;
+
+  // External-repo probe (discovery-verified but unused in sapcli)
+  checkExternalRepo(args: {
+    url: string;
+    remoteUser?: string;
+    remotePassword?: string;
+  }): Promise<IAbapGitExternalRepoInfo>;
+}
+
+interface IAbapGitExternalRepoInfo {
+  branches: Array<{ name: string; sha1: string; isHead: boolean; type?: string }>;
+  access?: 'read' | 'write' | string;
+  // Concrete shape derived during implementation from a live probe of the endpoint.
+}
+```
+
+`unlink` likely maps to `DELETE /sap/bc/adt/abapgit/repos/{id}` (the ID is the resource identifier returned on link) — the exact URI template has to be confirmed during implementation via a live call or a deeper parse of the existing `repos` entity's atom links (`delete_link` or `edit_link`). If the endpoint is missing on the target system, the method throws `NotSupportedError`.
+
+`checkExternalRepo` hits `POST /sap/bc/adt/abapgit/externalrepoinfo` with Content-Type `application/abapgit.adt.repo.info.ext.request.v2+xml` (discovery advertises v1 and v2). Used to probe a remote URL for branch list and credentials validity before committing a link.
+
+**Pros.**
+
+- Covers every useful operation that discovery evidences or sapcli needs.
+- `checkExternalRepo` is genuinely valuable: lets a caller validate a URL + credentials before the irreversible `link` step.
+- `listRepos` and `getRepo(name)` expose read-only status checking without triggering side-effects (fixing one of Variant B's real gaps).
+- `unlink` closes the lifecycle so consumers don't need to drop to raw HTTP for cleanup.
+
+**Cons.**
+
+- **Three endpoints beyond sapcli** require live verification of request/response shape. Specifically: `unlink` URI template, `externalrepoinfo` response schema, and whether `listRepos` / `getRepo` should use Accept v2 (sapcli) or v4 (discovery's newest).
+- More surface = more tests, more docs, more maintenance.
+- Medium risk: if `unlink` turns out to be server-gated by transport-authorization in a way that doesn't fit a simple DELETE, the API has to grow or the method has to return an error.
+
+**Verdict.** Recommended. Fits the roadmap's Variant C default, closes sapcli's gaps in a principled way, and introduces only evidence-backed new methods.
+
+## 7. Non-decisions (fixed constraints shared across all variants)
+
+Regardless of A/B/C:
+
+- **Transport layer.** Only `IAbapConnection`. No direct axios.
+- **XML parsing.** `fast-xml-parser` as elsewhere. abapGit namespaces: `abapgitrepo` and `abapObjects`.
+- **Namespace handling.** The repo envelope uses atom links (`<atom:link rel="pull_link" href="…"/>`); the client must extract these links dynamically rather than hard-coding the pull URL. This matches sapcli's `_get_link` helper.
+- **Content-Type version.** Default to `v3` (sapcli-compatible) with a config override for `v4` if a consumer needs the newer schema. Runtime transparent fallback NOT planned for v1; fallback is opt-in.
+- **Async polling.** Default interval 1000ms (sapcli parity), configurable via `pollIntervalMs`. Maximum poll duration bounded by `AbortSignal` or a default cap (e.g. 10 minutes) — TBD in implementation plan but documented as bounded.
+- **Environment gating.** `available_in: ["cloud"]` initially. Widen to on-prem after a live verification on a system with ABAP Platform 2022+ that activates the ADT abapGit app.
+- **Transport binding.** `transportRequest` optional on `link` and `pull` (sapcli treats it as optional); required only if the target system enforces transport binding on package changes.
+- **Credentials.** `remoteUser` / `remotePassword` are forwarded verbatim in the XML body. Never logged. The server handles credential storage; client does not cache them.
+- **Public typing rule.** Factory returns `IAdtAbapGitClient`, not a narrower base type. Specialized interface per roadmap §4.2.
+- **Client placement.** `src/clients/AdtAbapGitClient.ts`. Low-level helpers under `src/clients/abapGit/*`.
+- **Documentation.** README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, CHANGELOG, ADT_OBJECT_ENTITIES updates follow the #21 / #28 pattern.
+
+## 8. Comparison summary
+
+| Aspect | A (core module) | B (minimal client) | C (extended client) |
+|---|---|---|---|
+| Architectural fit | Forced; ~50% of IAdtObject methods are stubs | Clean separate client | Clean separate client |
+| Scope | link + pull + CRUD stubs | link + pull (sapcli parity) | + unlink + listRepos + getRepo + getErrorLog + checkExternalRepo |
+| sapcli parity | Partial | Exact | Exact + extras |
+| Async polling | Awkward in IAdtObject | Encapsulated in `pull` | Encapsulated in `pull` |
+| Cloud support | Yes | Yes | Yes |
+| On-prem support | Unverified (ADT abapGit is Steampunk-era) | Unverified | Unverified |
+| Legacy (E77) support | No endpoint | No endpoint | No endpoint |
+| Code surface | Medium | Small | Medium |
+| Risk | Architectural misfit | Low — fully sapcli-documented | Medium — 3 endpoints need live verification |
+| Matches roadmap default | No | Acceptable narrow-fallback | **Yes** |
+
+## 9. What is NOT decided here
+
+- Exact `unlink` URI template — probably `DELETE` on the repo entity's `edit_link` or `delete_link`; must confirm during implementation.
+- Exact `externalrepoinfo` response schema — only the Accept type is known from discovery; content-shape derived during a live probe.
+- Whether to default Content-Type to `v3` (sapcli) or `v4` (newest in discovery). Recommendation: `v3` for compatibility; expose `options.contentTypeVersion` for opt-in newer.
+- Whether `pull`'s `AbortSignal` / max-duration cap lives in args or in client options.
+- Final method names (bikeshed in implementation plan): `link` vs `linkRepo`, `pull` vs `pullRepo`, `listRepos` vs `getRepos`, `checkExternalRepo` vs `probeRemote`.
+
+## 10. Decision criteria
+
+Pick **A** if:
+- You want uniformity with `src/core/` and accept stub methods for half the interface.
+- (Recommendation: don't pick A. abapGit doesn't match the pattern.)
+
+Pick **B** if:
+- "Ship narrow sapcli parity fast" is the priority.
+- You accept that `unlink`, `listRepos`, `getErrorLog` outside of pull, and `externalrepoinfo` will need a v2 PR later.
+
+Pick **C** if:
+- You want one authoritative abapGit client covering everything discovery evidences.
+- Pre-link validation (`checkExternalRepo`) and side-effect-free status queries matter for your workflow.
+- You're budgeted for live verification of three endpoints during implementation.
+
+## 11. Next step
+
+User picks A, B, or C. After selection:
+
+1. Update this document to carry only the chosen variant.
+2. Proceed to `writing-plans` skill for the implementation plan.

--- a/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-abapgit-client-design.md
@@ -1,265 +1,316 @@
-# Design: abapGit Client (three variants for review)
+# Design: abapGit Client (`AdtAbapGitClient`)
 
 Date: 2026-04-19
-Status: Three-variant proposal awaiting user decision
-Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1 — pattern baseline)
+Status: Variant C selected — ready for implementation planning
+Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1)
 
-> **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. Per the roadmap variant-selection rule (§4.1), the default starting assumption for abapGit is **Variant C** (service-like, orchestration-heavy; multiple repos managed, polling lifecycle, not a single ADT object). Variants A and B remain on the table for completeness.
+> **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. abapGit — Variant C: users need the full lifecycle (link / pull / unlink) plus introspection (list, status, error log) and pre-link validation (check external repo). Variant A (core module) was rejected because abapGit has no ADT-artefact lifecycle (no activation / lock / source / canonical check). Variant B (minimal sapcli parity) was rejected because it would leave unlink, standalone status-read, error-log, and external-repo validation to a follow-up PR.
 
 ## 1. Goal
 
-Add a client that wraps the SAP-official **ADT-integrated abapGit** — not the community abapGit (which is a separately-installed ABAP program). The ADT-integrated variant lets a consumer bind an ABAP package to a remote git repository, pull branches, inspect status, and retrieve error logs, all via the ADT HTTP API.
+Add a client that wraps the SAP-official **ADT-integrated abapGit** — not the community abapGit (which is a separately-installed ABAP program). The ADT-integrated variant lets a consumer bind an ABAP package to a remote git repository, pull branches, inspect status, retrieve error logs, unlink when done, and probe a remote repository before committing to a link.
 
-## 2. Why three variants
+The class must cover every operation evidenced by either sapcli or our discovery corpus, expose them through a specialized `IAdtAbapGitClient` interface, and encapsulate the server-side async status polling (`R`/`E`/`A`/OK) so consumers see a synchronous API.
 
-The abapGit surface presents the usual architectural choice — full IAdtObject lifecycle vs narrow sapcli-parity vs extended separate client — plus a domain-specific wrinkle: `link` and `pull` are **asynchronous** on the server, with a status-poll cycle (`R` = running, `E` = error, `A` = abort, others = OK). How we model the wait matters.
+## 2. Scope
+
+**In scope:**
+
+- `link` — bind a package to a remote URL (matches sapcli `link`).
+- `pull` — trigger a pull and wait for terminal state, with optional progress heartbeat (matches sapcli `pull`).
+- `unlink` — remove an existing binding (beyond sapcli; discovery evidence needs live verification on the repo entity's edit/delete link).
+- `listRepos` — enumerate all linked repositories on the system.
+- `getRepo(packageName)` — fetch a single repo's current status without side effects.
+- `getErrorLog(packageName)` — fetch the error log as a first-class operation, not only as a side effect of a failed pull.
+- `checkExternalRepo` — probe a remote URL + credentials before the irreversible `link` (uses `/sap/bc/adt/abapgit/externalrepoinfo`).
+
+**Explicitly out of scope for v1 (may be added later):**
+
+- **Push.** The ADT abapGit service does not universally support push via this endpoint family; sapcli does not implement it. Excluded until a concrete workflow demands it.
+- **Branch management** (switch branch, list branches beyond `checkExternalRepo`'s branch list). The `branchName` is already carried on `link` and `pull`; dedicated branch ops wait for demand.
+- **Content-Type v4** (discovery's newest version). Default to v3 for sapcli compatibility; implementation exposes `options.contentTypeVersion` only if a consumer explicitly needs v4.
 
 ## 3. Verified evidence
 
 ### 3.1 sapcli reference (`sap/cli/abapgit.py`, `sap/adt/abapgit.py`)
 
-Two CLI commands, two repository operations:
+Implemented surface:
 
-- **`link <package> <url> [--branch] [--remote-user] [--remote-password] [--corrnr]`**
-  - `POST /sap/bc/adt/abapgit/repos`
+- **`link`** → `POST /sap/bc/adt/abapgit/repos`
   - Content-Type: `application/abapgit.adt.repo.v3+xml`
-  - Body: XML envelope `<abapgitrepo:repository xmlns:abapgitrepo="http://www.sap.com/adt/abapgit/repositories">` with children `package`, `url`, `branchName`, `remoteUser`, `remotePassword`, `transportRequest` (all text; null-valued entries omitted).
-  - Expected: HTTP 200.
-- **`pull <package> [--branch] [--remote-user] [--remote-password] [--corrnr]`**
-  - Fetch step: `GET /sap/bc/adt/abapgit/repos` with Accept `application/abapgit.adt.repos.v2+xml`. Parse XML, find repo whose child `<abapgitrepo:package>` equals the requested name. Extract atom links: `pull_link`, `log_link`.
-  - Pull trigger: `POST <pull_link>` with Content-Type `application/abapgit.adt.repo.v3+xml`, same body envelope as link.
-  - Expected: HTTP 202 (async accepted).
-  - Poll: re-fetch the repo list every 1s; repository status `R` means running; loop until state is different.
-  - Final states in sapcli code: `'E'` (error), `'A'` (abort), other (OK). On error/abort, fetch `log_link` and print log entries.
-- **Error log retrieval** (invoked inside `pull`):
+  - Body:
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <abapgitrepo:repository xmlns:abapgitrepo="http://www.sap.com/adt/abapgit/repositories">
+      <abapgitrepo:package>…</abapgitrepo:package>
+      <abapgitrepo:url>…</abapgitrepo:url>
+      <abapgitrepo:branchName>…</abapgitrepo:branchName>
+      <abapgitrepo:remoteUser>…</abapgitrepo:remoteUser>
+      <abapgitrepo:remotePassword>…</abapgitrepo:remotePassword>
+      <abapgitrepo:transportRequest>…</abapgitrepo:transportRequest>
+    </abapgitrepo:repository>
+    ```
+  - Null-valued entries are omitted (sapcli `repo_request_body` filters them).
+  - Expected HTTP 200.
+- **`pull`** — two-step async flow:
+  - Fetch: `GET /sap/bc/adt/abapgit/repos` with Accept `application/abapgit.adt.repos.v2+xml`. Parse, find repo where `<abapgitrepo:package>` matches. Extract atom links: `pull_link`, `log_link`.
+  - Trigger: `POST <pull_link>` with same Content-Type and XML envelope as link. Expect HTTP 202.
+  - Poll: every 1000ms re-fetch the list; repository status `R` = running; loop until status differs.
+  - Terminal states: `E` (error), `A` (abort), other = OK.
+- **Error log** (invoked inside sapcli's `pull` on non-OK terminal):
   - `GET <log_link>` with Accept `application/abapgit.adt.repo.object.v2+xml`
-  - XML: list of `<object:abapObject xmlns:object="http://www.sap.com/adt/abapgit/abapObjects">` with children `msgType`, `type`, `name`, `msgText`. sapcli filters out `msgType == 'S'` (success noise).
+  - Response XML: `<abapObjects:abapObject>` list with `msgType`, `type`, `name`, `msgText` children. sapcli filters out `msgType == 'S'`.
 
-Namespaces used by the XML envelopes:
-- `abapgitrepo = http://www.sap.com/adt/abapgit/repositories` — repo entity
-- `abapObjects = http://www.sap.com/adt/abapgit/abapObjects` — error log objects
+XML namespaces:
+
+- `abapgitrepo = http://www.sap.com/adt/abapgit/repositories`
+- `abapObjects = http://www.sap.com/adt/abapgit/abapObjects`
+
+Default branch when not provided by the caller (sapcli): `refs/heads/master`. sapcli's `pull` reuses the current binding's branch when `--branch` is omitted.
 
 ### 3.2 Discovery corpus
 
 Only in `docs/discovery/discovery_cloud_mdd_raw.xml` and `discovery_trial_raw.xml`:
 
-- `/sap/bc/adt/abapgit/repos` — collection (link + list)
-- `/sap/bc/adt/abapgit/externalrepoinfo` — probe endpoint (NOT used by sapcli)
-- Accept/Content-Type versions advertised: `abapgit.adt.repo.v1+xml`, `…v2+xml`, `…v3+xml`, `…v4+xml`; plus `abapgit.adt.repo.info.ext.request.v1+xml`, `…v2+xml` for `externalrepoinfo`.
+- `/sap/bc/adt/abapgit/repos` — collection (link + list).
+- `/sap/bc/adt/abapgit/externalrepoinfo` — probe endpoint (NOT wrapped by sapcli).
+- Accept/Content-Type versions advertised on `repos`: `abapgit.adt.repo.v1+xml` through `v4+xml`.
+- Accept/Content-Type versions advertised on `externalrepoinfo`: `abapgit.adt.repo.info.ext.request.v1+xml` and `v2+xml`.
 
-**Not in** `endpoints_onprem_modern_e19.txt` or `endpoints_onprem_old_e77.txt`. ADT-integrated abapGit ships with ABAP Platform / Steampunk — the E19 and E77 snapshots predate it or it was simply not activated on those systems. **Availability is cloud-only in our corpus.**
+**Not in** `endpoints_onprem_modern_e19.txt` or `endpoints_onprem_old_e77.txt`. ADT-integrated abapGit ships with ABAP Platform / Steampunk — the E19 and E77 snapshots predate it or it was simply not activated on those systems.
 
-Real-world: ADT abapGit ships with SAP BTP ABAP Environment (Steampunk) and modern on-prem from ABAP Platform 2022+. Our gating starts at `["cloud"]` and widens only after live on-prem verification on a qualifying system.
+**Real-world availability:** ADT abapGit ships with SAP BTP ABAP Environment (Steampunk) and modern on-prem from ABAP Platform 2022+. Gating starts `["cloud"]` and widens to `["cloud", "onprem"]` only after a live verification on a qualifying modern on-prem system.
 
-### 3.3 sapcli coverage gaps
+### 3.3 sapcli gaps Variant C fills
 
-sapcli implements only `link` and `pull` (+ the log retrieval inside `pull`). It does NOT cover:
+sapcli implements only `link` and `pull`. It does NOT cover:
 
-- **Unlink / delete** a repository binding (no `sap.adt.abapgit.Repository.unlink()`).
-- **Push** (the ADT abapGit service does not universally support push; depends on the remote repo permissions and server configuration).
-- **Branch management** (switch branch, list branches).
-- **External repo info probe** (`externalrepoinfo` — discovery-only, no sapcli wrapper).
+- **Unlink / delete** a repository binding.
+- **Push** (intentionally excluded from v1).
+- **Branch management** (intentionally excluded from v1; branch name is still carried in args).
+- **External repo info probe** (`externalrepoinfo` — discovery evidence only).
 - **Read-only status check** without triggering pull.
-- **Standalone log retrieval** (log is only printed as a side-effect of failed pulls in sapcli's CLI).
-- **Content-Type v4** (sapcli hard-codes v3; discovery shows v4 available on cloud).
+- **Standalone log retrieval** outside the pull flow.
 
-## 4. Variant A — core module under `src/core/abapGitRepo/`
+Variant C fills the first, fourth, fifth, and sixth via `unlink`, `checkExternalRepo`, `getRepo`, and `getErrorLog`. Push and branch management remain out of scope.
 
-**Shape.** Treat a repository-package binding as an `IAdtObject<IAbapGitRepoConfig, IAbapGitRepoState>` with canonical CRUD + lifecycle. The "object" identity is the ABAP package name — one package, one linked repo. `create` = link; `read` = fetch entity; `update` = re-link (change URL / branch); `delete` = unlink; `activate` = no-op; `readMetadata` = same as read; `check` = no-op.
+## 4. Public API shape
 
-**Why it could fit.**
-
-- Package-to-repo binding does have an identity (package name) and a lifecycle (create / read / update / delete).
-- Consumers discover `getAbapGitRepo()` next to other `getXxx()` factories and get a familiar shape.
-
-**Why it does NOT fit.**
-
-- **No canonical activation.** `/sap/bc/adt/activation` is meaningless for a repo binding — there is nothing to activate. The method becomes a stub.
-- **No lock/unlock.** abapGit has no `?_action=LOCK` contract in sapcli or discovery. Concurrent access control is handled server-side via the async status machine, not ADT locks. `lock()` / `unlock()` become stubs.
-- **No canonical check.** `/checkruns?reporters=abapCheckRun` does not apply to a repo binding. `check()` is a stub.
-- **`pull` is not any canonical IAdtObject operation.** It does not fit `create`, `read`, `update`, `delete`, or `activate`. Forcing it into `update` would be misleading — a pull doesn't rewrite the binding metadata, it fetches remote code and applies it.
-- **Async status polling is alien to the IAdtObject contract.** Every other core module operation is synchronous from the client's perspective. Adding polling to the base interface is a semantic stretch.
-
-**Verdict.** Variant A leaves roughly half of the IAdtObject interface as stubs and still needs a `pull()` domain method tacked on. Reject — it shares BSP's problem of forcing an unrelated surface into the CRUD template.
-
-## 5. Variant B — minimal separate client (sapcli parity)
-
-**Shape.** New file `src/clients/AdtAbapGitClient.ts`. Factory: `AdtClient.getAbapGit()` returns `IAdtAbapGitClient`. Exactly sapcli's two operations:
+### 4.1 Factory on `AdtClient`
 
 ```ts
-interface IAbapGitLinkArgs {
-  package: string;                 // ABAP package to bind
-  url: string;                     // remote git repo URL
-  branchName?: string;             // defaults to 'refs/heads/master' (sapcli parity)
-  remoteUser?: string;
-  remotePassword?: string;
-  transportRequest?: string;
-}
+getAbapGit(): IAdtAbapGitClient;
+```
 
-interface IAbapGitPullArgs {
-  package: string;                 // locate binding by package
-  branchName?: string;             // if absent, reuse the binding's current branch
-  remoteUser?: string;
-  remotePassword?: string;
-  transportRequest?: string;
-  pollIntervalMs?: number;         // default 1000 (sapcli parity)
-  onProgress?: (status: IAbapGitRepoStatus) => void;   // optional heartbeat callback
-}
+Returns an `AdtAbapGitClient` instance typed as the specialized public interface (per roadmap §4.2). No cast required at call sites.
 
-type AbapGitStatus = 'R' | 'E' | 'A' | string;   // 'R'=running, 'E'=error, 'A'=abort, other=OK
+### 4.2 Specialized public interface
 
-interface IAbapGitRepoStatus {
+```ts
+export type AbapGitStatus = 'R' | 'E' | 'A' | string;   // 'R'=running, 'E'=error, 'A'=abort, any other value = OK
+
+export interface IAbapGitRepoStatus {
   package: string;
   url: string;
   branchName: string;
   status: AbapGitStatus;
   statusText: string;
+  createdBy?: string;
+  createdAt?: string;
+  // Repository ID exposed by the entity (used internally for unlink; surfaced here
+  // because some consumers may want to correlate across calls).
+  repositoryId?: string;
 }
 
-interface IAbapGitPullResult {
-  finalStatus: IAbapGitRepoStatus;
-  errorLog?: IAbapGitErrorLogEntry[];   // populated only on 'E' or 'A' (sapcli parity)
-}
-
-interface IAbapGitErrorLogEntry {
-  msgType: string;   // 'E'|'W'|'I'|'S' — 'S' entries are filtered out
+export interface IAbapGitErrorLogEntry {
+  msgType: 'E' | 'W' | 'I' | 'S' | string;
   objectType: string;
   objectName: string;
   messageText: string;
 }
 
-interface IAdtAbapGitClient {
+export interface IAbapGitLinkArgs {
+  package: string;
+  url: string;
+  branchName?: string;      // default 'refs/heads/master'
+  remoteUser?: string;
+  remotePassword?: string;
+  transportRequest?: string;
+}
+
+export interface IAbapGitPullArgs {
+  package: string;
+  branchName?: string;      // if omitted, the binding's current branch is reused
+  remoteUser?: string;
+  remotePassword?: string;
+  transportRequest?: string;
+  pollIntervalMs?: number;  // default 1000
+  maxPollDurationMs?: number; // default 600_000 (10 min); throws on timeout
+  signal?: AbortSignal;     // optional external cancellation
+  onProgress?: (status: IAbapGitRepoStatus) => void;
+}
+
+export interface IAbapGitUnlinkArgs {
+  package: string;
+  transportRequest?: string;
+}
+
+export interface IAbapGitPullResult {
+  finalStatus: IAbapGitRepoStatus;
+  errorLog?: IAbapGitErrorLogEntry[];   // populated only on 'E' or 'A'
+}
+
+export interface IAbapGitExternalRepoCredentials {
+  url: string;
+  remoteUser?: string;
+  remotePassword?: string;
+}
+
+export interface IAbapGitExternalRepoBranch {
+  name: string;
+  sha1: string;
+  isHead: boolean;
+  type?: string;
+}
+
+export interface IAbapGitExternalRepoInfo {
+  branches: IAbapGitExternalRepoBranch[];
+  access?: 'read' | 'write' | string;
+  // Additional fields filled from the live response during implementation.
+}
+
+export interface IAdtAbapGitClient {
   link(args: IAbapGitLinkArgs): Promise<void>;
   pull(args: IAbapGitPullArgs): Promise<IAbapGitPullResult>;
+  unlink(args: IAbapGitUnlinkArgs): Promise<void>;
+  listRepos(): Promise<IAbapGitRepoStatus[]>;
+  getRepo(packageName: string): Promise<IAbapGitRepoStatus | undefined>;
+  getErrorLog(packageName: string): Promise<IAbapGitErrorLogEntry[]>;
+  checkExternalRepo(args: IAbapGitExternalRepoCredentials): Promise<IAbapGitExternalRepoInfo>;
 }
 ```
 
-Internally the `pull` method encapsulates: locate → POST pull → poll every `pollIntervalMs` → fetch error log on terminal non-OK → return.
-
-**Pros.**
-
-- **Exact sapcli parity.** Everything proven in sapcli is covered, nothing more. YAGNI-clean.
-- Smallest code surface; fastest to ship; smallest review footprint.
-- Polling abstraction lives inside `pull` as an internal detail — consumers don't have to think about it unless they want `onProgress` heartbeats.
-
-**Cons.**
-
-- **No unlink.** If a consumer needs to remove a repo binding, they have to drop to raw HTTP or wait for v2.
-- **No status-only check.** Every status probe triggers a full pull attempt — expensive and side-effectful.
-- **No external repo info probe** — `externalrepoinfo` endpoint unused.
-- **No way to enumerate linked repos** on a system — `listRepos` is a natural API that sapcli exposes only internally.
-
-**Verdict.** Right if "port exactly what sapcli ships" is the priority and follow-up extensions are acceptable.
-
-## 6. Variant C — extended separate client (recommended)
-
-**Shape.** Same file and factory as B, but the surface is broader:
+### 4.3 Options shape
 
 ```ts
-interface IAdtAbapGitClient {
-  // Core (sapcli parity)
-  link(args: IAbapGitLinkArgs): Promise<void>;
-  pull(args: IAbapGitPullArgs): Promise<IAbapGitPullResult>;
-
-  // Introspection (no sapcli wrapper, but all evidence-backed)
-  listRepos(): Promise<IAbapGitRepoStatus[]>;                          // GET /repos
-  getRepo(packageName: string): Promise<IAbapGitRepoStatus | undefined>;
-  getErrorLog(packageName: string): Promise<IAbapGitErrorLogEntry[]>;  // uses the repo's log_link
-
-  // Lifecycle (beyond sapcli)
-  unlink(args: { package: string; transportRequest?: string }): Promise<void>;
-
-  // External-repo probe (discovery-verified but unused in sapcli)
-  checkExternalRepo(args: {
-    url: string;
-    remoteUser?: string;
-    remotePassword?: string;
-  }): Promise<IAbapGitExternalRepoInfo>;
-}
-
-interface IAbapGitExternalRepoInfo {
-  branches: Array<{ name: string; sha1: string; isHead: boolean; type?: string }>;
-  access?: 'read' | 'write' | string;
-  // Concrete shape derived during implementation from a live probe of the endpoint.
+export interface IAdtAbapGitClientOptions {
+  contentTypeVersion?: 'v3' | 'v4';  // default 'v3' for sapcli compatibility
 }
 ```
 
-`unlink` likely maps to `DELETE /sap/bc/adt/abapgit/repos/{id}` (the ID is the resource identifier returned on link) — the exact URI template has to be confirmed during implementation via a live call or a deeper parse of the existing `repos` entity's atom links (`delete_link` or `edit_link`). If the endpoint is missing on the target system, the method throws `NotSupportedError`.
+Per the roadmap's options-contract note (§4.1), this is an independent per-class contract, not an attempt to standardise across all separate clients.
 
-`checkExternalRepo` hits `POST /sap/bc/adt/abapgit/externalrepoinfo` with Content-Type `application/abapgit.adt.repo.info.ext.request.v2+xml` (discovery advertises v1 and v2). Used to probe a remote URL for branch list and credentials validity before committing a link.
+## 5. Module layout
 
-**Pros.**
+```
+src/clients/
+  AdtAbapGitClient.ts            # handler — implements IAdtAbapGitClient
+  abapGit/
+    types.ts                     # public and internal types
+    xmlBuilder.ts                # builds <abapgitrepo:repository> envelope
+    xmlParser.ts                 # parses repo list, error log, externalrepoinfo
+    link.ts                      # POST /repos (link a package)
+    pull.ts                      # POST <pull_link> + poll logic
+    unlink.ts                    # DELETE <edit_link> (URI from live response)
+    listRepos.ts                 # GET /repos
+    getErrorLog.ts               # GET <log_link>
+    checkExternalRepo.ts         # POST /externalrepoinfo
+    poll.ts                      # internal polling helper with AbortSignal support
+```
 
-- Covers every useful operation that discovery evidences or sapcli needs.
-- `checkExternalRepo` is genuinely valuable: lets a caller validate a URL + credentials before the irreversible `link` step.
-- `listRepos` and `getRepo(name)` expose read-only status checking without triggering side-effects (fixing one of Variant B's real gaps).
-- `unlink` closes the lifecycle so consumers don't need to drop to raw HTTP for cleanup.
+Nine files under `src/clients/abapGit/` + the handler. Corresponds to a single-file-per-operation convention used by the core modules and keeps each file focused.
 
-**Cons.**
+## 6. Operation semantics
 
-- **Three endpoints beyond sapcli** require live verification of request/response shape. Specifically: `unlink` URI template, `externalrepoinfo` response schema, and whether `listRepos` / `getRepo` should use Accept v2 (sapcli) or v4 (discovery's newest).
-- More surface = more tests, more docs, more maintenance.
-- Medium risk: if `unlink` turns out to be server-gated by transport-authorization in a way that doesn't fit a simple DELETE, the API has to grow or the method has to return an error.
+### 6.1 `link`
 
-**Verdict.** Recommended. Fits the roadmap's Variant C default, closes sapcli's gaps in a principled way, and introduces only evidence-backed new methods.
+1. Build XML body (`buildLinkBody(args)`) with all non-null fields.
+2. `POST /sap/bc/adt/abapgit/repos` with Content-Type `application/abapgit.adt.repo.v${n}+xml` where `n = options.contentTypeVersion ?? 3`.
+3. On 200 → resolve. Non-2xx → throw.
 
-## 7. Non-decisions (fixed constraints shared across all variants)
+### 6.2 `pull`
 
-Regardless of A/B/C:
+1. `listRepos()` to locate the binding by package; extract `pull_link` from atom links. If missing → throw `NotFoundError`.
+2. Resolve `branchName`: caller-supplied or the binding's current `branchName`.
+3. `POST <pull_link>` with the XML envelope. Expect HTTP 202.
+4. **Poll loop** (`poll.ts`):
+   - Every `pollIntervalMs` (default 1000): `listRepos()` → find by package → inspect `status`.
+   - While status is `R`: continue. Invoke `onProgress(status)` if provided.
+   - Respect `signal`: throw `AbortError` if aborted.
+   - Respect `maxPollDurationMs` (default 600000): throw `TimeoutError` if exceeded.
+   - On non-`R` status: break loop. Return status.
+5. Terminal state handling:
+   - `E` or `A` → also fetch error log via `getErrorLog(package)`; attach to result.
+   - Anything else → treat as OK; no error log fetched.
+
+### 6.3 `unlink`
+
+Depends on the server-side URI template for removal. Two likely options, resolved during implementation:
+
+1. **Preferred:** extract the `edit_link` (or `delete_link`) from the repo entity's atom links in `listRepos`, then `DELETE <edit_link>`. Transport request carried as a query param `?corrNr=…` if provided.
+2. **Fallback:** if the entity does not expose a delete link, derive the URI as `/sap/bc/adt/abapgit/repos/{repositoryId}` and issue `DELETE`.
+
+Implementation chooses whichever the live server actually accepts. Fail fast with a clear error if neither works.
+
+### 6.4 `listRepos`
+
+`GET /sap/bc/adt/abapgit/repos` with Accept `application/abapgit.adt.repos.v2+xml`. Parse into `IAbapGitRepoStatus[]`.
+
+### 6.5 `getRepo(packageName)`
+
+Calls `listRepos()` internally and filters. Returns `undefined` if absent (no throw on 404-equivalent).
+
+### 6.6 `getErrorLog(packageName)`
+
+1. `listRepos()` to locate the binding and extract `log_link`.
+2. `GET <log_link>` with Accept `application/abapgit.adt.repo.object.v2+xml`.
+3. Parse entries; do **not** filter out `msgType == 'S'` here. That's sapcli's CLI formatting choice; library-level consumers decide for themselves.
+
+### 6.7 `checkExternalRepo`
+
+`POST /sap/bc/adt/abapgit/externalrepoinfo` with:
+- Content-Type: `application/abapgit.adt.repo.info.ext.request.v2+xml` (prefer v2 over v1).
+- Accept: same.
+- Body: XML envelope with `url`, `remoteUser`, `remotePassword`. Namespace and element names confirmed against a live response during implementation.
+
+Parse into `IAbapGitExternalRepoInfo`. Final response-shape confirmed at live-probe time; if the shape differs from the proposal, the spec and interface are adjusted in the implementation plan.
+
+## 7. Non-decisions (fixed constraints)
 
 - **Transport layer.** Only `IAbapConnection`. No direct axios.
-- **XML parsing.** `fast-xml-parser` as elsewhere. abapGit namespaces: `abapgitrepo` and `abapObjects`.
-- **Namespace handling.** The repo envelope uses atom links (`<atom:link rel="pull_link" href="…"/>`); the client must extract these links dynamically rather than hard-coding the pull URL. This matches sapcli's `_get_link` helper.
-- **Content-Type version.** Default to `v3` (sapcli-compatible) with a config override for `v4` if a consumer needs the newer schema. Runtime transparent fallback NOT planned for v1; fallback is opt-in.
-- **Async polling.** Default interval 1000ms (sapcli parity), configurable via `pollIntervalMs`. Maximum poll duration bounded by `AbortSignal` or a default cap (e.g. 10 minutes) — TBD in implementation plan but documented as bounded.
-- **Environment gating.** `available_in: ["cloud"]` initially. Widen to on-prem after a live verification on a system with ABAP Platform 2022+ that activates the ADT abapGit app.
-- **Transport binding.** `transportRequest` optional on `link` and `pull` (sapcli treats it as optional); required only if the target system enforces transport binding on package changes.
-- **Credentials.** `remoteUser` / `remotePassword` are forwarded verbatim in the XML body. Never logged. The server handles credential storage; client does not cache them.
+- **XML parsing.** `fast-xml-parser`; namespaces `abapgitrepo` and `abapObjects`.
+- **Credentials.** `remoteUser` / `remotePassword` forwarded verbatim in XML body; never logged.
+- **Atom links.** All sub-operations (`pull`, `unlink`, `getErrorLog`) extract their URLs from atom links on the repo entity rather than hard-coding paths. Matches sapcli's `_get_link` approach.
+- **Content-Type version.** Default `v3` (sapcli compat). v4 is opt-in via `options.contentTypeVersion`.
+- **Async polling.** Default 1000ms interval, 10-minute max duration. Abortable via `AbortSignal`.
+- **Environment gating.** `available_in: ["cloud"]` initially. Implementation plan probes a modern on-prem target if one is available; otherwise widens on first positive report.
+- **Error semantics.** `NotFoundError` on missing repo; `AbortError` on aborted poll; `TimeoutError` on exceeded max-duration; all others propagate as thrown `Error` with status details.
 - **Public typing rule.** Factory returns `IAdtAbapGitClient`, not a narrower base type. Specialized interface per roadmap §4.2.
-- **Client placement.** `src/clients/AdtAbapGitClient.ts`. Low-level helpers under `src/clients/abapGit/*`.
+- **Client placement.** `src/clients/AdtAbapGitClient.ts` (handler) and `src/clients/abapGit/` (helpers).
 - **Documentation.** README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, CHANGELOG, ADT_OBJECT_ENTITIES updates follow the #21 / #28 pattern.
 
-## 8. Comparison summary
+## 8. Open questions for the implementation plan
 
-| Aspect | A (core module) | B (minimal client) | C (extended client) |
-|---|---|---|---|
-| Architectural fit | Forced; ~50% of IAdtObject methods are stubs | Clean separate client | Clean separate client |
-| Scope | link + pull + CRUD stubs | link + pull (sapcli parity) | + unlink + listRepos + getRepo + getErrorLog + checkExternalRepo |
-| sapcli parity | Partial | Exact | Exact + extras |
-| Async polling | Awkward in IAdtObject | Encapsulated in `pull` | Encapsulated in `pull` |
-| Cloud support | Yes | Yes | Yes |
-| On-prem support | Unverified (ADT abapGit is Steampunk-era) | Unverified | Unverified |
-| Legacy (E77) support | No endpoint | No endpoint | No endpoint |
-| Code surface | Medium | Small | Medium |
-| Risk | Architectural misfit | Low — fully sapcli-documented | Medium — 3 endpoints need live verification |
-| Matches roadmap default | No | Acceptable narrow-fallback | **Yes** |
+These do not block variant selection but must be resolved during implementation:
 
-## 9. What is NOT decided here
+- **Unlink URI template.** Atom `edit_link` vs `/repos/{id}` — live probe during first implementation pass.
+- **`externalrepoinfo` response shape.** Confirmed against a live trace; the `IAbapGitExternalRepoInfo` type may gain or lose fields.
+- **`repositoryId`** on `IAbapGitRepoStatus` — where in the response XML it lives, whether it's surfaced on every version of the Accept type.
+- **`v3` vs `v4` Content-Type behaviour.** If `v3` response shape differs from `v4`, decide whether `listRepos()` parsing branches or whether we mandate a single version.
+- **On-prem availability.** Test on a modern on-prem system from `ABAP Platform 2022+` to confirm endpoints activate and to widen `available_in`.
 
-- Exact `unlink` URI template — probably `DELETE` on the repo entity's `edit_link` or `delete_link`; must confirm during implementation.
-- Exact `externalrepoinfo` response schema — only the Accept type is known from discovery; content-shape derived during a live probe.
-- Whether to default Content-Type to `v3` (sapcli) or `v4` (newest in discovery). Recommendation: `v3` for compatibility; expose `options.contentTypeVersion` for opt-in newer.
-- Whether `pull`'s `AbortSignal` / max-duration cap lives in args or in client options.
-- Final method names (bikeshed in implementation plan): `link` vs `linkRepo`, `pull` vs `pullRepo`, `listRepos` vs `getRepos`, `checkExternalRepo` vs `probeRemote`.
+## 9. Verification sources
 
-## 10. Decision criteria
+This design was adjusted after cross-checking against:
 
-Pick **A** if:
-- You want uniformity with `src/core/` and accept stub methods for half the interface.
-- (Recommendation: don't pick A. abapGit doesn't match the pattern.)
+- `~/prj/sapcli` — `sap/cli/abapgit.py`, `sap/adt/abapgit.py`.
+- `docs/discovery/discovery_{cloud_mdd,trial,e19,e77}_raw.xml` + `docs/discovery/endpoints_*.txt`.
+- Proposal rules: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` §4.1 (variant selection), §4.2 (public typing).
 
-Pick **B** if:
-- "Ship narrow sapcli parity fast" is the priority.
-- You accept that `unlink`, `listRepos`, `getErrorLog` outside of pull, and `externalrepoinfo` will need a v2 PR later.
+Not every claim is discovery-backed to the same degree. Specifically:
+- `unlink`, `checkExternalRepo` response shape, and `repositoryId` location require **live probing** during implementation.
+- On-prem availability is a real-world-known fact (ABAP Platform 2022+) that the captured discovery snapshots don't reflect.
 
-Pick **C** if:
-- You want one authoritative abapGit client covering everything discovery evidences.
-- Pre-link validation (`checkExternalRepo`) and side-effect-free status queries matter for your workflow.
-- You're budgeted for live verification of three endpoints during implementation.
+## 10. Next step
 
-## 11. Next step
-
-User picks A, B, or C. After selection:
-
-1. Update this document to carry only the chosen variant.
-2. Proceed to `writing-plans` skill for the implementation plan.
+Invoke `writing-plans` to produce `docs/superpowers/plans/2026-04-19-abapgit-client.md` with task-by-task TDD-oriented implementation.

--- a/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
@@ -1,10 +1,10 @@
-# Design: BSP Application Client (three variants — DEFERRED)
+# Design: BSP Application Client (three variants — PENDING INVESTIGATION)
 
 Date: 2026-04-19
-Status: **Deferred.** Spec kept for future reference; BSP client is not scheduled for near-term implementation.
+Status: **Pending investigation.** Part of the UI-tier investigation group alongside FLP (§3.4–3.5 of the roadmap proposal). Not shipped to production until a concrete consumer workflow justifies the class. Spec kept as a paper design so work can resume when the need surfaces.
 Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md`
 
-> **Deferral rationale.** BSP client covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline; the archive must be pre-built by external tooling (ui5 CLI, webpack, vite). Other roadmap candidates — especially abapGit — have broader everyday use-cases and higher priority. This spec is preserved so that when BSP work does start, the variant analysis is already available.
+> **Why on hold.** BSP client covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline; the archive must be pre-built by external tooling (ui5 CLI, webpack, vite). A meaningful BSP story needs an accompanying build-integration design — out of scope for this library until a real user workflow demands it. Other roadmap candidates — especially abapGit — have broader everyday use-cases and higher priority.
 
 > **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. Per the roadmap's variant-selection rule (§4.1), the default starting assumption for BSP is **Variant C** (service-like, orchestration-heavy). Variants A and B remain on the table for completeness and to make the architectural argument explicit.
 

--- a/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
@@ -1,8 +1,10 @@
-# Design: BSP Application Client (three variants for review)
+# Design: BSP Application Client (three variants — DEFERRED)
 
 Date: 2026-04-19
-Status: Three-variant proposal awaiting user decision
-Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1 of four remaining separate clients — pattern baseline slot)
+Status: **Deferred.** Spec kept for future reference; BSP client is not scheduled for near-term implementation.
+Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md`
+
+> **Deferral rationale.** BSP client covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline; the archive must be pre-built by external tooling (ui5 CLI, webpack, vite). Other roadmap candidates — especially abapGit — have broader everyday use-cases and higher priority. This spec is preserved so that when BSP work does start, the variant analysis is already available.
 
 > **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. Per the roadmap's variant-selection rule (§4.1), the default starting assumption for BSP is **Variant C** (service-like, orchestration-heavy). Variants A and B remain on the table for completeness and to make the architectural argument explicit.
 

--- a/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
@@ -1,0 +1,244 @@
+# Design: BSP Application Client (three variants for review)
+
+Date: 2026-04-19
+Status: Three-variant proposal awaiting user decision
+Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1 of four remaining separate clients — pattern baseline slot)
+
+> **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. Per the roadmap's variant-selection rule (§4.1), the default starting assumption for BSP is **Variant C** (service-like, orchestration-heavy). Variants A and B remain on the table for completeness and to make the architectural argument explicit.
+
+## 1. Goal
+
+Add a client for uploading, inspecting, and deleting BSP/UI5 applications in the ABAP repository. This covers the workflow a developer needs when shipping a Fiori/UI5 front-end artifact to an ABAP system: package a zip archive and push it to a BSP namespace, inspect what is there, and remove the application when done.
+
+## 2. Why three variants
+
+The BSP surface presents two orthogonal design choices that compound into three meaningful architectural variants:
+
+1. **Architectural shape.** A real ADT repository object (IAdtObject) vs a focused separate client.
+2. **Transport family.** OData v2 via `UI5/ABAP_REPOSITORY_SRV` (what sapcli uses) vs ADT filestore at `/sap/bc/adt/filestore/ui5-bsp/*` (what Eclipse ADT uses and our own discovery verified on every target including legacy E77).
+
+Variant A explores whether BSP fits IAdtObject. Variant B is a narrow sapcli-parity wrapper over OData v2. Variant C is the extended separate client that covers both worlds.
+
+## 3. Verified evidence
+
+### 3.1 sapcli reference (`sap/cli/bsp.py`)
+
+Dependencies and style:
+
+- Uses `pyodata` OData v2 client — not raw HTTP.
+- Entity set: `Repositories` (inferred — sapcli does not print the service URL, but pyodata clients are typically bound at construction to `UI5/ABAP_REPOSITORY_SRV`).
+
+Commands:
+
+- **`upload --bsp --package --app --corrnr`**
+  - Read zip archive from the local filesystem; base64-encode.
+  - Probe `Repositories.get_entity(Name=bsp)`. If 404 → `create_entity()`; otherwise `update_entity(Name=bsp)`.
+  - POST body payload: `{ Name, Package, ZipArchive }` (ZipArchive = base64 of the zip bytes).
+  - Custom OData query params (via pyodata `.custom(...)`): `CodePage=UTF8`, `TransportRequest=<corrnr>`, `client=<sap-client>`.
+  - Target system prerequisite (from sapcli docstring): `trnspace` editflag for `/0CUST/` and `/0SAP/` namespaces, plus disabling of `GATEWAY_VIRUSCAN_PROFILE`.
+- **`stat --bsp`** → `Repositories.get_entity(Name=bsp).execute()`. Prints `Name`, `Package`, `Description`. Returns exit code `NOT_FOUND` on 404.
+- **`delete --bsp --corrnr`** → `Repositories.delete_entity(Name=bsp).custom('TransportRequest', corrnr).execute()`. 404 silently tolerated.
+
+### 3.2 Discovery corpus (ADT filestore)
+
+From `docs/discovery/discovery_{cloud_mdd,e19,e77,trial}_raw.xml`:
+
+- `/sap/bc/adt/filestore/ui5-bsp` (collection) — present on **all four** targets (cloud MDD, modern on-prem E19, legacy E77, trial).
+- `/sap/bc/adt/filestore/ui5-bsp/objects` — sub-resource, all four targets.
+- `/sap/bc/adt/filestore/ui5-bsp/deploy-storage` — all four targets.
+- `/sap/bc/adt/filestore/ui5-bsp/ui5-rt-version` — all four targets.
+
+Crucially, this is **the only sapcli-referenced capability that discovery verifies on E77 (legacy)**. The OData v2 path sapcli uses has no legacy-friendly guarantee in our corpus; ADT filestore is the only transport proven to work everywhere.
+
+The exact semantics of the three ADT filestore sub-resources (which one accepts a zip, which returns a listing, which reports the UI5 runtime version, how transport is bound) are **not** spelled out in the discovery XML. Live probing is required before a final content-shape commitment.
+
+### 3.3 Repository pattern notes
+
+- sapcli's upload logic (`create` or `update` depending on whether the entity already exists) is a client-side upsert — the OData service does not expose a single "upsert" operation, so sapcli does the read-before-write itself.
+- Transport binding is always by corrnr passed as a custom query param, never via the XML/JSON payload.
+
+## 4. Variant A — core module under `src/core/bspApp/`
+
+**Shape.** Treat a BSP application as an `IAdtObject<IBspAppConfig, IBspAppState>` with canonical CRUD + lifecycle. Factory: `AdtClient.getBspApp()`.
+
+**Why it could fit.** A BSP application does have an identity (BSP name), a package, and lifecycle that approximates create / update / delete.
+
+**Why it does NOT fit.**
+
+- No lock/unlock semantics — neither sapcli nor discovery surface an `?_action=LOCK` contract for BSP.
+- No activation chain — BSP upload is immediate; there is no separate "activation" step after the data is pushed.
+- The source payload is a **binary zip archive**, not XML metadata plus ABAP text. The `IAdtObject` template expects either pure XML (DDIC-style) or XML metadata + `text/plain` source; neither matches.
+- The canonical `IAdtObject.check()` endpoint (`/checkruns?reporters=abapCheckRun`) is not meaningful for a BSP repository — there is no ABAP syntax to check.
+- The canonical `read` returns structured metadata; BSP's read returns a package reference and description, with the zip archive itself typically not returned.
+
+**Verdict.** Variant A is architecturally misaligned. Forcing BSP into `IAdtObject` would leave a handler where roughly half the interface methods are stubs. Reject this variant.
+
+## 5. Variant B — minimal separate client (sapcli parity, OData v2)
+
+**Shape.** New file `src/clients/AdtBspAppClient.ts`. Factory: `AdtClient.getBspApp()` returns the specialized `IAdtBspAppClient`. Transport: OData v2 over `UI5/ABAP_REPOSITORY_SRV` (hand-rolled minimal OData v2 — no `pyodata`-style dependency added).
+
+**Public surface** (sapcli parity exactly):
+
+```ts
+interface IBspAppClientStat {
+  name: string;
+  package: string;
+  description?: string;
+}
+
+interface IAdtBspAppClient {
+  upload(args: {
+    name: string;
+    package: string;
+    zipArchive: Buffer | Uint8Array | string;    // string = already base64
+    transportRequest: string;
+    codePage?: 'UTF8' | string;                   // defaults to UTF8
+  }): Promise<void>;
+
+  stat(name: string): Promise<IBspAppClientStat | undefined>;   // undefined on 404
+
+  delete(args: { name: string; transportRequest: string }): Promise<void>;
+}
+```
+
+**Pros.**
+
+- Smallest honest surface — only what sapcli ships, proven useful in practice.
+- OData v2 contract is fully specified by sapcli; no live-probing risk on day one.
+- Roadmap-aligned: Variant B is the narrow-subset default and matches the pattern-baseline slot well.
+
+**Cons.**
+
+- OData v2 path is **not verified on legacy E77** in our discovery. Sapcli works against it in practice, but a fresh port would need live verification before declaring E77 support.
+- Requires at least a minimal OData v2 helper (URL building, metadata fetching for EntitySets, `.custom(...)` query-param emulation). No existing library utility covers this; we'd hand-roll a tiny slice (no metadata introspection, fixed service URL, fixed EntitySet).
+- Leaves the ADT-native filestore path unused even though discovery proves it exists everywhere — future-v2 work if we ever want Eclipse-ADT-parity.
+- sapcli-targetted prerequisites (`trnspace editflag`, `GATEWAY_VIRUSCAN_PROFILE`) are server-side configuration the library cannot enforce. Must be documented, not implemented.
+
+**Verdict.** Right if the goal is exact sapcli parity with smallest code surface. Postpones the question of which transport is long-term correct.
+
+## 6. Variant C — extended separate client (recommended)
+
+**Shape.** New file `src/clients/AdtBspAppClient.ts`. Factory: `AdtClient.getBspApp()` returns `IAdtBspAppClient`. Transport chosen at **runtime via `AdtBspAppClientOptions.transport`**:
+
+```ts
+type BspAppTransport = 'adt-filestore' | 'odata-v2';
+
+interface IAdtBspAppClientOptions {
+  transport?: BspAppTransport;   // default 'adt-filestore' where available; falls back to 'odata-v2'
+}
+```
+
+The `'adt-filestore'` mode talks to `/sap/bc/adt/filestore/ui5-bsp/*` (discovery-verified on all four environments including legacy). The `'odata-v2'` mode preserves the sapcli-compatible path for systems that only expose `UI5/ABAP_REPOSITORY_SRV`. The library tries the ADT path first unless the caller pins a specific mode.
+
+**Public surface** (sapcli parity plus ADT-native extras):
+
+```ts
+interface IBspAppClientStat {
+  name: string;
+  package: string;
+  description?: string;
+  ui5RuntimeVersion?: string;   // from /filestore/ui5-bsp/ui5-rt-version (ADT mode only)
+  // Additional fields populated when the chosen transport returns them; callers
+  // must tolerate missing fields in either mode.
+}
+
+interface IBspAppClientObject {
+  name: string;
+  contentType?: string;
+  path?: string;
+}
+
+interface IAdtBspAppClient {
+  // Core (both modes)
+  upload(args: {
+    name: string;
+    package: string;
+    zipArchive: Buffer | Uint8Array | string;
+    transportRequest: string;
+    codePage?: 'UTF8' | string;
+  }): Promise<void>;
+
+  stat(name: string): Promise<IBspAppClientStat | undefined>;
+
+  delete(args: { name: string; transportRequest: string }): Promise<void>;
+
+  // ADT filestore extras (throw NotSupportedError in odata-v2 mode)
+  listObjects(name: string): Promise<IBspAppClientObject[]>;    // /filestore/ui5-bsp/objects?bsp=...
+  getUi5RuntimeVersion(): Promise<string>;                       // /filestore/ui5-bsp/ui5-rt-version
+}
+```
+
+**Pros.**
+
+- Covers every useful operation that either transport exposes — no successor v2 work needed for the common cases.
+- Proven-everywhere transport (ADT filestore) is the primary path; sapcli-compatible path stays available as fallback.
+- Single import, single mental model for consumers; transport choice is a runtime option, not a compile-time fork.
+- ADT filestore reuses the existing `IAbapConnection` HTTP session; no new OData-v2 helper needed for the primary path. A small OData-v2 helper is implemented only for the fallback, with reduced scope (just the three operations, no metadata introspection).
+
+**Cons.**
+
+- Both transports must be maintained — double the surface area.
+- ADT filestore semantics for upload (which sub-resource accepts the zip, what payload wrapper, how transport binds) are **not** fully known from our discovery corpus. Live verification is mandatory during implementation; if ADT filestore turns out to only support listing and read-only inspection, the upload path falls back to OData v2 anyway.
+- `listObjects` and `getUi5RuntimeVersion` have no sapcli precedent — their request/response shapes must be reverse-engineered from live traces.
+
+**Verdict.** Recommended. Fits the roadmap's default "Variant C" position for separate clients. Keeps sapcli parity intact while gaining legacy-friendly transport and ADT-native extras.
+
+## 7. Non-decisions (fixed constraints shared across all variants)
+
+Regardless of A/B/C:
+
+- **Transport layer.** Only `IAbapConnection`. No RFC.
+- **OData v2 helper, if needed.** Hand-rolled inside the module (`src/clients/bspApp/odataV2.ts`). Minimal: URL building with `$filter` / `$format`, entity upsert, entity delete, custom query param append. No schema introspection, no general-purpose client.
+- **Zip handling.** Accept `Buffer | Uint8Array | string`. When `string`, assume the caller already base64-encoded. Never read from disk — file I/O is the caller's responsibility.
+- **Transport-request binding.** `upload` and `delete` require `transportRequest`; `stat` / `listObjects` / `getUi5RuntimeVersion` do not.
+- **Environment gating.** Default `available_in: ["onprem", "cloud"]`. `legacy` remains in the provisional list IF the chosen transport works there; ADT filestore is verified on E77 by discovery, so Variant C can start with `["onprem", "cloud", "legacy"]` from day one. OData-v2 mode: legacy support depends on live verification.
+- **Error handling.** 404 on `stat` and `delete` returns `undefined` / no-op (sapcli behaviour). Other errors propagate as thrown `Error`.
+- **Public typing rule.** Factory returns `IAdtBspAppClient`, not a narrower base type. Specialized interface per roadmap §4.2.
+- **Client placement.** `src/clients/AdtBspAppClient.ts`. Low-level helpers under `src/clients/bspApp/*`.
+- **Documentation.** README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY updates follow the #21 / #28 pattern.
+
+## 8. Comparison summary
+
+| Aspect | A (core module) | B (minimal client) | C (extended client) |
+|---|---|---|---|
+| Architectural fit | Forced; ~half the IAdtObject methods are stubs | Clean separate client | Clean separate client |
+| Transport(s) | n/a | OData v2 only | ADT filestore primary + OData v2 fallback |
+| sapcli parity | Partial (CRUD maps, lifecycle stubs) | Exact | Exact + extras |
+| Legacy (E77) support | Not applicable — rejected | Depends on live probe | **Verified** by discovery (ADT filestore) |
+| Code surface | Medium (core module + content-types + tests) | Small | Medium |
+| Risk | Architectural — rejected | Low — contract fully sapcli-documented | Medium — ADT filestore semantics need live probe |
+| Matches roadmap default | No (roadmap defaults to C) | Acceptable narrow-fallback | **Yes** |
+| Analytics / extras | None | None | `listObjects`, `getUi5RuntimeVersion` |
+
+## 9. What is NOT decided here
+
+- Exact ADT filestore upload semantics (which sub-resource, what payload wrapper, response shape). Must be resolved during Variant C implementation via live probing — if it turns out to be unusable for upload, Variant C downgrades to Variant B's OData-v2-only path with a transport option retained for future upgrade.
+- Whether `listObjects` takes the BSP name as a query param or as a URL segment — discovery shows `/filestore/ui5-bsp/objects` as a collection but not the per-BSP binding.
+- Whether `getUi5RuntimeVersion` is system-global or per-BSP — likely global, but confirm via live trace.
+- Exact public method names (we may bikeshed `upload` vs `deploy`, `stat` vs `get`, `listObjects` vs `contents`). Final names in the implementation plan.
+- Cross-cutting options shape (per roadmap §4.1 note — `AdtClient` and `AdtRuntimeClient` differ). Variant C picks `IAdtBspAppClientOptions` as a fresh per-class contract; broader standardisation waits for more data points.
+
+## 10. Decision criteria
+
+Pick **A** if:
+- You want uniformity with the rest of `src/core/` and accept that half the IAdtObject surface will be stubs.
+- (Recommendation: don't pick A. BSP doesn't match the pattern.)
+
+Pick **B** if:
+- "Ship narrow sapcli parity fast" is the priority.
+- You accept that legacy-E77 support is unverified until someone runs the suite there.
+- You're comfortable reopening the design later if the ADT filestore path becomes interesting.
+
+Pick **C** if:
+- You want one authoritative BSP client that covers both transports.
+- ADT-filestore-verified legacy support matters (E77 coverage out of the box).
+- You're budgeted for live probing of ADT filestore during implementation.
+
+## 11. Next step
+
+User picks A, B, or C (or a hybrid). After selection:
+
+1. Update this document to carry only the chosen variant (prune the other two).
+2. Proceed to `writing-plans` for the implementation plan.
+
+This document intentionally does not proceed further until the choice is made.

--- a/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-bsp-app-client-design.md
@@ -26,7 +26,13 @@ Variant A explores whether BSP fits IAdtObject. Variant B is a narrow sapcli-par
 Dependencies and style:
 
 - Uses `pyodata` OData v2 client — not raw HTTP.
-- Entity set: `Repositories` (inferred — sapcli does not print the service URL, but pyodata clients are typically bound at construction to `UI5/ABAP_REPOSITORY_SRV`).
+- Entity set: `Repositories`.
+- Service URL: **`UI5/ABAP_REPOSITORY_SRV`** — explicitly bound at the command-group registration site (`sap/cli/__init__.py:111`):
+  ```python
+  (partial(odata_connection_from_args, 'UI5/ABAP_REPOSITORY_SRV'), sap.cli.bsp.CommandGroup())
+  ```
+- sapcli shares this OData-v2 pattern across all its UI-related commands — BSP uses `UI5/ABAP_REPOSITORY_SRV`, FLP uses `UI2/PAGE_BUILDER_CUST` (same line 112). Any minimal OData-v2 helper we implement is reusable between the two.
+- **sapcli does NOT use ADT filestore.** A repo-wide grep for `filestore`, `ui5-bsp`, `deploy-storage`, and `ui5-rt-version` returns zero hits in sapcli's source tree. There are no code comments or docstrings explaining the choice — the OData-v2 path appears historically established, not argued for in code. Our design therefore treats ADT filestore as a new transport that needs live verification, while OData v2 is the fully-sapcli-documented fallback.
 
 Commands:
 

--- a/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
@@ -195,7 +195,7 @@ Regardless of A/B/C:
 | Aspect | A (core module) | B (minimal client) | C (extended client) |
 |---|---|---|---|
 | Architectural fit | Consistent with 24 existing core modules | New pattern (but sapcli-backed) | Same pattern as B, bigger surface |
-| Scope | Full CRUD + state-toggle + maybe analytics | `state`, `on`, `off`, optional `check` | +`validate`, +`readMetadata/readSource`, +analytics |
+| Scope | Full CRUD + state-toggle + maybe analytics | `state`, `on`, `off` | +`check`, +`validate`, +`readMetadata/readSource`, +analytics |
 | Payload | Hybrid XML + JSON | JSON only | Hybrid XML + JSON |
 | Effort | Medium–Large | Small | Medium |
 | Matches roadmap proposal | No — requires updating proposal section 3.3 | Yes | Yes |

--- a/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
@@ -4,6 +4,8 @@ Date: 2026-04-19
 Status: Three-variant proposal awaiting user decision
 Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1)
 
+> **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own design document of this shape. The variant choice (A / B / C) is resolved **independently per class**, not once for the whole roadmap. Implementation planning for a class does not start until its own variant is picked.
+
 ## 1. Goal
 
 Add feature-toggle support to `@mcp-abap-adt/adt-clients`. This document presents **three architectural variants** with different scope and placement. The user picks one before implementation planning starts.

--- a/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
@@ -8,12 +8,12 @@ Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` 
 
 ## 1. Goal
 
-Add full feature-toggle support to `@mcp-abap-adt/adt-clients` as a core module under `src/core/featureToggle/`, following the same `IAdtObject<Config, State>` architecture that backs the existing 24 core modules. Extend the canonical interface with three feature-toggle-specific methods (`switchOn`, `switchOff`, `getRuntimeState`) to cover the sapcli use cases on top of the standard CRUD + lifecycle.
+Add full feature-toggle support to `@mcp-abap-adt/adt-clients` as a core module under `src/core/featureToggle/`, following the same `IAdtObject<Config, State>` architecture that backs the existing 24 core modules. The public API must be exposed through a **specialized interface** (`IFeatureToggleObject extends IAdtObject<...>`) so the feature-toggle-specific methods stay statically visible on the factory return type instead of being hidden behind casts.
 
 ## 2. Scope
 
 **In scope:**
-- Full CRUD + lifecycle per `IAdtObject<IFeatureToggleConfig, IFeatureToggleState>`: `validate`, `create`, `read`, `readMetadata`, `update`, `delete`, `lock`, `unlock`, `check`, `activate`, `readTransport`.
+- Full CRUD + lifecycle per `IFeatureToggleObject extends IAdtObject<IFeatureToggleConfig, IFeatureToggleState>`: `validate`, `create`, `read`, `readMetadata`, `update`, `delete`, `lock`, `unlock`, `check`, `activate`, `readTransport`.
 - Hybrid payload handling: XML metadata (`blue:blueSource`) + JSON source (rollout / toggledPackages / attributes) + JSON state/check/toggle responses.
 - Feature-toggle domain methods layered on top of the generic interface: `switchOn`, `switchOff`, `getRuntimeState`, plus `check` for pre-flight and `readSource` for the JSON rollout body.
 - New `adtClient.getFeatureToggle()` factory method on `AdtClient`.
@@ -74,10 +74,10 @@ Availability planning: `available_in: ["cloud", "onprem"]` provisionally; keep `
 ### 4.1 Factory on `AdtClient`
 
 ```ts
-getFeatureToggle(): IAdtObject<IFeatureToggleConfig, IFeatureToggleState>;
+getFeatureToggle(): IFeatureToggleObject;
 ```
 
-The returned handler is a standalone instance of `AdtFeatureToggle` with a richer surface than the plain `IAdtObject` contract. The extra methods (`switchOn`, `switchOff`, `getRuntimeState`, `readSource`) are exposed on the concrete class; consumers who need them cast the handler to `AdtFeatureToggle` (matching how `AdtFunctionInclude` exposes the extra `readSource()` method that is not part of `IAdtObject`).
+The returned handler is a standalone instance of `AdtFeatureToggle`, but the factory returns the specialized public interface `IFeatureToggleObject`, not the narrower `IAdtObject`. This preserves static type visibility for `switchOn`, `switchOff`, `getRuntimeState`, `checkState`, and `readSource` and avoids a cast-based API.
 
 ### 4.2 Config type
 
@@ -179,10 +179,41 @@ export interface IFeatureToggleCheckResult {
 }
 ```
 
-### 4.4 Domain methods (layered on top of `IAdtObject`)
+### 4.4 Specialized object interface
 
 ```ts
-class AdtFeatureToggle implements IAdtObject<IFeatureToggleConfig, IFeatureToggleState> {
+export interface IFeatureToggleObject
+  extends IAdtObject<IFeatureToggleConfig, IFeatureToggleState> {
+  switchOn(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
+
+  switchOff(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
+
+  getRuntimeState(
+    config: Partial<IFeatureToggleConfig>,
+  ): Promise<IFeatureToggleState>;
+
+  checkState(
+    config: Partial<IFeatureToggleConfig>,
+    opts?: { userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
+
+  readSource(
+    config: Partial<IFeatureToggleConfig>,
+    version?: 'active' | 'inactive',
+  ): Promise<IFeatureToggleState>;
+}
+```
+
+### 4.5 Domain methods (layered on top of `IAdtObject`)
+
+```ts
+class AdtFeatureToggle implements IFeatureToggleObject {
   // ...standard IAdtObject methods...
 
   /**
@@ -259,8 +290,8 @@ export interface IToggleFeatureToggleParams {
 
 ```
 src/core/featureToggle/
-  AdtFeatureToggle.ts        # handler class — IAdtObject + domain methods
-  types.ts                   # IFeatureToggleConfig, IFeatureToggleState, ICreateFeatureToggleParams, sub-types
+  AdtFeatureToggle.ts        # handler class — implements IFeatureToggleObject
+  types.ts                   # IFeatureToggleConfig, IFeatureToggleState, IFeatureToggleObject, ICreateFeatureToggleParams, sub-types
   xmlBuilder.ts              # builds the blue:blueSource root element for create/update metadata
   create.ts                  # POST /sfw/featuretoggles — metadata only
   read.ts                    # GET /sfw/featuretoggles/{name} — metadata XML

--- a/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
@@ -1,0 +1,237 @@
+# Design: Feature Toggle support (three variants for review)
+
+Date: 2026-04-19
+Status: Three-variant proposal awaiting user decision
+Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1)
+
+## 1. Goal
+
+Add feature-toggle support to `@mcp-abap-adt/adt-clients`. This document presents **three architectural variants** with different scope and placement. The user picks one before implementation planning starts.
+
+## 2. Why three variants
+
+sapcli exposes a minimal state-toggling facade (`on`, `off`, `state`), but the underlying ADT surface `/sap/bc/adt/sfw/featuretoggles` supports a full ADT object lifecycle (an `FTG2/FT` type with lock/unlock/activate, source content, check, dependencies, logs, related objects). That range creates three legitimate design choices — match sapcli, cover the rich surface as a client, or treat it as another core object type.
+
+## 3. Verified evidence
+
+### 3.1 sapcli reference (`sap/adt/featuretoggle.py`, `sap/cli/featuretoggle.py`)
+
+Implemented surface:
+
+- `GET /sap/bc/adt/sfw/featuretoggles/{name}/states` → runtime state (client + user level) as JSON
+  - Accept `application/vnd.sap.adt.states.v1+asjson`
+  - Body shape: `{ STATES: { NAME, CLIENT_STATE, CLIENT_CHANGED_BY, CLIENT_CHANGED_ON, USER_STATE, CLIENT_STATES[], USER_STATES[] } }`
+- `POST /sap/bc/adt/sfw/featuretoggles/{name}/toggle` → flip ON/OFF
+  - Content-Type `application/vnd.sap.adt.related.toggle.parameters.v1+asjson`
+  - Body `{ TOGGLE_PARAMETERS: { IS_USER_SPECIFIC: bool, STATE: "on" | "off", TRANSPORT_REQUEST?: string } }`
+
+Documented but not wired from CLI:
+
+- `POST /sap/bc/adt/sfw/featuretoggles/{name}/check`
+  - Accept `application/vnd.sap.adt.toggle.check.result.v1+asjson`
+  - Content-Type `application/vnd.sap.adt.toggle.check.parameters.v1+asjson`
+  - Result: `{ RESULT: { CURRENT_STATE, TRANSPORT_PACKAGE, TRANSPORT_URI, CUSTOMIZING_TRANSPORT_ALLOWED } }`
+- `POST /sap/bc/adt/sfw/featuretoggles/{name}/validate`
+  - Accept `application/vnd.sap.adt.toggle.validation.result.v1+asjson`
+  - Content-Type `application/vnd.sap.adt.toggle.validation.parameters.v1+asjson`
+
+Referenced metadata surface (from the GET of the object itself):
+
+- XML root `<blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue">` with adtcore attributes (`name`, `type="FTG2/FT"`, `description`, `responsible`, `masterLanguage`, `masterSystem`, `changedAt`, `changedBy`, `createdAt`, `createdBy`, `version`, etc.)
+- `<adtcore:packageRef …/>` child
+- Atom links to `source/main` (JSON rollout body), `source/main/versions`, GUI link, `schema`, `configuration`
+- Source payload at `…/source/main` is JSON: `{ header, rollout, toggledPackages[], relatedToggles[], attributes[] }`
+
+State enum: `"on" | "off" | "undefined"`.
+
+### 3.2 Discovery corpus (`docs/discovery/discovery_cloud_mdd_raw.xml`, `endpoints_cloud_mdd.txt`)
+
+All under `/sap/bc/adt/sfw/`:
+
+- `featuretoggles` (collection)
+- `featuretoggles/$configuration` (config template), `featuretoggles/$schema`
+- `featuretoggles/attributes/attributeKeys`, `featuretoggles/attributes/attributeValues`
+- `featuretoggles/{object_name}` with `?corrNr,lockHandle,version,accessMode,_action` — full CRUD + lock/unlock contract
+- `featuretoggles/{object_name}/check`
+- `featuretoggles/{object_name}/dependencies/validate`
+- `featuretoggles/{object_name}/logs`
+- `featuretoggles/{object_name}/objects`
+
+Only verified on cloud MDD in the captured snapshots. Not seen on E77 (legacy) or E19 (modern on-prem) in current discovery — per-class implementation must probe on-prem systems once the target is chosen.
+
+Availability planning: `available_in: ["cloud"]` initially; widen to `onprem` after probing a modern on-prem target; likely `unsupported` on `legacy`.
+
+## 4. Variant A — core module under `src/core/featureToggle/`
+
+**Shape.** Treat feature toggle as an `IAdtObject<IFeatureToggleConfig, IFeatureToggleState>` — same pattern as `authorizationField` and the other 23 core modules. Full canonical operation chains: `create → check → lock → update → unlock → activate`, `update → …`, `delete → check(deletion) → delete`. Plus domain-specific methods layered on: `switchOn`, `switchOff`, `getRuntimeState`.
+
+**Pros.**
+- Fits the dominant pattern of the repo — consumers discover `getFeatureToggle()` on `AdtClient` next to `getDataElement()`, `getAuthorizationField()`, etc.
+- Reuses existing infrastructure: content-type constants, XML builder, lock/unlock helpers, session transitions, test harness, `CLAUDE.md` count bump.
+- Legitimate — the object genuinely IS an ADT-managed artifact with `adtcore:type="FTG2/FT"`, packageRef, and activation semantics.
+
+**Cons.**
+- **Contradicts the roadmap proposal** (`2026-04-19-sapcli-separate-clients-proposal.md`) which explicitly places `AdtFeatureToggleClient` as a separate client. Accepting A means updating section 3.3 of that proposal.
+- **Mixed payload formats.** The object has XML metadata + JSON source at `/source/main` + JSON state/check/toggle/validate results. DDIC modules are pure XML; source-bearing modules are XML + text/plain. This is a **new hybrid** (XML + JSON) the `src/core/` pattern has not yet absorbed — either forces innovation in the shared core helpers or isolates all the JSON handling inside this one module.
+- The rich sub-resource surface (`/logs`, `/dependencies/validate`, `/objects`, `$configuration`, `$schema`, `attributes/*`) has no natural home in the canonical CRUD chains. It would either attach as a loose set of extra methods (awkward) or get dropped.
+- The sapcli use case (flip ON/OFF with corrnr) is NOT a standard CRUD operation — it's a state-machine command on an existing object. It sits oddly next to create/read/update/delete.
+
+**Verdict.** Architecturally consistent for lifecycle, architecturally awkward for state-toggle + analytics.
+
+## 5. Variant B — minimal separate client (sapcli parity)
+
+**Shape.** New file `src/clients/AdtFeatureToggleClient.ts`. Factory: `adtClient.getFeatureToggle()` (or a standalone class consumers instantiate directly with `IAbapConnection`). Surface:
+
+```ts
+class AdtFeatureToggleClient {
+  constructor(connection: IAbapConnection, logger?: ILogger, options?: ...);
+
+  getRuntimeState(name: string): Promise<IFeatureToggleRuntimeState>;
+  switchOn(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
+  switchOff(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
+  check(name: string, opts?: { userSpecific?: boolean }): Promise<IFeatureToggleCheckResult>;  // optional
+}
+```
+
+Types:
+
+```ts
+type FeatureToggleState = 'on' | 'off' | 'undefined';
+
+interface IFeatureToggleClientState {
+  client: string;
+  description?: string;
+  state: FeatureToggleState;
+}
+
+interface IFeatureToggleRuntimeState {
+  name: string;
+  clientState: FeatureToggleState;  // aggregate of current session's client
+  userState: FeatureToggleState;
+  clientStates: IFeatureToggleClientState[];  // all clients
+  userStates: Array<{ user: string; state: FeatureToggleState }>;
+}
+
+interface IFeatureToggleCheckResult {
+  currentState: FeatureToggleState;
+  transportPackage: string;
+  transportUri: string;
+  customizingTransportAllowed: boolean;
+}
+```
+
+No create / no read-definition / no update / no delete / no lock / no activate / no analytics. Just the three operations sapcli ships.
+
+**Pros.**
+- **Matches the roadmap proposal exactly** — baseline size, baseline pattern for "separate client in current architecture".
+- Smallest honest surface — only what is proven by existing sapcli usage. YAGNI for the rest.
+- JSON-only — no XML parsing in this class at all. Keeps the first JSON-consuming client isolated and clean.
+- Fastest to ship; fastest to review; easiest test scaffolding.
+
+**Cons.**
+- Users who need metadata (description, package, changedBy) or analytics (logs, dependencies) get nothing. They must drop to raw `connection.makeAdtRequest` or wait for v2 of this class.
+- Does not exercise the repo's lock/activate flow — so the "pattern baseline" claim is partially unvalidated (the bigger clients will have to re-discover conventions).
+
+**Verdict.** Right if the priority is to ship a usable fast client and postpone deeper work.
+
+## 6. Variant C — extended separate client
+
+**Shape.** Same file location as B (`src/clients/AdtFeatureToggleClient.ts`), same constructor, but richer surface:
+
+```ts
+class AdtFeatureToggleClient {
+  constructor(connection: IAbapConnection, logger?: ILogger, options?: ...);
+
+  // State (sapcli parity)
+  getRuntimeState(name: string): Promise<IFeatureToggleRuntimeState>;
+  switchOn(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
+  switchOff(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
+
+  // Pre-flight checks
+  check(name: string, opts?: { userSpecific?: boolean }): Promise<IFeatureToggleCheckResult>;
+  validate(name: string, opts: { state: FeatureToggleState; userSpecific?: boolean }): Promise<IFeatureToggleValidationResult>;
+
+  // Read definition (lightweight metadata)
+  readMetadata(name: string): Promise<IFeatureToggleMetadata>;  // parses the XML blueSource
+  readSource(name: string): Promise<IFeatureToggleSource>;       // parses the JSON rollout body
+
+  // Analytics
+  listAffectedObjects(name: string): Promise<IFeatureToggleAffectedObject[]>;
+  readDependencies(name: string): Promise<IFeatureToggleDependency[]>;
+  readLogs(name: string): Promise<IFeatureToggleLogEntry[]>;
+}
+```
+
+Types expand accordingly (kept out of this variant sketch to avoid premature bikeshedding; finalised in the implementation plan).
+
+**Still out of scope for C:** create / delete / lock-unlock / activate / update of the toggle definition itself. Those remain the developer's job in ADT or a future extension.
+
+**Pros.**
+- Covers everything useful a consumer might ask for without reimplementing the underlying object lifecycle.
+- Single client, one file per concern (state, check, metadata, analytics).
+- Exercises mixed-payload parsing (XML metadata + JSON state / source / analytics) in a way the rest of the library hasn't yet faced — generates lessons for BSP/FLP/gCTS before those land.
+
+**Cons.**
+- **Roughly 3× the implementation effort of B** without 3× the user value for day-1 usage.
+- Analytics methods (`listAffectedObjects`, `readDependencies`, `readLogs`) have no reference usage in sapcli — contract details (response shapes, edge cases) are only defined by live discovery against a specific system; bring-up cost is higher.
+- Pre-flight `check` / `validate` distinction in sapcli comments is ambiguous; per-class implementation must nail down the semantic difference with live traces, raising scope risk.
+
+**Verdict.** Right if the plan is "one well-rounded class, no successor work needed", and the user is willing to budget for the discovery work on analytics.
+
+## 7. Non-decisions (same across all variants)
+
+Regardless of A/B/C:
+
+- **Transport:** Only `IAbapConnection`. No RFC, no direct axios.
+- **JSON parsing:** Native `JSON.parse`; no new dependencies. Hand-roll types.
+- **Content-type constants:** Added to `src/constants/contentTypes.ts` alongside the established `ACCEPT_*` / `CT_*` entries.
+- **Accept negotiation:** Integrate with the existing `wrapConnectionAcceptNegotiation` wrapper. Feature-toggle endpoints are strict about Accept — expect 406 handling to matter.
+- **Environment gating:** `available_in: ["cloud"]` initially. Probe on-prem modern + legacy during bring-up; widen or narrow based on evidence. Tests default to `onprem`-first convention only if the on-prem probe succeeds; otherwise cloud-only.
+- **Transport-request binding:** `switchOn` / `switchOff` always require `transportRequest` (matches sapcli — `--corrnr` is marked `required`); `user-specific` toggles may skip it but the proposal keeps it required for safety. Final decision in the implementation plan.
+- **Encoding:** `quote_plus` in sapcli → `encodeURIComponent` in TypeScript, applied to the feature-toggle name segment.
+- **Documentation:** Updates to README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, ADT_OBJECT_ENTITIES follow the `#21` pattern from the auth-field / function-include release.
+
+## 8. Comparison summary
+
+| Aspect | A (core module) | B (minimal client) | C (extended client) |
+|---|---|---|---|
+| Architectural fit | Consistent with 24 existing core modules | New pattern (but sapcli-backed) | Same pattern as B, bigger surface |
+| Scope | Full CRUD + state-toggle + maybe analytics | `state`, `on`, `off`, optional `check` | +`validate`, +`readMetadata/readSource`, +analytics |
+| Payload | Hybrid XML + JSON | JSON only | Hybrid XML + JSON |
+| Effort | Medium–Large | Small | Medium |
+| Matches roadmap proposal | No — requires updating proposal section 3.3 | Yes | Yes |
+| Pattern-baseline value | Exercises core-module conventions already well-known | Exercises the new "separate client" contract minimally | Exercises the new contract under real complexity |
+| Risk of rework | Moderate (hybrid payload in core is new) | Low | Moderate (analytics contract unknown) |
+| Testability on cloud trial | Needs writeable FTG2/FT objects (may not be permitted) | Needs one readable feature toggle to `state` / `switch` | Same as B + analytics endpoints to read |
+
+## 9. What is NOT decided here
+
+- Final public method names (we may need `getState` vs `fetchState`, `switchOn` vs `enable` — bikeshed in the implementation plan, not now).
+- Exact config/state TypeScript type names.
+- Whether the class is created directly or via `AdtClient.getFeatureToggle()`. The proposal leans toward the factory pattern for consistency, but a standalone import-and-instantiate flow is also defensible — decide together with option choice.
+- Cross-cutting options shape (per proposal review note #5 — `IAdtClientOptions` vs runtime-style vs new shared contract).
+
+## 10. Decision criteria
+
+Pick **A** if:
+- You want uniformity with the rest of `src/core/` at the cost of one extra hybrid-payload shared-helper evolution.
+- Plan to also cover feature-toggle lifecycle (create/delete) in-scope.
+
+Pick **B** if:
+- "Ship fast, validate the separate-client pattern, extend later" is the priority.
+- The only near-term consumer need is ON/OFF switching with corrnr.
+- You want to preserve roadmap-proposal ordering verbatim.
+
+Pick **C** if:
+- You want one definitive feature-toggle class, not an iterative v1 → v2 → v3.
+- You're budgeted for the discovery work on `logs` / `dependencies` / `objects`.
+
+## 11. Next step
+
+User picks A, B, or C (or a hybrid variant). After selection:
+
+1. Update this document to carry only the chosen variant (prune the other two).
+2. Update `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` if the choice was A (since the roadmap placement changes).
+3. Proceed to `writing-plans` skill for the implementation plan.
+
+This document intentionally does not proceed further until the choice is made.

--- a/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
@@ -44,7 +44,7 @@ Referenced metadata surface (from the GET of the object itself):
 
 State enum: `"on" | "off" | "undefined"`.
 
-### 3.2 Discovery corpus (`docs/discovery/discovery_cloud_mdd_raw.xml`, `endpoints_cloud_mdd.txt`)
+### 3.2 Discovery corpus (`docs/discovery/discovery_cloud_mdd_raw.xml`, `endpoints_cloud_mdd.txt`, `endpoints_onprem_modern_e19.txt`)
 
 All under `/sap/bc/adt/sfw/`:
 
@@ -57,9 +57,9 @@ All under `/sap/bc/adt/sfw/`:
 - `featuretoggles/{object_name}/logs`
 - `featuretoggles/{object_name}/objects`
 
-Only verified on cloud MDD in the captured snapshots. Not seen on E77 (legacy) or E19 (modern on-prem) in current discovery — per-class implementation must probe on-prem systems once the target is chosen.
+Verified in the captured snapshots for **cloud MDD** and **modern on-prem E19**. Not seen on E77 (legacy) in current discovery. Per-class implementation should still probe a live modern on-prem target before promising write support, but `available_in` does not need to start cloud-only on discovery grounds.
 
-Availability planning: `available_in: ["cloud"]` initially; widen to `onprem` after probing a modern on-prem target; likely `unsupported` on `legacy`.
+Availability planning: `available_in: ["cloud", "onprem"]` provisionally; keep `legacy` unsupported unless later evidence proves otherwise. The implementation plan should decide whether write operations stay enabled on both environments immediately or whether tests roll out cloud-first while on-prem write support is validated.
 
 ## 4. Variant A — core module under `src/core/featureToggle/`
 
@@ -89,7 +89,6 @@ class AdtFeatureToggleClient {
   getRuntimeState(name: string): Promise<IFeatureToggleRuntimeState>;
   switchOn(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
   switchOff(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
-  check(name: string, opts?: { userSpecific?: boolean }): Promise<IFeatureToggleCheckResult>;  // optional
 }
 ```
 
@@ -120,7 +119,7 @@ interface IFeatureToggleCheckResult {
 }
 ```
 
-No create / no read-definition / no update / no delete / no lock / no activate / no analytics. Just the three operations sapcli ships.
+No create / no read-definition / no update / no delete / no lock / no activate / no analytics. Just the three operations sapcli ships: `state`, `on`, `off`.
 
 **Pros.**
 - **Matches the roadmap proposal exactly** — baseline size, baseline pattern for "separate client in current architecture".
@@ -186,7 +185,7 @@ Regardless of A/B/C:
 - **JSON parsing:** Native `JSON.parse`; no new dependencies. Hand-roll types.
 - **Content-type constants:** Added to `src/constants/contentTypes.ts` alongside the established `ACCEPT_*` / `CT_*` entries.
 - **Accept negotiation:** Integrate with the existing `wrapConnectionAcceptNegotiation` wrapper. Feature-toggle endpoints are strict about Accept — expect 406 handling to matter.
-- **Environment gating:** `available_in: ["cloud"]` initially. Probe on-prem modern + legacy during bring-up; widen or narrow based on evidence. Tests default to `onprem`-first convention only if the on-prem probe succeeds; otherwise cloud-only.
+- **Environment gating:** `available_in: ["cloud", "onprem"]` provisionally based on current discovery; keep `legacy` unsupported unless later evidence proves otherwise. The implementation plan should decide whether tests run on both environments immediately or stage write coverage after one live on-prem verification pass.
 - **Transport-request binding:** `switchOn` / `switchOff` always require `transportRequest` (matches sapcli — `--corrnr` is marked `required`); `user-specific` toggles may skip it but the proposal keeps it required for safety. Final decision in the implementation plan.
 - **Encoding:** `quote_plus` in sapcli → `encodeURIComponent` in TypeScript, applied to the feature-toggle name segment.
 - **Documentation:** Updates to README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, ADT_OBJECT_ENTITIES follow the `#21` pattern from the auth-field / function-include release.

--- a/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
+++ b/docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md
@@ -1,18 +1,27 @@
-# Design: Feature Toggle support (three variants for review)
+# Design: Feature Toggle as a core module (`src/core/featureToggle/`)
 
 Date: 2026-04-19
-Status: Three-variant proposal awaiting user decision
+Status: Variant A selected — ready for implementation planning
 Parent: `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` (roadmap item #1)
 
-> **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own design document of this shape. The variant choice (A / B / C) is resolved **independently per class**, not once for the whole roadmap. Implementation planning for a class does not start until its own variant is picked.
+> **Per-class variant-selection pattern.** Each class in the sapcli-separate-clients roadmap gets its own three-variant design document. The variant choice is resolved independently per class. Feature toggle — Variant A: users need both to **create/manage feature toggle artifacts** and to **switch their state**. The other two variants (minimal and extended separate client) were rejected because they only covered state management.
 
 ## 1. Goal
 
-Add feature-toggle support to `@mcp-abap-adt/adt-clients`. This document presents **three architectural variants** with different scope and placement. The user picks one before implementation planning starts.
+Add full feature-toggle support to `@mcp-abap-adt/adt-clients` as a core module under `src/core/featureToggle/`, following the same `IAdtObject<Config, State>` architecture that backs the existing 24 core modules. Extend the canonical interface with three feature-toggle-specific methods (`switchOn`, `switchOff`, `getRuntimeState`) to cover the sapcli use cases on top of the standard CRUD + lifecycle.
 
-## 2. Why three variants
+## 2. Scope
 
-sapcli exposes a minimal state-toggling facade (`on`, `off`, `state`), but the underlying ADT surface `/sap/bc/adt/sfw/featuretoggles` supports a full ADT object lifecycle (an `FTG2/FT` type with lock/unlock/activate, source content, check, dependencies, logs, related objects). That range creates three legitimate design choices — match sapcli, cover the rich surface as a client, or treat it as another core object type.
+**In scope:**
+- Full CRUD + lifecycle per `IAdtObject<IFeatureToggleConfig, IFeatureToggleState>`: `validate`, `create`, `read`, `readMetadata`, `update`, `delete`, `lock`, `unlock`, `check`, `activate`, `readTransport`.
+- Hybrid payload handling: XML metadata (`blue:blueSource`) + JSON source (rollout / toggledPackages / attributes) + JSON state/check/toggle responses.
+- Feature-toggle domain methods layered on top of the generic interface: `switchOn`, `switchOff`, `getRuntimeState`, plus `check` for pre-flight and `readSource` for the JSON rollout body.
+- New `adtClient.getFeatureToggle()` factory method on `AdtClient`.
+
+**Explicitly out of scope for v1 (may be added later):**
+- Analytics surface: `/logs`, `/dependencies/validate` (cloud) vs `/validation` (E19), `/objects` (cloud) vs `/objects/types` (E19). Per-environment divergence is large enough that v1 punts; v2 can add a focused `readDependencies` / `readLogs` after live traces confirm per-environment behaviour.
+- `$configuration` and `$schema` — UI-driven form templates. Consumers that need dynamic form rendering can reach `connection.makeAdtRequest` directly; the toggle client does not wrap them.
+- `attributes/attributeKeys` / `attributes/attributeValues` — value-help endpoints for the authoring UI. Same rationale as above.
 
 ## 3. Verified evidence
 
@@ -22,24 +31,21 @@ Implemented surface:
 
 - `GET /sap/bc/adt/sfw/featuretoggles/{name}/states` → runtime state (client + user level) as JSON
   - Accept `application/vnd.sap.adt.states.v1+asjson`
-  - Body shape: `{ STATES: { NAME, CLIENT_STATE, CLIENT_CHANGED_BY, CLIENT_CHANGED_ON, USER_STATE, CLIENT_STATES[], USER_STATES[] } }`
+  - Body: `{ STATES: { NAME, CLIENT_STATE, CLIENT_CHANGED_BY, CLIENT_CHANGED_ON, USER_STATE, CLIENT_STATES[], USER_STATES[] } }`
 - `POST /sap/bc/adt/sfw/featuretoggles/{name}/toggle` → flip ON/OFF
   - Content-Type `application/vnd.sap.adt.related.toggle.parameters.v1+asjson`
   - Body `{ TOGGLE_PARAMETERS: { IS_USER_SPECIFIC: bool, STATE: "on" | "off", TRANSPORT_REQUEST?: string } }`
 
-Documented but not wired from CLI:
+Documented but not wired from sapcli CLI:
 
 - `POST /sap/bc/adt/sfw/featuretoggles/{name}/check`
   - Accept `application/vnd.sap.adt.toggle.check.result.v1+asjson`
   - Content-Type `application/vnd.sap.adt.toggle.check.parameters.v1+asjson`
   - Result: `{ RESULT: { CURRENT_STATE, TRANSPORT_PACKAGE, TRANSPORT_URI, CUSTOMIZING_TRANSPORT_ALLOWED } }`
-- `POST /sap/bc/adt/sfw/featuretoggles/{name}/validate`
-  - Accept `application/vnd.sap.adt.toggle.validation.result.v1+asjson`
-  - Content-Type `application/vnd.sap.adt.toggle.validation.parameters.v1+asjson`
 
-Referenced metadata surface (from the GET of the object itself):
+Referenced metadata surface (from GET of the object itself):
 
-- XML root `<blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue">` with adtcore attributes (`name`, `type="FTG2/FT"`, `description`, `responsible`, `masterLanguage`, `masterSystem`, `changedAt`, `changedBy`, `createdAt`, `createdBy`, `version`, etc.)
+- XML root `<blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue">` with adtcore attributes (`name`, `type="FTG2/FT"`, `description`, `responsible`, `masterLanguage`, `masterSystem`, `version`, `changedAt/changedBy`, `createdAt/createdBy`, `language`, `descriptionTextLimit`)
 - `<adtcore:packageRef …/>` child
 - Atom links to `source/main` (JSON rollout body), `source/main/versions`, GUI link, `schema`, `configuration`
 - Source payload at `…/source/main` is JSON: `{ header, rollout, toggledPackages[], relatedToggles[], attributes[] }`
@@ -51,188 +57,287 @@ State enum: `"on" | "off" | "undefined"`.
 All under `/sap/bc/adt/sfw/`:
 
 - `featuretoggles` (collection)
-- `featuretoggles/$configuration` (config template), `featuretoggles/$schema`
+- `featuretoggles/$configuration`, `featuretoggles/$schema`
 - `featuretoggles/attributes/attributeKeys`, `featuretoggles/attributes/attributeValues`
 - `featuretoggles/{object_name}` with `?corrNr,lockHandle,version,accessMode,_action` — full CRUD + lock/unlock contract
 - `featuretoggles/{object_name}/check`
-- `featuretoggles/{object_name}/dependencies/validate`
-- `featuretoggles/{object_name}/logs`
-- `featuretoggles/{object_name}/objects`
+- `featuretoggles/{object_name}/dependencies/validate` (cloud MDD) / `featuretoggles/validation` (E19 modern on-prem)
+- `featuretoggles/{object_name}/logs` (cloud MDD)
+- `featuretoggles/{object_name}/objects` (cloud MDD) / `featuretoggles/objects/types` (E19)
 
 Verified in the captured snapshots for **cloud MDD** and **modern on-prem E19**. Not seen on E77 (legacy) in current discovery. Per-class implementation should still probe a live modern on-prem target before promising write support, but `available_in` does not need to start cloud-only on discovery grounds.
 
 Availability planning: `available_in: ["cloud", "onprem"]` provisionally; keep `legacy` unsupported unless later evidence proves otherwise. The implementation plan should decide whether write operations stay enabled on both environments immediately or whether tests roll out cloud-first while on-prem write support is validated.
 
-## 4. Variant A — core module under `src/core/featureToggle/`
+## 4. Public API shape
 
-**Shape.** Treat feature toggle as an `IAdtObject<IFeatureToggleConfig, IFeatureToggleState>` — same pattern as `authorizationField` and the other 23 core modules. Full canonical operation chains: `create → check → lock → update → unlock → activate`, `update → …`, `delete → check(deletion) → delete`. Plus domain-specific methods layered on: `switchOn`, `switchOff`, `getRuntimeState`.
-
-**Pros.**
-- Fits the dominant pattern of the repo — consumers discover `getFeatureToggle()` on `AdtClient` next to `getDataElement()`, `getAuthorizationField()`, etc.
-- Reuses existing infrastructure: content-type constants, XML builder, lock/unlock helpers, session transitions, test harness, `CLAUDE.md` count bump.
-- Legitimate — the object genuinely IS an ADT-managed artifact with `adtcore:type="FTG2/FT"`, packageRef, and activation semantics.
-
-**Cons.**
-- **Contradicts the roadmap proposal** (`2026-04-19-sapcli-separate-clients-proposal.md`) which explicitly places `AdtFeatureToggleClient` as a separate client. Accepting A means updating section 3.3 of that proposal.
-- **Mixed payload formats.** The object has XML metadata + JSON source at `/source/main` + JSON state/check/toggle/validate results. DDIC modules are pure XML; source-bearing modules are XML + text/plain. This is a **new hybrid** (XML + JSON) the `src/core/` pattern has not yet absorbed — either forces innovation in the shared core helpers or isolates all the JSON handling inside this one module.
-- The rich sub-resource surface (`/logs`, `/dependencies/validate`, `/objects`, `$configuration`, `$schema`, `attributes/*`) has no natural home in the canonical CRUD chains. It would either attach as a loose set of extra methods (awkward) or get dropped.
-- The sapcli use case (flip ON/OFF with corrnr) is NOT a standard CRUD operation — it's a state-machine command on an existing object. It sits oddly next to create/read/update/delete.
-
-**Verdict.** Architecturally consistent for lifecycle, architecturally awkward for state-toggle + analytics.
-
-## 5. Variant B — minimal separate client (sapcli parity)
-
-**Shape.** New file `src/clients/AdtFeatureToggleClient.ts`. Factory: `adtClient.getFeatureToggle()` (or a standalone class consumers instantiate directly with `IAbapConnection`). Surface:
+### 4.1 Factory on `AdtClient`
 
 ```ts
-class AdtFeatureToggleClient {
-  constructor(connection: IAbapConnection, logger?: ILogger, options?: ...);
+getFeatureToggle(): IAdtObject<IFeatureToggleConfig, IFeatureToggleState>;
+```
 
-  getRuntimeState(name: string): Promise<IFeatureToggleRuntimeState>;
-  switchOn(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
-  switchOff(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
+The returned handler is a standalone instance of `AdtFeatureToggle` with a richer surface than the plain `IAdtObject` contract. The extra methods (`switchOn`, `switchOff`, `getRuntimeState`, `readSource`) are exposed on the concrete class; consumers who need them cast the handler to `AdtFeatureToggle` (matching how `AdtFunctionInclude` exposes the extra `readSource()` method that is not part of `IAdtObject`).
+
+### 4.2 Config type
+
+```ts
+export interface IFeatureToggleConfig {
+  featureToggleName: string;            // required — uppercase name of the FT artifact
+  packageName?: string;                  // required for create
+  description?: string;                  // required for create/update
+  transportRequest?: string;
+  masterSystem?: string;
+  responsible?: string;
+
+  // Source body — optional at create (empty FT), required for meaningful update
+  // Shape mirrors the JSON payload at .../source/main
+  source?: IFeatureToggleSource;
+
+  onLock?: (lockHandle: string) => void;
+}
+
+export interface IFeatureToggleSource {
+  header?: IFeatureToggleHeader;
+  rollout?: IFeatureToggleRollout;
+  toggledPackages?: string[];
+  relatedToggles?: string[];
+  attributes?: IFeatureToggleAttribute[];
+}
+
+export interface IFeatureToggleHeader {
+  description?: string;
+  originalLanguage?: string;       // 'en', 'de', ...
+  abapLanguageVersion?: string;    // 'standard', 'cloudDevelopment', ...
+}
+
+export interface IFeatureToggleRollout {
+  lifecycleStatus?: 'new' | 'inValidation' | 'released' | 'discontinued';
+  validationStep?: 'internal' | 'releaseToCustomer' | string;
+  rolloutStep?: 'releaseToCustomer' | 'generalAvailability' | 'generalRollout' | string;
+  strategy?: 'immediate' | 'gradual' | string;
+  finalDate?: string;
+  event?: 'noRestriction' | string;
+  planning?: IFeatureTogglePlanning;
+  configurable?: boolean;
+  defaultEnabledFor?: 'none' | 'someCustomers' | 'allCustomers' | string;
+  reversible?: boolean;
+}
+
+export interface IFeatureTogglePlanning {
+  referenceProduct?: string;                                    // 'S4HANA OD', ...
+  releaseToCustomer?: { version: string; sp: string };
+  generalAvailability?: { version: string; sp: string };
+  generalRollout?: { version: string; sp: string };
+}
+
+export interface IFeatureToggleAttribute {
+  key: string;                 // 'LC2_LIFECYCLE_STATUS', 'LC2_ROLLOUT_STRATEGY', ...
+  value: string;
 }
 ```
 
-Types:
+### 4.3 State type
 
 ```ts
-type FeatureToggleState = 'on' | 'off' | 'undefined';
+export interface IFeatureToggleState extends IAdtObjectState {
+  // Inherits readResult, validationResponse, createResult, updateResult, errors, etc.
+  // Plus feature-toggle-specific optional fields populated by domain methods:
+  runtimeState?: IFeatureToggleRuntimeState;      // populated by getRuntimeState()
+  checkResult?: IFeatureToggleCheckResult;         // populated by check() extended form
+  sourceResult?: IFeatureToggleSource;             // populated by readSource()
+}
 
-interface IFeatureToggleClientState {
+export type FeatureToggleState = 'on' | 'off' | 'undefined';
+
+export interface IFeatureToggleClientLevel {
   client: string;
   description?: string;
   state: FeatureToggleState;
 }
 
-interface IFeatureToggleRuntimeState {
-  name: string;
-  clientState: FeatureToggleState;  // aggregate of current session's client
-  userState: FeatureToggleState;
-  clientStates: IFeatureToggleClientState[];  // all clients
-  userStates: Array<{ user: string; state: FeatureToggleState }>;
+export interface IFeatureToggleUserLevel {
+  user: string;
+  state: FeatureToggleState;
 }
 
-interface IFeatureToggleCheckResult {
+export interface IFeatureToggleRuntimeState {
+  name: string;
+  clientState: FeatureToggleState;
+  userState: FeatureToggleState;
+  clientChangedBy?: string;
+  clientChangedOn?: string;
+  clientStates: IFeatureToggleClientLevel[];
+  userStates: IFeatureToggleUserLevel[];
+}
+
+export interface IFeatureToggleCheckResult {
   currentState: FeatureToggleState;
-  transportPackage: string;
-  transportUri: string;
+  transportPackage?: string;
+  transportUri?: string;
   customizingTransportAllowed: boolean;
 }
 ```
 
-No create / no read-definition / no update / no delete / no lock / no activate / no analytics. Just the three operations sapcli ships: `state`, `on`, `off`.
-
-**Pros.**
-- **Matches the roadmap proposal exactly** — baseline size, baseline pattern for "separate client in current architecture".
-- Smallest honest surface — only what is proven by existing sapcli usage. YAGNI for the rest.
-- JSON-only — no XML parsing in this class at all. Keeps the first JSON-consuming client isolated and clean.
-- Fastest to ship; fastest to review; easiest test scaffolding.
-
-**Cons.**
-- Users who need metadata (description, package, changedBy) or analytics (logs, dependencies) get nothing. They must drop to raw `connection.makeAdtRequest` or wait for v2 of this class.
-- Does not exercise the repo's lock/activate flow — so the "pattern baseline" claim is partially unvalidated (the bigger clients will have to re-discover conventions).
-
-**Verdict.** Right if the priority is to ship a usable fast client and postpone deeper work.
-
-## 6. Variant C — extended separate client
-
-**Shape.** Same file location as B (`src/clients/AdtFeatureToggleClient.ts`), same constructor, but richer surface:
+### 4.4 Domain methods (layered on top of `IAdtObject`)
 
 ```ts
-class AdtFeatureToggleClient {
-  constructor(connection: IAbapConnection, logger?: ILogger, options?: ...);
+class AdtFeatureToggle implements IAdtObject<IFeatureToggleConfig, IFeatureToggleState> {
+  // ...standard IAdtObject methods...
 
-  // State (sapcli parity)
-  getRuntimeState(name: string): Promise<IFeatureToggleRuntimeState>;
-  switchOn(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
-  switchOff(name: string, opts: { transportRequest: string; userSpecific?: boolean }): Promise<void>;
+  /**
+   * Switch the toggle ON, binding the change to a transport request.
+   * Client-level by default; pass userSpecific: true for user-scoped.
+   */
+  switchOn(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
 
-  // Pre-flight checks
-  check(name: string, opts?: { userSpecific?: boolean }): Promise<IFeatureToggleCheckResult>;
-  validate(name: string, opts: { state: FeatureToggleState; userSpecific?: boolean }): Promise<IFeatureToggleValidationResult>;
+  /**
+   * Switch the toggle OFF. Same shape as switchOn.
+   * Note: the toggle's rollout.reversible flag must permit OFF after activation.
+   */
+  switchOff(
+    config: Partial<IFeatureToggleConfig>,
+    opts: { transportRequest: string; userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
 
-  // Read definition (lightweight metadata)
-  readMetadata(name: string): Promise<IFeatureToggleMetadata>;  // parses the XML blueSource
-  readSource(name: string): Promise<IFeatureToggleSource>;       // parses the JSON rollout body
+  /**
+   * Fetch the current runtime state (client-level aggregate + per-client + per-user).
+   */
+  getRuntimeState(
+    config: Partial<IFeatureToggleConfig>,
+  ): Promise<IFeatureToggleState>;
 
-  // Analytics
-  listAffectedObjects(name: string): Promise<IFeatureToggleAffectedObject[]>;
-  readDependencies(name: string): Promise<IFeatureToggleDependency[]>;
-  readLogs(name: string): Promise<IFeatureToggleLogEntry[]>;
+  /**
+   * Pre-flight check before a toggle. Returns current state plus transport binding
+   * info (package, URI, whether a customizing transport is allowed).
+   */
+  checkState(
+    config: Partial<IFeatureToggleConfig>,
+    opts?: { userSpecific?: boolean },
+  ): Promise<IFeatureToggleState>;
+
+  /**
+   * Read the JSON source body at .../source/main (rollout + toggledPackages + attributes).
+   * Parallel to AdtFunctionInclude.readSource, but returns structured JSON, not text.
+   */
+  readSource(
+    config: Partial<IFeatureToggleConfig>,
+    version?: 'active' | 'inactive',
+  ): Promise<IFeatureToggleState>;
 }
 ```
 
-Types expand accordingly (kept out of this variant sketch to avoid premature bikeshedding; finalised in the implementation plan).
+`check` (canonical `IAdtObject.check`) stays available — it hits `/checkruns?reporters=abapCheckRun` for syntactic validation, same as every other core module. `checkState` is the feature-toggle-specific `/check` endpoint that returns transport-binding info. The names are deliberately different to avoid confusion between the two checks.
 
-**Still out of scope for C:** create / delete / lock-unlock / activate / update of the toggle definition itself. Those remain the developer's job in ADT or a future extension.
+### 4.5 Low-level parameter types (snake_case, internal)
 
-**Pros.**
-- Covers everything useful a consumer might ask for without reimplementing the underlying object lifecycle.
-- Single client, one file per concern (state, check, metadata, analytics).
-- Exercises mixed-payload parsing (XML metadata + JSON state / source / analytics) in a way the rest of the library hasn't yet faced — generates lessons for BSP/FLP/gCTS before those land.
+Same pattern as `ICreateAuthorizationFieldParams` / `ICreateFunctionIncludeParams`: snake_case wire-format mirror used only by the low-level files. Not exported from `index.ts`.
 
-**Cons.**
-- **Roughly 3× the implementation effort of B** without 3× the user value for day-1 usage.
-- Analytics methods (`listAffectedObjects`, `readDependencies`, `readLogs`) have no reference usage in sapcli — contract details (response shapes, edge cases) are only defined by live discovery against a specific system; bring-up cost is higher.
-- Pre-flight `check` / `validate` distinction in sapcli comments is ambiguous; per-class implementation must nail down the semantic difference with live traces, raising scope risk.
+```ts
+export interface ICreateFeatureToggleParams {
+  feature_toggle_name: string;
+  description?: string;
+  package_name: string;
+  transport_request?: string;
+  master_system?: string;
+  responsible?: string;
+  source?: IFeatureToggleSource;  // JSON, not snake_case — it goes verbatim into the source PUT
+}
 
-**Verdict.** Right if the plan is "one well-rounded class, no successor work needed", and the user is willing to budget for the discovery work on analytics.
+export interface IToggleFeatureToggleParams {
+  feature_toggle_name: string;
+  state: 'on' | 'off';
+  is_user_specific: boolean;
+  transport_request?: string;
+}
+```
 
-## 7. Non-decisions (same across all variants)
+## 5. Architectural placement and module layout
 
-Regardless of A/B/C:
+```
+src/core/featureToggle/
+  AdtFeatureToggle.ts        # handler class — IAdtObject + domain methods
+  types.ts                   # IFeatureToggleConfig, IFeatureToggleState, ICreateFeatureToggleParams, sub-types
+  xmlBuilder.ts              # builds the blue:blueSource root element for create/update metadata
+  create.ts                  # POST /sfw/featuretoggles — metadata only
+  read.ts                    # GET /sfw/featuretoggles/{name} — metadata XML
+  readSource.ts              # GET /sfw/featuretoggles/{name}/source/main — JSON
+  update.ts                  # PUT /sfw/featuretoggles/{name}?lockHandle= — metadata XML
+  updateSource.ts            # PUT /sfw/featuretoggles/{name}/source/main?lockHandle= — JSON
+  delete.ts                  # POST /deletion/check + /deletion/delete
+  lock.ts                    # POST /sfw/featuretoggles/{name}?_action=LOCK&accessMode=MODIFY
+  unlock.ts                  # POST /sfw/featuretoggles/{name}?_action=UNLOCK&lockHandle=
+  check.ts                   # POST /checkruns?reporters=abapCheckRun (canonical check)
+  activation.ts              # POST /activation
+  validation.ts              # pre-create name validation (probe via GET or dedicated endpoint if available)
+  getState.ts                # GET /sfw/featuretoggles/{name}/states — domain: runtime state
+  checkState.ts              # POST /sfw/featuretoggles/{name}/check — domain: pre-flight with transport info
+  switch.ts                  # POST /sfw/featuretoggles/{name}/toggle — domain: switch on/off
+  index.ts                   # barrel exports
+```
 
-- **Transport:** Only `IAbapConnection`. No RFC, no direct axios.
-- **JSON parsing:** Native `JSON.parse`; no new dependencies. Hand-roll types.
-- **Content-type constants:** Added to `src/constants/contentTypes.ts` alongside the established `ACCEPT_*` / `CT_*` entries.
-- **Accept negotiation:** Integrate with the existing `wrapConnectionAcceptNegotiation` wrapper. Feature-toggle endpoints are strict about Accept — expect 406 handling to matter.
-- **Environment gating:** `available_in: ["cloud", "onprem"]` provisionally based on current discovery; keep `legacy` unsupported unless later evidence proves otherwise. The implementation plan should decide whether tests run on both environments immediately or stage write coverage after one live on-prem verification pass.
-- **Transport-request binding:** `switchOn` / `switchOff` always require `transportRequest` (matches sapcli — `--corrnr` is marked `required`); `user-specific` toggles may skip it but the proposal keeps it required for safety. Final decision in the implementation plan.
-- **Encoding:** `quote_plus` in sapcli → `encodeURIComponent` in TypeScript, applied to the feature-toggle name segment.
-- **Documentation:** Updates to README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, ADT_OBJECT_ENTITIES follow the `#21` pattern from the auth-field / function-include release.
+Counts: 16 files, larger than `authorizationField` (12) and `functionInclude` (14) because of the hybrid-payload split (XML metadata file + JSON source file) combined with the domain-specific state operations.
 
-## 8. Comparison summary
+## 6. Operation chains
 
-| Aspect | A (core module) | B (minimal client) | C (extended client) |
-|---|---|---|---|
-| Architectural fit | Consistent with 24 existing core modules | New pattern (but sapcli-backed) | Same pattern as B, bigger surface |
-| Scope | Full CRUD + state-toggle + maybe analytics | `state`, `on`, `off` | +`check`, +`validate`, +`readMetadata/readSource`, +analytics |
-| Payload | Hybrid XML + JSON | JSON only | Hybrid XML + JSON |
-| Effort | Medium–Large | Small | Medium |
-| Matches roadmap proposal | No — requires updating proposal section 3.3 | Yes | Yes |
-| Pattern-baseline value | Exercises core-module conventions already well-known | Exercises the new "separate client" contract minimally | Exercises the new contract under real complexity |
-| Risk of rework | Moderate (hybrid payload in core is new) | Low | Moderate (analytics contract unknown) |
-| Testability on cloud trial | Needs writeable FTG2/FT objects (may not be permitted) | Needs one readable feature toggle to `state` / `switch` | Same as B + analytics endpoints to read |
+### 6.1 Canonical (copies from `AdtProgram`/`AdtFunctionInclude` — source-bearing template, but "source" here is JSON, not text/plain)
 
-## 9. What is NOT decided here
+- **create:** validate → create (metadata XML) → if `source` provided: stateful → lock → stateless → updateSource (JSON PUT) → stateful → unlock → stateless → activate
+- **update:** stateful → lock → stateless → check (inactive version with JSON source if provided) → updateMetadata (XML, if description/packageRef changed) → updateSource (if `source` provided) → stateful → unlock → stateless → check → activate → read with long polling → error cleanup
+- **delete:** checkDeletion → delete
 
-- Final public method names (we may need `getState` vs `fetchState`, `switchOn` vs `enable` — bikeshed in the implementation plan, not now).
-- Exact config/state TypeScript type names.
-- Whether the class is created directly or via `AdtClient.getFeatureToggle()`. The proposal leans toward the factory pattern for consistency, but a standalone import-and-instantiate flow is also defensible — decide together with option choice.
-- Cross-cutting options shape (per proposal review note #5 — `IAdtClientOptions` vs runtime-style vs new shared contract).
+### 6.2 Domain chains
 
-## 10. Decision criteria
+- **switchOn / switchOff:** `checkState(userSpecific)` → if `CUSTOMIZING_TRANSPORT_ALLOWED && transportRequest` → POST `/toggle` with `TOGGLE_PARAMETERS: { IS_USER_SPECIFIC, STATE, TRANSPORT_REQUEST }`. No lock/activate. Populates `state.runtimeState` via fresh `getRuntimeState()` afterwards.
+- **getRuntimeState:** GET `/states` (stateless). Single request, parse JSON, populate `state.runtimeState`.
+- **checkState:** POST `/check` (stateless) with `{ PARAMETERS: { IS_USER_SPECIFIC } }`. Populates `state.checkResult`.
+- **readSource:** GET `/source/main` (stateless). Parse JSON, populate `state.sourceResult`.
 
-Pick **A** if:
-- You want uniformity with the rest of `src/core/` at the cost of one extra hybrid-payload shared-helper evolution.
-- Plan to also cover feature-toggle lifecycle (create/delete) in-scope.
+## 7. Non-decisions (fixed constraints shared with the rest of the library)
 
-Pick **B** if:
-- "Ship fast, validate the separate-client pattern, extend later" is the priority.
-- The only near-term consumer need is ON/OFF switching with corrnr.
-- You want to preserve roadmap-proposal ordering verbatim.
+- **Transport:** `IAbapConnection` only. No RFC, no direct axios.
+- **JSON parsing:** Native `JSON.parse`. Hand-rolled types in `types.ts`. No schema validation library — shape is enforced at assignment and via TS types only.
+- **XML parsing:** `fast-xml-parser` as for the rest of the library.
+- **Content-type constants:** Added to `src/constants/contentTypes.ts` — `ACCEPT_FEATURE_TOGGLE_METADATA`, `CT_FEATURE_TOGGLE_METADATA` (for `blue:blueSource`), `ACCEPT_FEATURE_TOGGLE_STATES`, `ACCEPT_FEATURE_TOGGLE_CHECK_RESULT`, `CT_FEATURE_TOGGLE_CHECK_PARAMETERS`, `CT_FEATURE_TOGGLE_TOGGLE_PARAMETERS`, `CT_FEATURE_TOGGLE_SOURCE` (`application/vnd.sap.adt.toggle.content.v2+json`).
+- **Accept negotiation:** Integrate with the existing `wrapConnectionAcceptNegotiation` wrapper.
+- **Environment gating:** `available_in: ["cloud", "onprem"]` provisionally based on current discovery. `legacy` unsupported. Final gating decided after the implementation plan runs an on-prem write probe.
+- **Transport-request binding:** `switchOn` / `switchOff` **require** `transportRequest` (matches sapcli's required `--corrnr`). Domain methods that don't mutate (`getRuntimeState`, `checkState`, `readSource`) don't need it.
+- **Encoding:** `encodeURIComponent` (equivalent of sapcli's `quote_plus`) on the feature-toggle name segment.
+- **Documentation:** Follow the `#21` pattern — update README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, ADT_OBJECT_ENTITIES, CLAUDE.md count (24 → 25).
+- **Test fixture:** Create a Z-prefixed FT under `ZAC_SHR_PKG`. If cloud trial's JWT-expiry pattern makes create flaky, fall back to `available_in: ["onprem"]` for the create-chain test while keeping `["cloud", "onprem"]` for read-only domain methods.
 
-Pick **C** if:
-- You want one definitive feature-toggle class, not an iterative v1 → v2 → v3.
-- You're budgeted for the discovery work on `logs` / `dependencies` / `objects`.
+## 8. Impact on the roadmap proposal
+
+The roadmap (`2026-04-19-sapcli-separate-clients-proposal.md`) listed `AdtFeatureToggleClient` as roadmap item #1. Accepting Variant A means:
+
+- Feature toggle is **no longer a separate client**. Section 3.3 of the roadmap removed.
+- The recommended PR ordering becomes 4 separate clients (BSP → FLP → abapGit → gCTS) — feature toggle graduates to the same "core module" bucket as `authorizationField` and is released through the ordinary core-module PR workflow.
+- The "pattern baseline" slot the proposal gave to feature toggle now shifts to **BSP** (still small, but its separate-client nature is real — no FTG-like CRUD to promote it to core).
+
+The roadmap proposal document will be amended in the same PR that delivers this spec.
+
+## 9. Verification sources
+
+This design was adjusted after cross-checking against:
+
+- `~/prj/sapcli` — `sap/adt/featuretoggle.py`, `sap/cli/featuretoggle.py`.
+- `docs/discovery/discovery_{cloud_mdd,e19,e77,trial}_raw.xml` + `docs/discovery/endpoints_{cloud_mdd,onprem_modern_e19}.txt`.
+- `src/__tests__/helpers/test-config.yaml.template` — for the `cloud` / `onprem` / `legacy` vocabulary.
+
+Not every claim is discovery-backed to the same degree. Per-environment endpoint divergence (cloud vs E19) is noted in section 3.2; the implementation plan must resolve it (e.g. accept both paths, or restrict to the intersection).
+
+## 10. Open questions for the implementation plan
+
+These do not affect variant selection but need resolution before code lands:
+
+- **Cross-environment sub-resource divergence.** Cloud `dependencies/validate` vs E19 `validation`, cloud `objects` vs E19 `objects/types`. Because analytics endpoints are out of scope for v1, this bites only if we later extend. Decision can wait.
+- **`IAdtClientOptions` vs runtime-style options object.** Per the roadmap-review note #5, `AdtClient` and `AdtRuntimeClient` don't share a contract. This module lives in `src/core/` like the others, so it inherits the existing core-module options shape (no new contract needed); flagged here only for completeness.
+- **Test data lifecycle.** Feature toggles bind to packages; the shared test package `ZAC_SHR_PKG` may or may not permit FTG2/FT creation on every target. Probe during test bring-up; if write is blocked, gate to read-only tests with `available_in: ["onprem"]`.
+- **Source-round-trip fidelity.** The JSON source payload has SAP-maintained fields (LC2_* attribute keys) that may be server-populated after create. Round-trip tests (read after create → compare) likely need field-subset matching, not full equality.
 
 ## 11. Next step
 
-User picks A, B, or C (or a hybrid variant). After selection:
-
-1. Update this document to carry only the chosen variant (prune the other two).
-2. Update `docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md` if the choice was A (since the roadmap placement changes).
-3. Proceed to `writing-plans` skill for the implementation plan.
-
-This document intentionally does not proceed further until the choice is made.
+Invoke `writing-plans` to produce `docs/superpowers/plans/2026-04-19-feature-toggle.md` with task-by-task TDD-oriented implementation.

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -131,7 +131,7 @@ This proposal was adjusted after cross-checking against:
 - `docs/discovery/discovery_{cloud_mdd,e19,e77,trial}_raw.xml` + `docs/discovery/endpoints_{cloud_mdd,onprem_modern_e19,onprem_old_e77}.txt` — live discovery snapshots.
 - `src/__tests__/helpers/test-config.yaml.template` — for the 3-level `cloud` / `onprem` / `legacy` environment vocabulary.
 
-All endpoint paths, content types, and cloud-availability claims in sections 3 and 4 come from these sources. Per-class specs must re-verify their own surface against the same sources, because this proposal compresses evidence — it does not replace it.
+Endpoint paths, content types, and availability claims in sections 3 and 4 are derived from a combination of sapcli references and local discovery snapshots; not every claim is discovery-backed to the same degree. Per-class specs must re-verify their own surface against the same sources, because this proposal compresses evidence — it does not replace it.
 
 ## 10. Next step
 

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -121,6 +121,16 @@ Each spec may independently drop a candidate from scope if verification against 
 - Not a commitment to implement all five. The ordering is a recommendation; at any point after a completed PR the user may stop, reorder, or drop remaining items.
 - Not a schedule. No dates, no velocity estimates. Each class ships when its spec/plan/PR cycle completes.
 
-## 9. Next step
+## 9. Review notes
+
+These notes record mismatches spotted during proposal review so they are resolved before per-class specs lock in the wrong assumptions.
+
+- **Feature toggle endpoint family must be corrected.** The proposal currently says `/sap/bc/adt/feature-toggles/*`, but the local discovery corpus exposes `/sap/bc/adt/sfw/featuretoggles*`. The per-class spec must use the discovery-backed family and not the provisional path written above.
+- **BSP transport assumptions need to be re-verified.** The proposal currently describes BSP as an OData v2 client over `ABAP_REPOSITORY_SRV`, while the local discovery corpus already exposes ADT filestore endpoints under `/sap/bc/adt/filestore/ui5-bsp/*`. Before PR ordering depends on a shared OData helper, the BSP spec must confirm whether the implementation target is ADT filestore, external OData, or a mixed flow.
+- **Environment gating should use the repo's real vocabulary.** Current test/config infrastructure distinguishes `cloud`, `onprem`, and `legacy`, not just "on-prem" vs "cloud". Each per-class spec should explicitly state legacy behaviour (supported, read-only, or unsupported) instead of collapsing everything non-cloud into one bucket.
+- **abapGit cloud availability should not be described as merely speculative.** The local discovery corpus already contains `/sap/bc/adt/abapgit/repos` and `/sap/bc/adt/abapgit/externalrepoinfo` on cloud. The open question is feature parity, not baseline endpoint presence.
+- **Constructor conventions need tighter wording.** `AdtClient` and `AdtRuntimeClient` do not currently expose identical option contracts. Per-class specs should define whether a separate client follows the richer `IAdtClientOptions` shape, a reduced runtime-style options object, or a new shared options contract.
+
+## 10. Next step
 
 After this proposal is accepted, start the spec cycle for **#1: `AdtFeatureToggleClient`** (or a different ordering if the user reprioritises).

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -1,0 +1,126 @@
+# Proposal: Separate ADT clients ported from sapcli
+
+Date: 2026-04-19
+Status: Proposal for per-class scoping and PR ordering
+
+## 1. Goal
+
+Extend `@mcp-abap-adt/adt-clients` with a set of **separate client classes** that wrap capabilities present in `~/prj/sapcli` but absent from the current library. Each capability is a self-contained ADT / OData surface that does not fit the `IAdtObject<Config, State>` per-type CRUD pattern and therefore must live next to `AdtClient` / `AdtRuntimeClient` / `AdtExecutor`, not inside `src/core/`.
+
+This proposal **does not design any individual class**. It lists the candidates, fixes their rough shape, and locks the ordering so each class can be picked up in its own spec → plan → PR cycle later.
+
+## 2. Scope boundaries
+
+- Only features that fit the existing architectural conventions (interface-only connection via `IAbapConnection`, HTTP/ADT over the standard transport, no direct RFC).
+- Only features genuinely distinct from the per-type CRUD handlers under `src/core/`.
+- Out of scope: RFC-based features (STRUST, raw BAPI, RFC user admin) — RFC lives in `@mcp-abap-adt/connection`.
+- Out of scope: anything already covered by `AdtClient` core modules or `AdtRuntimeClient` extensions.
+
+## 3. Candidate classes
+
+All names are working titles; final names may be refined during the per-class brainstorming.
+
+### 3.1 `AdtGctsClient`
+
+- **Purpose:** gCTS (git-enabled CTS) — repository lifecycle on the SAP server-side (clone, pull, push, branch management, commit history).
+- **sapcli references:** `sap/cli/gcts.py`, `sap/rest/gcts/*`.
+- **Endpoint family:** `/sap/bc/cts_abapvcs/repository/{rid}/*`, `/sap/bc/cts_abapvcs/gcts/*`.
+- **Complexity:** Large. Requires async activity-tracking, long-running request handling, structured error parsing for git-specific failures.
+- **Special considerations:**
+  - gCTS responses are JSON, not XML — first non-XML dominant surface in this library.
+  - Operations can be long-running (clone of large repos) → need cancellation / timeout policy.
+  - Authentication for remote git — secrets stored server-side; client must pass credential-pointer, not secrets.
+
+### 3.2 `AdtAbapGitClient`
+
+- **Purpose:** abapGit repositories linked into the SAP system — link, unlink, pull, status, push (where supported), error log retrieval.
+- **sapcli references:** `sap/cli/abapgit.py`, `sap/adt/abapgit.py`.
+- **Endpoint family:** `/sap/bc/adt/abapgit/repos`, per-repo sub-resources.
+- **Complexity:** Medium. Simpler than gCTS but still involves status polling and per-repo operation queueing.
+- **Special considerations:**
+  - Shares surface semantics with gCTS but uses the abapGit app-specific OData/REST instead of the cts_abapvcs handler.
+  - On-prem-only in most systems; cloud variant should be probed during spec stage.
+
+### 3.3 `AdtFeatureToggleClient`
+
+- **Purpose:** Read and toggle state of ABAP feature toggles (`cl_abap_feature*` family), tied to CTS via corrnr.
+- **sapcli references:** `sap/cli/featuretoggle.py`, `sap/adt/featuretoggle.py`.
+- **Endpoint family:** `/sap/bc/adt/feature-toggles/*`.
+- **Complexity:** Small. State machine (off / on / deleted) with corrnr binding.
+- **Special considerations:** Use this class as the **pattern baseline** for "separate client in the current architecture" — small enough to exercise conventions (constructor shape, public API style, test harness wiring) before committing to larger classes.
+
+### 3.4 `AdtFlpBuilderClient`
+
+- **Purpose:** Fiori Launchpad page builder — catalogs, groups, tiles driven by YAML/JSON config.
+- **sapcli references:** `sap/cli/flp.py`, `sap/flp/builder.py`.
+- **Endpoint family:** OData v2 service `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` (+ related).
+- **Complexity:** Small–Medium. Most of the work is mapping YAML → CRUD sequence on known OData entities.
+- **Special considerations:**
+  - OData v2 — first OData v2 consumer in this library. Must decide whether to lean on an existing OData client (if any is already a dev-dep elsewhere) or implement a minimal inline client. Proposal recommends the latter to keep the dependency footprint unchanged.
+
+### 3.5 `AdtBspAppClient`
+
+- **Purpose:** Upload and manage BSP / UI5 applications in the ABAP repository.
+- **sapcli references:** `sap/cli/bsp.py`.
+- **Endpoint family:** UI5 `ABAP_REPOSITORY_SRV` OData v2 service (binary archive as base64 payload).
+- **Complexity:** Small. Straightforward binary-upload + corrnr binding.
+- **Special considerations:** Uses the same OData v2 transport as `AdtFlpBuilderClient` — share the minimal v2 helper between them if we implement one.
+
+## 4. Architectural constraints (shared across all candidates)
+
+All candidate classes must:
+
+- Accept `IAbapConnection` + `ILogger` (and optionally `IAdtSystemContext` / `IAdtClientOptions`) via constructor, matching `AdtClient` / `AdtRuntimeClient` conventions.
+- Depend only on the `IAbapConnection` interface. No RFC, no direct transport.
+- Expose zero-argument factory methods — identity / repo-name / toggle-id lives in config objects, not factory parameters.
+- Live under `src/clients/` (or `src/runtime/` if runtime-adjacent) alongside existing top-level clients, NOT under `src/core/`.
+- Integrate with the existing Accept/content-type correction wrapper when applicable.
+- Ship with integration tests under `src/__tests__/integration/clients/{clientName}/` (new fixture path; no existing folder) using the established `TestConfigResolver` / `BaseTester` helpers where they fit.
+- Add `on-prem` vs `cloud` `available_in` gating from day one (some surfaces are on-prem-only — gCTS cloud story differs from on-prem).
+
+## 5. Recommended PR ordering
+
+One PR per class. Rationale: each endpoint family has its own semantics, auth quirks, and test needs. Bundling would produce a review nightmare.
+
+| Order | Class | Why this slot |
+|---|---|---|
+| 1 | `AdtFeatureToggleClient` | **Pattern baseline.** Small, fast to ship, validates the "separate client in current architecture" contract end-to-end (factory placement, public API style, test harness) before tackling larger scopes. |
+| 2 | `AdtBspAppClient` | Introduces the minimal OData v2 helper that `AdtFlpBuilderClient` can then reuse. Small surface, isolated. |
+| 3 | `AdtFlpBuilderClient` | Reuses the OData v2 helper from #2. |
+| 4 | `AdtAbapGitClient` | Medium scope. Prepares the ground for gCTS (shared repo-lifecycle vocabulary). |
+| 5 | `AdtGctsClient` | Largest scope, most unknowns. Benefits from lessons learned in #1–#4 (async polling, OData helpers, error parsing). |
+
+Each PR is self-contained and independently releasable as a **minor** version bump per semver (new public API, no breaking changes).
+
+## 6. Per-class workflow
+
+For each class in the ordered list:
+
+1. **Spec** — new `docs/superpowers/specs/YYYY-MM-DD-<class-name>-design.md` with:
+   - Verified endpoint list (cross-check sapcli + `docs/discovery/*.xml`)
+   - Public API shape (config types, state types, constructor signature)
+   - Operation chains (any lifecycle / polling logic)
+   - Test strategy and environment gating
+2. **Implementation plan** — `docs/superpowers/plans/YYYY-MM-DD-<class-name>.md` via `writing-plans` skill.
+3. **Execution** — subagent-driven-development (same pattern used for #19).
+4. **PR** — bundled with docs updates (README, CLIENT_API_REFERENCE, ARCHITECTURE, LEGACY, ADT_OBJECT_ENTITIES or equivalent).
+5. **Post-merge** — version bump (minor), CHANGELOG, tag, release. User publishes to npm.
+
+Each spec may independently drop a candidate from scope if verification against discovery/sapcli reveals the endpoint family is unsuitable for the current architecture (e.g. requires RFC, requires a transport the connection layer does not expose, or demands state beyond what `IAbapConnection` supports).
+
+## 7. Risks and open questions
+
+- **JSON vs XML responses.** gCTS is JSON-first. The library has a heavily XML-centric parsing pipeline. Need to decide: per-client JSON handling (simpler) vs shared JSON utility (DRY). Recommendation: per-client for now; extract shared helper only after the second JSON-consuming client appears.
+- **OData v2 surface.** We will consume two OData v2 services (BSP, FLP). Decision on minimal inline helper vs shared utility should be taken in the #2 spec, not here.
+- **Cloud availability matrix.** Several of these surfaces are on-prem-only (gCTS cloud story is partial; abapGit largely on-prem). Each spec must verify cloud availability from `docs/discovery/` and set `available_in` accordingly before implementation.
+- **Test environment.** Some operations (git push / pull, BSP upload) require test fixtures (remote git repos, BSP archives) that do not exist in the current test infrastructure. Each spec must enumerate what fixtures it needs and how they are provisioned.
+
+## 8. What this proposal is not
+
+- Not a design spec for any individual class — those come one per class in their own documents.
+- Not a commitment to implement all five. The ordering is a recommendation; at any point after a completed PR the user may stop, reorder, or drop remaining items.
+- Not a schedule. No dates, no velocity estimates. Each class ships when its spec/plan/PR cycle completes.
+
+## 9. Next step
+
+After this proposal is accepted, start the spec cycle for **#1: `AdtFeatureToggleClient`** (or a different ordering if the user reprioritises).

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -41,13 +41,9 @@ All names are working titles; final names may be refined during the per-class br
   - Shares surface semantics with gCTS but uses the abapGit app-specific handler instead of the cts_abapvcs handler.
   - **Cloud presence verified** in `docs/discovery/discovery_cloud_mdd_raw.xml` and `discovery_trial_raw.xml` (`/sap/bc/adt/abapgit/repos`, `/sap/bc/adt/abapgit/externalrepoinfo`). The open question is feature parity (push, branch management), not baseline endpoint presence.
 
-### 3.3 `AdtFeatureToggleClient`
+### 3.3 ~~`AdtFeatureToggleClient`~~ — graduated to `src/core/featureToggle/`
 
-- **Purpose:** Read and toggle state of ABAP feature toggles (`cl_abap_feature*` family), tied to CTS via corrnr.
-- **sapcli references:** `sap/cli/featuretoggle.py`, `sap/adt/featuretoggle.py`.
-- **Endpoint family:** `/sap/bc/adt/sfw/featuretoggles*` (verified in `docs/discovery/discovery_cloud_mdd_raw.xml`). Sub-resources include per-object access at `{name}{?corrNr,lockHandle,version,accessMode,_action}`, plus `{name}/check`, `{name}/dependencies/validate`, `{name}/logs`, `{name}/objects`, `$configuration`, `$schema`, and `attributes/{attributeKeys,attributeValues}`.
-- **Complexity:** Small. State machine (off / on / deleted) with corrnr binding and standard lock/unlock via the `_action` query parameter.
-- **Special considerations:** Use this class as the **pattern baseline** for "separate client in the current architecture" — small enough to exercise conventions (constructor shape, public API style, test harness wiring) before committing to larger classes.
+**Removed from separate-clients scope.** The per-class design for feature toggle (`docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md`) selected Variant A: feature toggle is a legitimate ADT artifact (`adtcore:type="FTG2/FT"` with packageRef, lock/unlock, activation), and users need both to **create** custom feature toggles and to **switch** their state. The natural home is `src/core/featureToggle/` alongside the other 24 core modules, with domain methods (`switchOn` / `switchOff` / `getRuntimeState` / `checkState` / `readSource`) layered on top of the canonical `IAdtObject` surface. It ships through the ordinary core-module PR workflow, not through this roadmap.
 
 ### 3.4 `AdtFlpBuilderClient`
 
@@ -86,11 +82,12 @@ One PR per class. Rationale: each endpoint family has its own semantics, auth qu
 
 | Order | Class | Why this slot |
 |---|---|---|
-| 1 | `AdtFeatureToggleClient` | **Pattern baseline.** Small, fast to ship, validates the "separate client in current architecture" contract end-to-end (factory placement, public API style, test harness) before tackling larger scopes. |
-| 2 | `AdtBspAppClient` | Introduces the minimal OData v2 helper that `AdtFlpBuilderClient` can then reuse. Small surface, isolated. |
-| 3 | `AdtFlpBuilderClient` | Reuses the OData v2 helper from #2. |
-| 4 | `AdtAbapGitClient` | Medium scope. Prepares the ground for gCTS (shared repo-lifecycle vocabulary). |
-| 5 | `AdtGctsClient` | Largest scope, most unknowns. Benefits from lessons learned in #1–#4 (async polling, OData helpers, error parsing). |
+| 1 | `AdtBspAppClient` | **Pattern baseline.** Small, isolated surface; introduces whatever minimal OData v2 / ADT filestore helper is chosen so `AdtFlpBuilderClient` can reuse it. Validates the "separate client in current architecture" contract end-to-end (factory placement, public API style, test harness). |
+| 2 | `AdtFlpBuilderClient` | Reuses the transport helper from #1. |
+| 3 | `AdtAbapGitClient` | Medium scope. Prepares the ground for gCTS (shared repo-lifecycle vocabulary). |
+| 4 | `AdtGctsClient` | Largest scope, most unknowns. Benefits from lessons learned in #1–#3 (async polling, OData / filestore helpers, error parsing). |
+
+(Feature toggle is no longer in this list — see section 3.3; it ships as a core module.)
 
 Each PR is self-contained and independently releasable as a **minor** version bump per semver (new public API, no breaking changes).
 
@@ -120,7 +117,7 @@ Each spec may independently drop a candidate from scope if verification against 
 ## 8. What this proposal is not
 
 - Not a design spec for any individual class — those come one per class in their own documents.
-- Not a commitment to implement all five. The ordering is a recommendation; at any point after a completed PR the user may stop, reorder, or drop remaining items.
+- Not a commitment to implement all four remaining candidates. The ordering is a recommendation; at any point after a completed PR the user may stop, reorder, or drop remaining items. (Feature toggle graduated to the `src/core/` workflow after its own per-class design chose Variant A.)
 - Not a schedule. No dates, no velocity estimates. Each class ships when its spec/plan/PR cycle completes.
 
 ## 9. Verification sources
@@ -135,4 +132,4 @@ Endpoint paths, content types, and availability claims in sections 3 and 4 are d
 
 ## 10. Next step
 
-After this proposal is accepted, start the spec cycle for **#1: `AdtFeatureToggleClient`** (or a different ordering if the user reprioritises).
+Feature toggle (formerly #1) has been graduated to `src/core/featureToggle/` and moves ahead via the core-module workflow. Next in the separate-clients roadmap: **#1: `AdtBspAppClient`** (or a different ordering if the user reprioritises).

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -76,6 +76,31 @@ All candidate classes must:
 - Ship with integration tests under `src/__tests__/integration/clients/{clientName}/` (new fixture path; no existing folder) using the established `TestConfigResolver` / `BaseTester` helpers where they fit.
 - Use the **3-level environment vocabulary** in `available_in`: `cloud`, `onprem`, `legacy` — matching the existing `test-config.yaml.template` convention (e.g. `["onprem", "legacy"]`, `["legacy"]`). Each per-class spec must explicitly state legacy behaviour (supported, read-only, or unsupported) rather than collapsing it into a single non-cloud bucket.
 
+### 4.1 Variant-selection rule (`A` / `B` / `C`)
+
+Per-class design docs use the same three-variant pattern, but the default choice differs by surface shape:
+
+- **Variant A** fits only when the ADT surface is fundamentally a **repository object** with a real object identity and lifecycle: collection endpoint, object URI, metadata payload, package binding, lock/unlock, activation, source/main or equivalent.
+- **Variant B** is a narrow fallback for a deliberately reduced wrapper. It is acceptable only when v1 intentionally exposes a subset of the surface and explicitly does **not** aim to be the main long-term API.
+- **Variant C** is the default for **separate clients** in this roadmap: service-like, orchestration-heavy, repository-management, OData multi-entity, or long-running operational surfaces that do not naturally map to `IAdtObject<Config, State>`.
+
+Applied to the current roadmap:
+
+- `AdtBspAppClient`: default starting assumption is **Variant C**
+- `AdtFlpBuilderClient`: default starting assumption is **Variant C**
+- `AdtAbapGitClient`: default starting assumption is **Variant C**
+- `AdtGctsClient`: default starting assumption is **Variant C**
+- `FeatureToggle`: selected **Variant A** in its own design doc because the evidence points to a real ADT artifact (`FTG2/FT`) rather than a service-only surface
+
+`~/prj/sapcli` is useful for endpoint traces, headers, payloads, and operation sequences, but **not** as the primary architectural argument for `A` vs `B` vs `C`, because sapcli models many unrelated surfaces as separate manager classes.
+
+### 4.2 Public typing rule
+
+- Every new public class with API beyond a shared base contract must have its own **specialized public interface**.
+- Separate clients therefore expose dedicated interfaces such as `IAdtBspAppClient`, `IAdtFlpBuilderClient`, `IAdtAbapGitClient`, `IAdtGctsClient` (final names decided per spec).
+- Core modules that extend `IAdtObject<Config, State>` with domain methods must expose a specialized interface that extends `IAdtObject<...>` and includes those methods.
+- Factory methods must return the specialized interface, **not** the narrower base type, so the full supported API remains statically visible without casts.
+
 ## 5. Recommended PR ordering
 
 One PR per class. Rationale: each endpoint family has its own semantics, auth quirks, and test needs. Bundling would produce a review nightmare.

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -70,9 +70,10 @@ Kept as paper designs for when investigation resumes:
 
 All candidate classes must:
 
+- **Be standalone top-level classes**, following the existing pattern used by `AdtClient`, `AdtRuntimeClient`, `AdtExecutor`, and `AdtClientsWS`. Users instantiate them directly: `new AdtAbapGitClient(connection, logger, options)`. There is **no** factory method on `AdtClient` — `AdtClient` only produces `IAdtObject<Config, State>` implementations. For every non-`IAdtObject` interface, a separate top-level client class serves as its own factory surface.
 - Accept `IAbapConnection` + `ILogger` via constructor. The **options contract** (`IAdtClientOptions`-style vs a reduced runtime-style object vs a new shared contract) is NOT yet standard across the repo — `AdtClient` and `AdtRuntimeClient` currently differ. Each per-class spec **must explicitly choose** one of these shapes and justify the pick; a cross-cutting decision can happen later if a pattern emerges.
 - Depend only on the `IAbapConnection` interface. No RFC, no direct transport.
-- Expose zero-argument factory methods — identity / repo-name / toggle-id lives in config objects, not factory parameters.
+- Expose zero-argument (or config-object-only) public methods — per-operation identity (repo name, toggle id) lives in the argument objects, not in the constructor or as additional factories.
 - Live under `src/clients/` (or `src/runtime/` if runtime-adjacent) alongside existing top-level clients, NOT under `src/core/`.
 - Integrate with the existing Accept/content-type correction wrapper when applicable.
 - Ship with integration tests under `src/__tests__/integration/clients/{clientName}/` (new fixture path; no existing folder) using the established `TestConfigResolver` / `BaseTester` helpers where they fit.
@@ -101,7 +102,8 @@ Applied to the current roadmap:
 - Every new public class with API beyond a shared base contract must have its own **specialized public interface**.
 - Separate clients therefore expose dedicated interfaces such as `IAdtBspAppClient`, `IAdtFlpBuilderClient`, `IAdtAbapGitClient`, `IAdtGctsClient` (final names decided per spec).
 - Core modules that extend `IAdtObject<Config, State>` with domain methods must expose a specialized interface that extends `IAdtObject<...>` and includes those methods.
-- Factory methods must return the specialized interface, **not** the narrower base type, so the full supported API remains statically visible without casts.
+- **Separate clients are standalone top-level classes**, not factory methods on `AdtClient`. `AdtClient` only manufactures `IAdtObject` implementations. Each separate client's concrete class implements its own specialized interface; consumers `new` the class directly.
+- For core-module domain methods, the (existing) `AdtClient.getXxx()` factory returns the specialized interface (e.g. `IFeatureToggleObject`), not the narrower `IAdtObject<...>` — so the full supported API stays statically visible without casts.
 
 ## 5. Recommended PR ordering
 

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -38,15 +38,15 @@ All names are working titles; final names may be refined during the per-class br
 - **Endpoint family:** `/sap/bc/adt/abapgit/repos`, per-repo sub-resources.
 - **Complexity:** Medium. Simpler than gCTS but still involves status polling and per-repo operation queueing.
 - **Special considerations:**
-  - Shares surface semantics with gCTS but uses the abapGit app-specific OData/REST instead of the cts_abapvcs handler.
-  - On-prem-only in most systems; cloud variant should be probed during spec stage.
+  - Shares surface semantics with gCTS but uses the abapGit app-specific handler instead of the cts_abapvcs handler.
+  - **Cloud presence verified** in `docs/discovery/discovery_cloud_mdd_raw.xml` and `discovery_trial_raw.xml` (`/sap/bc/adt/abapgit/repos`, `/sap/bc/adt/abapgit/externalrepoinfo`). The open question is feature parity (push, branch management), not baseline endpoint presence.
 
 ### 3.3 `AdtFeatureToggleClient`
 
 - **Purpose:** Read and toggle state of ABAP feature toggles (`cl_abap_feature*` family), tied to CTS via corrnr.
 - **sapcli references:** `sap/cli/featuretoggle.py`, `sap/adt/featuretoggle.py`.
-- **Endpoint family:** `/sap/bc/adt/feature-toggles/*`.
-- **Complexity:** Small. State machine (off / on / deleted) with corrnr binding.
+- **Endpoint family:** `/sap/bc/adt/sfw/featuretoggles*` (verified in `docs/discovery/discovery_cloud_mdd_raw.xml`). Sub-resources include per-object access at `{name}{?corrNr,lockHandle,version,accessMode,_action}`, plus `{name}/check`, `{name}/dependencies/validate`, `{name}/logs`, `{name}/objects`, `$configuration`, `$schema`, and `attributes/{attributeKeys,attributeValues}`.
+- **Complexity:** Small. State machine (off / on / deleted) with corrnr binding and standard lock/unlock via the `_action` query parameter.
 - **Special considerations:** Use this class as the **pattern baseline** for "separate client in the current architecture" — small enough to exercise conventions (constructor shape, public API style, test harness wiring) before committing to larger classes.
 
 ### 3.4 `AdtFlpBuilderClient`
@@ -62,21 +62,23 @@ All names are working titles; final names may be refined during the per-class br
 
 - **Purpose:** Upload and manage BSP / UI5 applications in the ABAP repository.
 - **sapcli references:** `sap/cli/bsp.py`.
-- **Endpoint family:** UI5 `ABAP_REPOSITORY_SRV` OData v2 service (binary archive as base64 payload).
-- **Complexity:** Small. Straightforward binary-upload + corrnr binding.
-- **Special considerations:** Uses the same OData v2 transport as `AdtFlpBuilderClient` — share the minimal v2 helper between them if we implement one.
+- **Endpoint family:** Two candidate surfaces to evaluate in the per-class spec:
+  - **ADT filestore** at `/sap/bc/adt/filestore/ui5-bsp/*` (sub-resources `objects`, `deploy-storage`, `ui5-rt-version`) — verified in `docs/discovery/discovery_{cloud_mdd,e19,e77,trial}_raw.xml`. This is the modern ADT-native path.
+  - **External OData v2** via `UI5/ABAP_REPOSITORY_SRV` — the path used by sapcli, still available on systems that expose it.
+- **Complexity:** Small. Straightforward binary-upload + corrnr binding on either surface.
+- **Special considerations:** The per-class spec must pick one surface (or document a mixed flow) **before** deciding whether `AdtFlpBuilderClient` should share an OData v2 helper with BSP — if BSP goes ADT filestore, the helper stops being shared.
 
 ## 4. Architectural constraints (shared across all candidates)
 
 All candidate classes must:
 
-- Accept `IAbapConnection` + `ILogger` (and optionally `IAdtSystemContext` / `IAdtClientOptions`) via constructor, matching `AdtClient` / `AdtRuntimeClient` conventions.
+- Accept `IAbapConnection` + `ILogger` via constructor. The **options contract** (`IAdtClientOptions`-style vs a reduced runtime-style object vs a new shared contract) is NOT yet standard across the repo — `AdtClient` and `AdtRuntimeClient` currently differ. Each per-class spec **must explicitly choose** one of these shapes and justify the pick; a cross-cutting decision can happen later if a pattern emerges.
 - Depend only on the `IAbapConnection` interface. No RFC, no direct transport.
 - Expose zero-argument factory methods — identity / repo-name / toggle-id lives in config objects, not factory parameters.
 - Live under `src/clients/` (or `src/runtime/` if runtime-adjacent) alongside existing top-level clients, NOT under `src/core/`.
 - Integrate with the existing Accept/content-type correction wrapper when applicable.
 - Ship with integration tests under `src/__tests__/integration/clients/{clientName}/` (new fixture path; no existing folder) using the established `TestConfigResolver` / `BaseTester` helpers where they fit.
-- Add `on-prem` vs `cloud` `available_in` gating from day one (some surfaces are on-prem-only — gCTS cloud story differs from on-prem).
+- Use the **3-level environment vocabulary** in `available_in`: `cloud`, `onprem`, `legacy` — matching the existing `test-config.yaml.template` convention (e.g. `["onprem", "legacy"]`, `["legacy"]`). Each per-class spec must explicitly state legacy behaviour (supported, read-only, or unsupported) rather than collapsing it into a single non-cloud bucket.
 
 ## 5. Recommended PR ordering
 
@@ -112,7 +114,7 @@ Each spec may independently drop a candidate from scope if verification against 
 
 - **JSON vs XML responses.** gCTS is JSON-first. The library has a heavily XML-centric parsing pipeline. Need to decide: per-client JSON handling (simpler) vs shared JSON utility (DRY). Recommendation: per-client for now; extract shared helper only after the second JSON-consuming client appears.
 - **OData v2 surface.** We will consume two OData v2 services (BSP, FLP). Decision on minimal inline helper vs shared utility should be taken in the #2 spec, not here.
-- **Cloud availability matrix.** Several of these surfaces are on-prem-only (gCTS cloud story is partial; abapGit largely on-prem). Each spec must verify cloud availability from `docs/discovery/` and set `available_in` accordingly before implementation.
+- **Cloud availability matrix.** The cloud story differs per surface: `abapgit/repos` and `abapgit/externalrepoinfo` are present on cloud MDD and trial; `sfw/featuretoggles*` is present on cloud MDD; `filestore/ui5-bsp/*` is present across all targets. gCTS cloud coverage is partial. Each per-class spec must still verify its specific surface against `docs/discovery/*.xml` and set `available_in` using the 3-level vocabulary (`cloud` / `onprem` / `legacy`) accordingly.
 - **Test environment.** Some operations (git push / pull, BSP upload) require test fixtures (remote git repos, BSP archives) that do not exist in the current test infrastructure. Each spec must enumerate what fixtures it needs and how they are provisioned.
 
 ## 8. What this proposal is not
@@ -121,15 +123,15 @@ Each spec may independently drop a candidate from scope if verification against 
 - Not a commitment to implement all five. The ordering is a recommendation; at any point after a completed PR the user may stop, reorder, or drop remaining items.
 - Not a schedule. No dates, no velocity estimates. Each class ships when its spec/plan/PR cycle completes.
 
-## 9. Review notes
+## 9. Verification sources
 
-These notes record mismatches spotted during proposal review so they are resolved before per-class specs lock in the wrong assumptions.
+This proposal was adjusted after cross-checking against:
 
-- **Feature toggle endpoint family must be corrected.** The proposal currently says `/sap/bc/adt/feature-toggles/*`, but the local discovery corpus exposes `/sap/bc/adt/sfw/featuretoggles*`. The per-class spec must use the discovery-backed family and not the provisional path written above.
-- **BSP transport assumptions need to be re-verified.** The proposal currently describes BSP as an OData v2 client over `ABAP_REPOSITORY_SRV`, while the local discovery corpus already exposes ADT filestore endpoints under `/sap/bc/adt/filestore/ui5-bsp/*`. Before PR ordering depends on a shared OData helper, the BSP spec must confirm whether the implementation target is ADT filestore, external OData, or a mixed flow.
-- **Environment gating should use the repo's real vocabulary.** Current test/config infrastructure distinguishes `cloud`, `onprem`, and `legacy`, not just "on-prem" vs "cloud". Each per-class spec should explicitly state legacy behaviour (supported, read-only, or unsupported) instead of collapsing everything non-cloud into one bucket.
-- **abapGit cloud availability should not be described as merely speculative.** The local discovery corpus already contains `/sap/bc/adt/abapgit/repos` and `/sap/bc/adt/abapgit/externalrepoinfo` on cloud. The open question is feature parity, not baseline endpoint presence.
-- **Constructor conventions need tighter wording.** `AdtClient` and `AdtRuntimeClient` do not currently expose identical option contracts. Per-class specs should define whether a separate client follows the richer `IAdtClientOptions` shape, a reduced runtime-style options object, or a new shared options contract.
+- `~/prj/sapcli` — reference implementation, especially `sap/cli/{gcts,abapgit,featuretoggle,flp,bsp}.py` and corresponding `sap/adt/*.py` modules.
+- `docs/discovery/discovery_{cloud_mdd,e19,e77,trial}_raw.xml` + `docs/discovery/endpoints_{cloud_mdd,onprem_modern_e19,onprem_old_e77}.txt` — live discovery snapshots.
+- `src/__tests__/helpers/test-config.yaml.template` — for the 3-level `cloud` / `onprem` / `legacy` environment vocabulary.
+
+All endpoint paths, content types, and cloud-availability claims in sections 3 and 4 come from these sources. Per-class specs must re-verify their own surface against the same sources, because this proposal compresses evidence — it does not replace it.
 
 ## 10. Next step
 

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -45,23 +45,26 @@ All names are working titles; final names may be refined during the per-class br
 
 **Removed from separate-clients scope.** The per-class design for feature toggle (`docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md`) selected Variant A: feature toggle is a legitimate ADT artifact (`adtcore:type="FTG2/FT"` with packageRef, lock/unlock, activation), and users need both to **create** custom feature toggles and to **switch** their state. The natural home is `src/core/featureToggle/` alongside the other 24 core modules, with domain methods (`switchOn` / `switchOff` / `getRuntimeState` / `checkState` / `readSource`) layered on top of the canonical `IAdtObject` surface. It ships through the ordinary core-module PR workflow, not through this roadmap.
 
-### 3.4 `AdtFlpBuilderClient` — DEFERRED
+### 3.4–3.5 UI-tier group (BSP + FLP) — PENDING INVESTIGATION
 
-**Not in near-term scope.** Fiori Launchpad page-builder customisation (catalogs, groups, tiles via YAML → OData v2 on `UI2/PAGE_BUILDER_CUST`) is niche; no current user workflow demands it. Reactivate only on concrete demand. Original details preserved below for future reference.
+**Not shipped to production until a concrete consumer workflow justifies them.** Both surfaces concern UI-tier artifacts (Fiori app upload via BSP; Fiori Launchpad page-builder customisation via FLP) and neither has a proven demand from the library's current user base. They form one group because they share the same constraint: we don't yet know **what we actually need from them**. Each may be reactivated, reshaped, or dropped outright once a real use-case surfaces.
+
+Kept as paper designs for when investigation resumes:
+
+#### 3.4 `AdtFlpBuilderClient`
 
 - **Purpose:** Fiori Launchpad page builder — catalogs, groups, tiles driven by YAML/JSON config.
 - **sapcli references:** `sap/cli/flp.py`, `sap/flp/builder.py`.
 - **Endpoint family:** OData v2 service `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` (+ related).
 
-### 3.5 `AdtBspAppClient` — DEFERRED
-
-**Not in near-term scope.** Covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline — the archive must be pre-built by external tooling (ui5 CLI, webpack, vite). Useful when build-tool integration becomes in-scope or a user workflow explicitly requires BSP upload. Per-class three-variant design already written: `docs/superpowers/specs/2026-04-19-bsp-app-client-design.md`. Reactivate from there.
+#### 3.5 `AdtBspAppClient`
 
 - **Purpose:** Upload and manage BSP / UI5 applications in the ABAP repository.
 - **sapcli references:** `sap/cli/bsp.py`.
-- **Endpoint family:** Two candidate surfaces (see per-class design):
+- **Endpoint family:** Two candidate surfaces (see per-class design `docs/superpowers/specs/2026-04-19-bsp-app-client-design.md`):
   - **ADT filestore** at `/sap/bc/adt/filestore/ui5-bsp/*` — discovery-verified on all targets including E77 legacy.
   - **External OData v2** via `UI5/ABAP_REPOSITORY_SRV` — the sapcli-documented path.
+- **Limitation noted during review:** BSP covers only the final "upload zip → BSP namespace" step; the archive must be pre-built by external tooling (ui5 CLI, webpack, vite). A meaningful BSP client needs an accompanying build-integration story that is out of scope for this library.
 
 ## 4. Architectural constraints (shared across all candidates)
 

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -45,24 +45,23 @@ All names are working titles; final names may be refined during the per-class br
 
 **Removed from separate-clients scope.** The per-class design for feature toggle (`docs/superpowers/specs/2026-04-19-feature-toggle-client-design.md`) selected Variant A: feature toggle is a legitimate ADT artifact (`adtcore:type="FTG2/FT"` with packageRef, lock/unlock, activation), and users need both to **create** custom feature toggles and to **switch** their state. The natural home is `src/core/featureToggle/` alongside the other 24 core modules, with domain methods (`switchOn` / `switchOff` / `getRuntimeState` / `checkState` / `readSource`) layered on top of the canonical `IAdtObject` surface. It ships through the ordinary core-module PR workflow, not through this roadmap.
 
-### 3.4 `AdtFlpBuilderClient`
+### 3.4 `AdtFlpBuilderClient` — DEFERRED
+
+**Not in near-term scope.** Fiori Launchpad page-builder customisation (catalogs, groups, tiles via YAML → OData v2 on `UI2/PAGE_BUILDER_CUST`) is niche; no current user workflow demands it. Reactivate only on concrete demand. Original details preserved below for future reference.
 
 - **Purpose:** Fiori Launchpad page builder — catalogs, groups, tiles driven by YAML/JSON config.
 - **sapcli references:** `sap/cli/flp.py`, `sap/flp/builder.py`.
 - **Endpoint family:** OData v2 service `/sap/opu/odata/UI2/PAGE_BUILDER_CUST` (+ related).
-- **Complexity:** Small–Medium. Most of the work is mapping YAML → CRUD sequence on known OData entities.
-- **Special considerations:**
-  - OData v2 — first OData v2 consumer in this library. Must decide whether to lean on an existing OData client (if any is already a dev-dep elsewhere) or implement a minimal inline client. Proposal recommends the latter to keep the dependency footprint unchanged.
 
-### 3.5 `AdtBspAppClient`
+### 3.5 `AdtBspAppClient` — DEFERRED
+
+**Not in near-term scope.** Covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline — the archive must be pre-built by external tooling (ui5 CLI, webpack, vite). Useful when build-tool integration becomes in-scope or a user workflow explicitly requires BSP upload. Per-class three-variant design already written: `docs/superpowers/specs/2026-04-19-bsp-app-client-design.md`. Reactivate from there.
 
 - **Purpose:** Upload and manage BSP / UI5 applications in the ABAP repository.
 - **sapcli references:** `sap/cli/bsp.py`.
-- **Endpoint family:** Two candidate surfaces to evaluate in the per-class spec:
-  - **ADT filestore** at `/sap/bc/adt/filestore/ui5-bsp/*` (sub-resources `objects`, `deploy-storage`, `ui5-rt-version`) — verified in `docs/discovery/discovery_{cloud_mdd,e19,e77,trial}_raw.xml`. This is the modern ADT-native path.
-  - **External OData v2** via `UI5/ABAP_REPOSITORY_SRV` — the path used by sapcli, still available on systems that expose it.
-- **Complexity:** Small. Straightforward binary-upload + corrnr binding on either surface.
-- **Special considerations:** The per-class spec must pick one surface (or document a mixed flow) **before** deciding whether `AdtFlpBuilderClient` should share an OData v2 helper with BSP — if BSP goes ADT filestore, the helper stops being shared.
+- **Endpoint family:** Two candidate surfaces (see per-class design):
+  - **ADT filestore** at `/sap/bc/adt/filestore/ui5-bsp/*` — discovery-verified on all targets including E77 legacy.
+  - **External OData v2** via `UI5/ABAP_REPOSITORY_SRV` — the sapcli-documented path.
 
 ## 4. Architectural constraints (shared across all candidates)
 
@@ -86,10 +85,10 @@ Per-class design docs use the same three-variant pattern, but the default choice
 
 Applied to the current roadmap:
 
-- `AdtBspAppClient`: default starting assumption is **Variant C**
-- `AdtFlpBuilderClient`: default starting assumption is **Variant C**
 - `AdtAbapGitClient`: default starting assumption is **Variant C**
 - `AdtGctsClient`: default starting assumption is **Variant C**
+- `AdtBspAppClient`: default starting assumption is **Variant C** — **deferred** (see §3.5)
+- `AdtFlpBuilderClient`: default starting assumption is **Variant C** — **deferred** (see §3.4)
 - `FeatureToggle`: selected **Variant A** in its own design doc because the evidence points to a real ADT artifact (`FTG2/FT`) rather than a service-only surface
 
 `~/prj/sapcli` is useful for endpoint traces, headers, payloads, and operation sequences, but **not** as the primary architectural argument for `A` vs `B` vs `C`, because sapcli models many unrelated surfaces as separate manager classes.
@@ -107,10 +106,10 @@ One PR per class. Rationale: each endpoint family has its own semantics, auth qu
 
 | Order | Class | Why this slot |
 |---|---|---|
-| 1 | `AdtBspAppClient` | **Pattern baseline.** Small, isolated surface; introduces whatever minimal OData v2 / ADT filestore helper is chosen so `AdtFlpBuilderClient` can reuse it. Validates the "separate client in current architecture" contract end-to-end (factory placement, public API style, test harness). |
-| 2 | `AdtFlpBuilderClient` | Reuses the transport helper from #1. |
-| 3 | `AdtAbapGitClient` | Medium scope. Prepares the ground for gCTS (shared repo-lifecycle vocabulary). |
-| 4 | `AdtGctsClient` | Largest scope, most unknowns. Benefits from lessons learned in #1–#3 (async polling, OData / filestore helpers, error parsing). |
+| 1 | `AdtAbapGitClient` | **Pattern baseline.** Widest everyday use-case (ABAP source version control); discovery-verified on cloud + on-prem; medium scope. Validates the "separate client in current architecture" contract end-to-end (factory placement, public API style, test harness) with a broadly-useful feature rather than a niche one. |
+| 2 | `AdtGctsClient` | Largest scope, most unknowns, but complements #1 — abapGit is VCS, gCTS is transport-system-with-git. Different workloads, different audiences. Benefits from lessons learned in #1 (async polling, repo-lifecycle vocabulary, error parsing). |
+| (deferred) | `AdtBspAppClient` | Covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline (archive must be pre-built by external tooling). See `2026-04-19-bsp-app-client-design.md` (Deferred). Reactivate when build-tool integration becomes in-scope or a user workflow explicitly requires BSP upload. |
+| (deferred) | `AdtFlpBuilderClient` | Fiori Launchpad page-builder customisation is even narrower than BSP. Deferred alongside BSP — reactivate only if a concrete consumer workflow demands it. |
 
 (Feature toggle is no longer in this list — see section 3.3; it ships as a core module.)
 
@@ -157,4 +156,4 @@ Endpoint paths, content types, and availability claims in sections 3 and 4 are d
 
 ## 10. Next step
 
-Feature toggle (formerly #1) has been graduated to `src/core/featureToggle/` and moves ahead via the core-module workflow. Next in the separate-clients roadmap: **#1: `AdtBspAppClient`** (or a different ordering if the user reprioritises).
+Feature toggle graduated to `src/core/featureToggle/` and moves ahead via the core-module workflow. BSP and FLP have been deferred (see §3.4, §3.5). Next in the separate-clients roadmap: **#1: `AdtAbapGitClient`** — broadest everyday use-case and discovery-verified on cloud + on-prem.

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -1,7 +1,9 @@
 # Proposal: Separate ADT clients ported from sapcli
 
 Date: 2026-04-19 (last updated 2026-04-20)
-Status: Active queue empty — featureToggle graduated (v5.3.0), abapGit shipped (v5.4.0), BSP+FLP deferred, gCTS out of scope
+Status: Active queue empty — featureToggle graduated (v5.3.0), abapGit shipped (v5.4.0), BSP+FLP deferred pending investigation, gCTS extracted to a separate repo (`fr0ster/mcp-abap-adt-gcts-client`, private).
+
+> **About this branch.** `proposal/sapcli-separate-clients` remains open as a working document for the two **deferred** candidates (BSP + FLP). Reactivation of either requires a concrete consumer workflow. The branch is not on a merge path; it is a pending-investigation log. See §3.4 and §3.5 for the deferral rationale. gCTS has moved out of this repository — see `fr0ster/mcp-abap-adt-gcts-client` for future work.
 
 ## 1. Goal
 

--- a/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
+++ b/docs/superpowers/specs/2026-04-19-sapcli-separate-clients-proposal.md
@@ -1,7 +1,7 @@
 # Proposal: Separate ADT clients ported from sapcli
 
-Date: 2026-04-19
-Status: Proposal for per-class scoping and PR ordering
+Date: 2026-04-19 (last updated 2026-04-20)
+Status: Active queue empty — featureToggle graduated (v5.3.0), abapGit shipped (v5.4.0), BSP+FLP deferred, gCTS out of scope
 
 ## 1. Goal
 
@@ -20,16 +20,24 @@ This proposal **does not design any individual class**. It lists the candidates,
 
 All names are working titles; final names may be refined during the per-class brainstorming.
 
-### 3.1 `AdtGctsClient`
+### 3.1 ~~`AdtGctsClient`~~ — OUT OF SCOPE for this library
 
-- **Purpose:** gCTS (git-enabled CTS) — repository lifecycle on the SAP server-side (clone, pull, push, branch management, commit history).
-- **sapcli references:** `sap/cli/gcts.py`, `sap/rest/gcts/*`.
-- **Endpoint family:** `/sap/bc/cts_abapvcs/repository/{rid}/*`, `/sap/bc/cts_abapvcs/gcts/*`.
-- **Complexity:** Large. Requires async activity-tracking, long-running request handling, structured error parsing for git-specific failures.
-- **Special considerations:**
-  - gCTS responses are JSON, not XML — first non-XML dominant surface in this library.
-  - Operations can be long-running (clone of large repos) → need cancellation / timeout policy.
-  - Authentication for remote git — secrets stored server-side; client must pass credential-pointer, not secrets.
+**Removed from the sapcli-separate-clients roadmap.** gCTS is **not** an ADT service — it lives under `/sap/bc/cts_abapvcs/*`, a separate REST service family that is deliberately absent from every ADT discovery snapshot captured in `docs/discovery/`. Shipping it inside `@mcp-abap-adt/adt-clients` would violate the package's stated scope ("ADT clients for SAP ABAP systems").
+
+Surface facts for the record:
+
+- sapcli references: `sap/cli/gcts.py` (~1060 lines) + `sap/rest/gcts/*` (7 modules).
+- Endpoint family: `/sap/bc/cts_abapvcs/repository/{rid}/*`, `/sap/bc/cts_abapvcs/config/*`, `/sap/bc/cts_abapvcs/system/*`, plus repo-task endpoints and activity-tracking.
+- JSON-only responses (not XML); async activity-tracking; long-running operations; server-side credential pointers for remote git.
+- sapcli-parity v1 would expose ~30 commands (clone, checkout, commit, push, pull, delete, list/create/delete branch, config, user credentials, system config, messages, objects, activities, tasks, repolist, history, etc.).
+
+**If gCTS support is wanted, it belongs in a separate repository with its own npm package** (working title `@mcp-abap-adt/gcts-client` under a repo of its own). That repo would:
+
+- Reuse the existing `IAbapConnection` interface as a peer dependency for transport.
+- Own its own specs, roadmap, PR flow, CI, and release cadence — independent of `@mcp-abap-adt/adt-clients`.
+- Not pretend to be ADT; its scope would be gCTS (`/sap/bc/cts_abapvcs/*`) and any related non-ADT CTS-over-git surfaces.
+
+Brainstorming, spec-writing, and implementation for `@mcp-abap-adt/gcts-client`, if and when it starts, happen in that separate repository — not in this one.
 
 ### 3.2 `AdtAbapGitClient`
 
@@ -89,10 +97,10 @@ Per-class design docs use the same three-variant pattern, but the default choice
 
 Applied to the current roadmap:
 
-- `AdtAbapGitClient`: default starting assumption is **Variant C**
-- `AdtGctsClient`: default starting assumption is **Variant C**
+- `AdtAbapGitClient`: default starting assumption was **Variant C** — **shipped** (v5.4.0)
 - `AdtBspAppClient`: default starting assumption is **Variant C** — **deferred** (see §3.5)
 - `AdtFlpBuilderClient`: default starting assumption is **Variant C** — **deferred** (see §3.4)
+- ~~`AdtGctsClient`~~: **out of scope** (see §3.1) — would be a separate sibling repo
 - `FeatureToggle`: selected **Variant A** in its own design doc because the evidence points to a real ADT artifact (`FTG2/FT`) rather than a service-only surface
 
 `~/prj/sapcli` is useful for endpoint traces, headers, payloads, and operation sequences, but **not** as the primary architectural argument for `A` vs `B` vs `C`, because sapcli models many unrelated surfaces as separate manager classes.
@@ -100,7 +108,7 @@ Applied to the current roadmap:
 ### 4.2 Public typing rule
 
 - Every new public class with API beyond a shared base contract must have its own **specialized public interface**.
-- Separate clients therefore expose dedicated interfaces such as `IAdtBspAppClient`, `IAdtFlpBuilderClient`, `IAdtAbapGitClient`, `IAdtGctsClient` (final names decided per spec).
+- Separate clients therefore expose dedicated interfaces such as `IAdtBspAppClient`, `IAdtFlpBuilderClient`, `IAdtAbapGitClient` (final names decided per spec).
 - Core modules that extend `IAdtObject<Config, State>` with domain methods must expose a specialized interface that extends `IAdtObject<...>` and includes those methods.
 - **Separate clients are standalone top-level classes**, not factory methods on `AdtClient`. `AdtClient` only manufactures `IAdtObject` implementations. Each separate client's concrete class implements its own specialized interface; consumers `new` the class directly.
 - For core-module domain methods, the (existing) `AdtClient.getXxx()` factory returns the specialized interface (e.g. `IFeatureToggleObject`), not the narrower `IAdtObject<...>` — so the full supported API stays statically visible without casts.
@@ -109,14 +117,16 @@ Applied to the current roadmap:
 
 One PR per class. Rationale: each endpoint family has its own semantics, auth quirks, and test needs. Bundling would produce a review nightmare.
 
-| Order | Class | Why this slot |
+| Order | Class | Status |
 |---|---|---|
-| 1 | `AdtAbapGitClient` | **Pattern baseline.** Widest everyday use-case (ABAP source version control); discovery-verified on cloud + on-prem; medium scope. Validates the "separate client in current architecture" contract end-to-end (factory placement, public API style, test harness) with a broadly-useful feature rather than a niche one. |
-| 2 | `AdtGctsClient` | Largest scope, most unknowns, but complements #1 — abapGit is VCS, gCTS is transport-system-with-git. Different workloads, different audiences. Benefits from lessons learned in #1 (async polling, repo-lifecycle vocabulary, error parsing). |
-| (deferred) | `AdtBspAppClient` | Covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline (archive must be pre-built by external tooling). See `2026-04-19-bsp-app-client-design.md` (Deferred). Reactivate when build-tool integration becomes in-scope or a user workflow explicitly requires BSP upload. |
-| (deferred) | `AdtFlpBuilderClient` | Fiori Launchpad page-builder customisation is even narrower than BSP. Deferred alongside BSP — reactivate only if a concrete consumer workflow demands it. |
+| shipped | `AdtAbapGitClient` | v5.4.0 — standalone top-level client, see §3.2 |
+| (deferred) | `AdtBspAppClient` | Covers only the final "upload zip → BSP namespace" step of a longer UI5/Fiori deploy pipeline. UI-tier investigation group, §3.5. |
+| (deferred) | `AdtFlpBuilderClient` | Fiori Launchpad page-builder customisation. UI-tier investigation group, §3.4. |
+| (out of scope) | ~~`AdtGctsClient`~~ | Non-ADT service at `/sap/bc/cts_abapvcs/*`. Belongs in a separate repo with its own package. See §3.1. |
 
-(Feature toggle is no longer in this list — see section 3.3; it ships as a core module.)
+Feature toggle is no longer in this list — see the old §3.3 (removed); it shipped as a core module in v5.3.0.
+
+With `AdtAbapGitClient` shipped, the active queue of this roadmap is **empty**: all remaining candidates are either deferred (BSP, FLP) or out of scope (gCTS). Reactivation of any deferred candidate happens on explicit user demand.
 
 Each PR is self-contained and independently releasable as a **minor** version bump per semver (new public API, no breaking changes).
 
@@ -138,15 +148,15 @@ Each spec may independently drop a candidate from scope if verification against 
 
 ## 7. Risks and open questions
 
-- **JSON vs XML responses.** gCTS is JSON-first. The library has a heavily XML-centric parsing pipeline. Need to decide: per-client JSON handling (simpler) vs shared JSON utility (DRY). Recommendation: per-client for now; extract shared helper only after the second JSON-consuming client appears.
+- **JSON vs XML responses.** Feature toggle already introduced per-module JSON handling for `source/main` + state/check endpoints. Further JSON-heavy clients would push for a shared JSON helper; per-client remains the default until a second one lands. (gCTS — originally flagged as the second JSON-first candidate — is out of scope for this repo, see §3.1.)
 - **OData v2 surface.** We will consume two OData v2 services (BSP, FLP). Decision on minimal inline helper vs shared utility should be taken in the #2 spec, not here.
-- **Cloud availability matrix.** The cloud story differs per surface: `abapgit/repos` and `abapgit/externalrepoinfo` are present on cloud MDD and trial; `sfw/featuretoggles*` is present on cloud MDD; `filestore/ui5-bsp/*` is present across all targets. gCTS cloud coverage is partial. Each per-class spec must still verify its specific surface against `docs/discovery/*.xml` and set `available_in` using the 3-level vocabulary (`cloud` / `onprem` / `legacy`) accordingly.
+- **Cloud availability matrix.** The cloud story differs per surface: `abapgit/repos` and `abapgit/externalrepoinfo` are present on cloud MDD and trial; `sfw/featuretoggles*` is present on cloud MDD; `filestore/ui5-bsp/*` is present across all targets. Each per-class spec must still verify its specific surface against `docs/discovery/*.xml` and set `available_in` using the 3-level vocabulary (`cloud` / `onprem` / `legacy`) accordingly.
 - **Test environment.** Some operations (git push / pull, BSP upload) require test fixtures (remote git repos, BSP archives) that do not exist in the current test infrastructure. Each spec must enumerate what fixtures it needs and how they are provisioned.
 
 ## 8. What this proposal is not
 
 - Not a design spec for any individual class — those come one per class in their own documents.
-- Not a commitment to implement all four remaining candidates. The ordering is a recommendation; at any point after a completed PR the user may stop, reorder, or drop remaining items. (Feature toggle graduated to the `src/core/` workflow after its own per-class design chose Variant A.)
+- Not a commitment to implement all listed candidates. The ordering was a recommendation; at any point after a completed PR the user may stop, reorder, or drop remaining items. Final disposition (post-execution): featureToggle graduated to `src/core/`, abapGit shipped, BSP and FLP deferred as the UI-tier investigation group, gCTS moved out of scope (separate repo if ever built).
 - Not a schedule. No dates, no velocity estimates. Each class ships when its spec/plan/PR cycle completes.
 
 ## 9. Verification sources
@@ -161,4 +171,11 @@ Endpoint paths, content types, and availability claims in sections 3 and 4 are d
 
 ## 10. Next step
 
-Feature toggle graduated to `src/core/featureToggle/` and moves ahead via the core-module workflow. BSP and FLP have been deferred (see §3.4, §3.5). Next in the separate-clients roadmap: **#1: `AdtAbapGitClient`** — broadest everyday use-case and discovery-verified on cloud + on-prem.
+Roadmap execution summary:
+
+- **Graduated:** `featureToggle` → `src/core/featureToggle/` (shipped in v5.3.0 via the ordinary core-module workflow).
+- **Shipped:** `AdtAbapGitClient` (v5.4.0).
+- **Deferred:** `AdtBspAppClient`, `AdtFlpBuilderClient` — UI-tier investigation group (§3.4, §3.5). Not scheduled.
+- **Out of scope:** `AdtGctsClient` (§3.1). If needed, it goes into a separate repo with its own npm package (`@mcp-abap-adt/gcts-client`).
+
+The active queue of this roadmap is **empty**. No further per-class work planned under this proposal unless a deferred candidate is reactivated or a new candidate surfaces.


### PR DESCRIPTION
## Summary
Roadmap document listing five candidate client classes to port from the `~/prj/sapcli` reference implementation as separate facades next to `AdtClient` / `AdtRuntimeClient` / `AdtExecutor`. Each class will receive its own design spec, implementation plan, and PR.

**Candidates (in recommended PR order):**
1. `AdtFeatureToggleClient` — pattern baseline, smallest scope
2. `AdtBspAppClient` — introduces minimal OData v2 helper
3. `AdtFlpBuilderClient` — reuses OData v2 helper from #2
4. `AdtAbapGitClient` — medium scope, preparation for gCTS
5. `AdtGctsClient` — largest scope, last to ship

## Review notes section
The document includes a `## 9. Review notes` section capturing five mismatches spotted during review and verified against `docs/discovery/*.xml`:
- Feature toggle endpoint family → `sfw/featuretoggles` (not `feature-toggles`)
- BSP target → ADT `filestore/ui5-bsp/*` is available and should be considered, not just external OData
- Environment gating → use the 3-level `cloud` / `onprem` / `legacy` vocabulary actually used by `test-config.yaml`
- abapGit cloud presence → verified in discovery, not speculative
- Constructor options → per-class decision required; `AdtClient` vs `AdtRuntimeClient` don't share a single contract

Per-class specs will resolve these before locking in wrong assumptions.

## Test plan
- [x] Discovery cross-check: all endpoint corrections validated against `docs/discovery/discovery_{cloud_mdd,e19,e77,trial}_raw.xml`
- [x] Environment vocabulary cross-check: `["legacy"]` and `["onprem", "legacy"]` confirmed in `test-config.yaml.template`
- [x] No code changes; pure roadmap document

## Scope
- Not a design for any individual class — those come one per class in their own specs
- Not a commitment to implement all five — ordering is a recommendation, user may stop/reorder/drop at any point

🤖 Generated with [Claude Code](https://claude.com/claude-code)