### PR TITLE
chore: release 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.3.0] - 2026-04-19
 
 ### Added
 
 - **featureToggle** core module: FTG2/FT type handler with full CRUD + lifecycle, plus five domain methods (switchOn, switchOff, getRuntimeState, checkState, readSource) through the specialized IFeatureToggleObject interface. New AdtClient.getFeatureToggle() factory. Endpoint /sap/bc/adt/sfw/featuretoggles/{name}. Hybrid XML metadata + JSON source payload — first JSON-source-bearing core module. Available on modern on-prem and cloud MDD; absent on legacy kernels. (#27)
+
+### Documentation
+
+- Expanded CLIENT_API_REFERENCE featureToggle section with full coverage of all five domain methods, realistic source-body example, update semantics, and an environment-matrix table (modern on-prem / cloud / legacy). (#28)
 
 ## [5.2.1] - 2026-04-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.2.1",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Minor release bundling #27 (featureToggle core module) and #28 (CLIENT_API_REFERENCE expansion).

- Bump `package.json` version: 5.2.1 → 5.3.0 (minor — new public API, no breaking changes)
- Regenerate `package-lock.json` (0 `"link": true` entries)
- Promote `## [Unreleased]` CHANGELOG section to `## [5.3.0] - 2026-04-19` with entries for both #27 (Added) and #28 (Documentation)

## Test plan
- [x] `npm install --package-lock-only` — clean
- [x] Version alignment: package.json + CHANGELOG
- [x] Release assembles only merged, previously-reviewed PRs

After merge: tag `v5.3.0` and `npm publish` (user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)