### PR TITLE
chore: release 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.4.0] - 2026-04-20
 
 ### Added
 
-- **AdtAbapGitClient** — standalone top-level client (not a factory on AdtClient) wrapping the SAP-official ADT-integrated abapGit (`/sap/bc/adt/abapgit/*`). Covers link, pull (with async status polling and an abort/timeout recovery contract that attaches `lastKnownStatus` to thrown errors), unlink (via `DELETE /repos/{key}`), listRepos, getRepo, getErrorLog, and checkExternalRepo (pre-link probe with access mode and branch list). Specialized `IAdtAbapGitClient` interface. Available on SAP BTP ABAP Environment / cloud and modern on-prem from ABAP Platform 2022+; absent on legacy kernels. (#XX — PR number TBD at merge time)
+- **AdtAbapGitClient** — standalone top-level client (not a factory on AdtClient) wrapping the SAP-official ADT-integrated abapGit (`/sap/bc/adt/abapgit/*`). Covers link, pull (with async status polling and an abort/timeout recovery contract that attaches `lastKnownStatus` to thrown errors), unlink (via `DELETE /repos/{key}`), listRepos, getRepo, getErrorLog, and checkExternalRepo (pre-link probe with access mode and branch list). Specialized `IAdtAbapGitClient` interface. Available on SAP BTP ABAP Environment / cloud and modern on-prem from ABAP Platform 2022+; absent on legacy kernels. (#30)
 
 ## [5.3.0] - 2026-04-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Minor release bundling #30 (AdtAbapGitClient).

- Bump `package.json` version: 5.3.0 → 5.4.0 (minor — new public API, no breaking changes)
- Regenerate `package-lock.json` (0 `"link": true` entries)
- Promote `## [Unreleased]` CHANGELOG section to `## [5.4.0] - 2026-04-20`

## Test plan
- [x] `npm install --package-lock-only` — clean
- [x] Version alignment: package.json + CHANGELOG
- [x] Release assembles only merged, previously-reviewed PR (#30)

After merge: tag `v5.4.0` and `npm publish` (user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)