### PR TITLE
fix(accessControl): tolerate transient has_errors=true with empty errors (#20)

### DIFF
--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -317,6 +317,7 @@ export class AdtAccessControl
           config.accessControlName,
           'inactive',
           codeToCheck,
+          this.logger,
         );
         this.logger?.info?.('Check inactive with update content passed');
       }
@@ -373,6 +374,8 @@ export class AdtAccessControl
         this.connection,
         config.accessControlName,
         'inactive',
+        undefined,
+        this.logger,
       );
       this.logger?.info?.('Final check passed');
 
@@ -552,6 +555,8 @@ export class AdtAccessControl
       this.connection,
       config.accessControlName,
       version,
+      undefined,
+      this.logger,
     );
     return state;
   }

--- a/src/core/accessControl/check.ts
+++ b/src/core/accessControl/check.ts
@@ -1,32 +1,71 @@
 import type {
   IAdtResponse as AxiosResponse,
   IAbapConnection,
+  ILogger,
 } from '@mcp-abap-adt/interfaces';
 import { parseCheckRunResponse, runCheckRun } from '../../utils/checkRun';
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Check access control syntax
+ *
+ * Retries once on transient `status='notProcessed'` with empty errors —
+ * observed on cloud trial under full-suite load, where the CHECK reporter
+ * occasionally returns has_errors=true without findings because async
+ * validation has not materialized yet (#20). After the retry, if the state
+ * persists with no real errors, downgrade to a warning and return the
+ * response instead of throwing with an empty message.
  */
 export async function checkAccessControl(
   connection: IAbapConnection,
   accessControlName: string,
   version: string = 'inactive',
   sourceCode?: string,
+  logger?: ILogger,
 ): Promise<AxiosResponse> {
-  const response = await runCheckRun(
-    connection,
-    'access_control',
-    accessControlName,
-    version,
-    'abapCheckRun',
-    sourceCode,
-  );
-  const checkResult = parseCheckRunResponse(response);
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const response = await runCheckRun(
+      connection,
+      'access_control',
+      accessControlName,
+      version,
+      'abapCheckRun',
+      sourceCode,
+    );
+    const checkResult = parseCheckRunResponse(response);
 
-  if (checkResult.has_errors) {
-    const errorMessages = checkResult.errors.map((err) => err.text).join('; ');
-    throw new Error(`Access control check failed: ${errorMessages}`);
+    if (!checkResult.has_errors) {
+      return response;
+    }
+
+    if (checkResult.errors.length > 0) {
+      const errorMessages = checkResult.errors
+        .map((err) => err.text)
+        .join('; ');
+      throw new Error(`Access control check failed: ${errorMessages}`);
+    }
+
+    // has_errors=true but errors is empty — driven by status='notProcessed'
+    // in parseCheckRunResponse. Likely transient under load.
+    if (attempt === 0) {
+      logger?.warn?.(
+        `Access control check returned has_errors=true with empty errors (status=${checkResult.status}, message=${checkResult.message || 'none'}); retrying once`,
+      );
+      await delay(2000);
+      continue;
+    }
+
+    logger?.warn?.(
+      `Access control check still has_errors=true with empty errors after retry (status=${checkResult.status}, message=${checkResult.message || 'none'}); treating as transient and continuing`,
+    );
+    return response;
   }
 
-  return response;
+  // Unreachable: loop returns on every path
+  throw new Error(
+    `Access control check failed: unexpected control flow for ${accessControlName}`,
+  );
 }


### PR DESCRIPTION
## Summary

- Fixes #20 — `AccessControl - Full workflow` test intermittently failed on cloud trial under full-suite load with `Access control check failed:` (note trailing space — `errorMessages` was empty).
- Root cause: `parseCheckRunResponse` sets `has_errors=true` when `status='notProcessed'` even with no real findings. Under load on cloud trial, the async validation occasionally has not materialized yet.
- `checkAccessControl` now retries once (2 s delay) on this transient state and treats it as a warning if it persists after the retry. Real findings (`errors` non-empty) still throw with the full message as before.
- Same retry-on-transient pattern already used in `src/core/view/check.ts`.

## Test plan

- [ ] Build is clean (`npm run build`)
- [ ] Isolated run: `npm test -- integration/core/accessControl` still passes
- [ ] Full suite on cloud trial: `AccessControl - Full workflow` no longer flakes under load
- [ ] Logs show the new transient warning when the condition triggers (DEBUG_ADT_TESTS=true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)