### PR TITLE
chore: release 5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.1] - 2026-04-20
+
+### Fixed
+
+- `tools/adt-object-entities.js` now enumerates standalone top-level clients under `src/clients/` (AdtAbapGitClient, AdtRuntimeClient, AdtExecutor, AdtClientsWS, DebuggerSessionClient). Previously the generator only scanned `src/core/*` and `AdtClient.ts`, so clients added as non-IAdtObject siblings were invisible in `docs/usage/ADT_OBJECT_ENTITIES.md`. Regenerated. (#32)
+
 ## [5.4.0] - 2026-04-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Patch release bundling #32 (ADT_OBJECT_ENTITIES generator fix).

- Bump `package.json` version: 5.4.0 → 5.4.1 (patch — docs-tooling fix, no runtime change)
- Regenerate `package-lock.json`
- Promote CHANGELOG entry as `## [5.4.1] - 2026-04-20` under **Fixed**.

## Test plan
- [x] `npm install --package-lock-only` — clean
- [x] Version alignment: package.json + CHANGELOG
- [x] Release assembles only merged, previously-reviewed PR (#32)

After merge: tag `v5.4.1` and `npm publish` (user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)