### PR TITLE
fix(behaviorDefinition): URL-encode namespaced object names in ADT paths

### DIFF
--- a/src/__tests__/unit/core/behaviorDefinition/Namespace.test.ts
+++ b/src/__tests__/unit/core/behaviorDefinition/Namespace.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression tests: namespaced (e.g. /NSP/) behavior definition names must be
+ * URL-encoded in the request path, exactly like class/interface/view do.
+ *
+ * Bug: BDEF URLs were built with `${name.toLowerCase()}` (raw), so a name like
+ * `/NSP/R_TEST` produced `.../behaviordefinitions//nsp/r_test`, with raw slashes
+ * that break the ADT path. The encoded form must be `%2fnsp%2fr_test`.
+ */
+
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { lock, lockForUpdate } from '../../../../core/behaviorDefinition/lock';
+import { unlock } from '../../../../core/behaviorDefinition/unlock';
+import { update } from '../../../../core/behaviorDefinition/update';
+
+const LOCK_RESPONSE = `<?xml version="1.0" encoding="UTF-8"?><asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0"><asx:values><DATA><LOCK_HANDLE>LH123</LOCK_HANDLE><CORRNR/></DATA></asx:values></asx:abap>`;
+
+function createConnectionMock(data = '') {
+  return {
+    makeAdtRequest: jest.fn().mockResolvedValue({ status: 200, data }),
+  } as unknown as IAbapConnection;
+}
+
+function firstUrl(connection: IAbapConnection): string {
+  return (connection.makeAdtRequest as jest.Mock).mock.calls[0][0].url;
+}
+
+const NS_NAME = '/NSP/R_TEST';
+const ENCODED = 'behaviordefinitions/%2fnsp%2fr_test';
+const RAW_SLASHES = 'behaviordefinitions//nsp';
+
+describe('behavior definition namespace URL encoding', () => {
+  it('lock() encodes the namespaced name in the path', async () => {
+    const connection = createConnectionMock(LOCK_RESPONSE);
+    await lock(connection, NS_NAME);
+    const url = firstUrl(connection);
+    expect(url).toContain(ENCODED);
+    expect(url).not.toContain(RAW_SLASHES);
+  });
+
+  it('lockForUpdate() encodes the namespaced name in the path', async () => {
+    const connection = createConnectionMock(LOCK_RESPONSE);
+    await lockForUpdate(connection, NS_NAME, 'session');
+    const url = firstUrl(connection);
+    expect(url).toContain(ENCODED);
+    expect(url).not.toContain(RAW_SLASHES);
+  });
+
+  it('update() encodes the namespaced name in the path', async () => {
+    const connection = createConnectionMock();
+    await update(connection, {
+      name: NS_NAME,
+      sourceCode: 'managed; define behavior for ZX {}',
+      lockHandle: 'LH123',
+    });
+    const url = firstUrl(connection);
+    expect(url).toContain(ENCODED);
+    expect(url).not.toContain(RAW_SLASHES);
+  });
+
+  it('unlock() encodes the namespaced name in the path', async () => {
+    const connection = createConnectionMock();
+    await unlock(connection, NS_NAME, 'LH123');
+    const url = firstUrl(connection);
+    expect(url).toContain(ENCODED);
+    expect(url).not.toContain(RAW_SLASHES);
+  });
+
+  it('does not alter plain (non-namespaced) names', async () => {
+    const connection = createConnectionMock(LOCK_RESPONSE);
+    await lock(connection, 'Z_MY_BDEF');
+    const url = firstUrl(connection);
+    expect(url).toContain('behaviordefinitions/z_my_bdef');
+  });
+});

--- a/src/core/behaviorDefinition/activation.ts
+++ b/src/core/behaviorDefinition/activation.ts
@@ -7,6 +7,7 @@ import type {
   IAbapConnection,
 } from '@mcp-abap-adt/interfaces';
 import { activateObjectInSession } from '../../utils/activationUtils';
+import { encodeSapObjectName } from '../../utils/internalUtils';
 
 /**
  * Activate behavior definition
@@ -31,7 +32,7 @@ export async function activate(
   name: string,
   preauditRequested: boolean = true,
 ): Promise<AxiosResponse> {
-  const objectUri = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}`;
+  const objectUri = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}`;
   return await activateObjectInSession(
     connection,
     objectUri,

--- a/src/core/behaviorDefinition/check.ts
+++ b/src/core/behaviorDefinition/check.ts
@@ -10,6 +10,7 @@ import {
   ACCEPT_CHECK_MESSAGES,
   CT_CHECK_OBJECTS,
 } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
 import type { CheckReporter } from './types';
 
@@ -50,9 +51,9 @@ export async function check(
     // TODO: analyze whether chkrun:contentType can be extracted to a constant
     const base64Content = Buffer.from(sourceCode, 'utf-8').toString('base64');
     xmlBody = `<?xml version="1.0" encoding="UTF-8"?><chkrun:checkObjectList xmlns:chkrun="http://www.sap.com/adt/checkrun" xmlns:adtcore="http://www.sap.com/adt/core">
-    <chkrun:checkObject adtcore:uri="/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}" chkrun:version="${version}">
+    <chkrun:checkObject adtcore:uri="/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}" chkrun:version="${version}">
         <chkrun:artifacts>
-            <chkrun:artifact chkrun:contentType="text/plain; charset=utf-8" chkrun:uri="/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}/source/main">
+            <chkrun:artifact chkrun:contentType="text/plain; charset=utf-8" chkrun:uri="/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}/source/main">
                 <chkrun:content>${base64Content}</chkrun:content>
             </chkrun:artifact>
         </chkrun:artifacts>
@@ -61,7 +62,7 @@ export async function check(
   } else {
     // Check saved version
     xmlBody = `<?xml version="1.0" encoding="UTF-8"?><chkrun:checkObjectList xmlns:chkrun="http://www.sap.com/adt/checkrun" xmlns:adtcore="http://www.sap.com/adt/core">
-    <chkrun:checkObject adtcore:uri="/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}" chkrun:version="${version}"/>
+    <chkrun:checkObject adtcore:uri="/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}" chkrun:version="${version}"/>
 </chkrun:checkObjectList>`;
   }
 

--- a/src/core/behaviorDefinition/delete.ts
+++ b/src/core/behaviorDefinition/delete.ts
@@ -12,6 +12,7 @@ import {
   CT_DELETION,
   CT_DELETION_CHECK,
 } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
 
 /**
@@ -35,7 +36,7 @@ export async function checkDeletion(
   connection: IAbapConnection,
   name: string,
 ): Promise<AxiosResponse> {
-  const objectUri = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}`;
+  const objectUri = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}`;
 
   const xmlPayload = `<?xml version="1.0" encoding="UTF-8"?><del:checkRequest xmlns:del="http://www.sap.com/adt/deletion" xmlns:adtcore="http://www.sap.com/adt/core">
     <del:object adtcore:uri="${objectUri}"/>
@@ -82,7 +83,7 @@ export async function deleteBehaviorDefinition(
   name: string,
   transportRequest?: string,
 ): Promise<AxiosResponse> {
-  const objectUri = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}`;
+  const objectUri = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}`;
 
   const transportXml = transportRequest
     ? `<del:transportNumber>${transportRequest}</del:transportNumber>`

--- a/src/core/behaviorDefinition/lock.ts
+++ b/src/core/behaviorDefinition/lock.ts
@@ -8,6 +8,7 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import { XMLParser } from 'fast-xml-parser';
 import { ACCEPT_LOCK } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
 
 /**
@@ -32,7 +33,7 @@ export async function lock(
   name: string,
   accessMode: string = 'MODIFY',
 ): Promise<string> {
-  const url = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}?_action=LOCK&accessMode=${accessMode}`;
+  const url = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}?_action=LOCK&accessMode=${accessMode}`;
 
   const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
@@ -99,7 +100,7 @@ export async function lockForUpdate(
   _sessionId: string,
   accessMode: string = 'MODIFY',
 ): Promise<{ response: AxiosResponse; lockHandle: string; corrNr?: string }> {
-  const url = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}?_action=LOCK&accessMode=${accessMode}`;
+  const url = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}?_action=LOCK&accessMode=${accessMode}`;
 
   const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>

--- a/src/core/behaviorDefinition/read.ts
+++ b/src/core/behaviorDefinition/read.ts
@@ -13,6 +13,7 @@ import {
   CT_BEHAVIOR_DEFINITION,
 } from '../../constants/contentTypes';
 import { makeAdtRequestWithAcceptNegotiation } from '../../utils/acceptNegotiation';
+import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
 import type { IReadOptions } from '../shared/types';
 
@@ -42,7 +43,7 @@ export async function read(
   logger?: ILogger,
 ): Promise<AxiosResponse> {
   const query = options?.withLongPolling ? `&withLongPolling=true` : '';
-  const url = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}?version=${version}${query}`;
+  const url = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}?version=${version}${query}`;
 
   const headers = {
     Accept: options?.accept ?? CT_BEHAVIOR_DEFINITION,
@@ -85,7 +86,7 @@ export async function readSource(
   logger?: ILogger,
 ): Promise<AxiosResponse> {
   const query = options?.withLongPolling ? `&withLongPolling=true` : '';
-  const url = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}/source/main?version=${version}${query}`;
+  const url = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}/source/main?version=${version}${query}`;
 
   const headers = {
     Accept: options?.accept ?? ACCEPT_SOURCE,
@@ -115,7 +116,7 @@ export async function getBehaviorDefinitionTransport(
   options?: IReadOptions,
 ): Promise<AxiosResponse> {
   const query = options?.withLongPolling ? '?withLongPolling=true' : '';
-  const url = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}/transport${query}`;
+  const url = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}/transport${query}`;
 
   const headers = {
     Accept: options?.accept ?? ACCEPT_TRANSPORT,

--- a/src/core/behaviorDefinition/unlock.ts
+++ b/src/core/behaviorDefinition/unlock.ts
@@ -6,6 +6,7 @@ import type {
   IAdtResponse as AxiosResponse,
   IAbapConnection,
 } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
 
 /**
@@ -33,7 +34,7 @@ export async function unlock(
   name: string,
   lockHandle: string,
 ): Promise<AxiosResponse> {
-  const url = `/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}?_action=UNLOCK&lockHandle=${encodeURIComponent(lockHandle)}`;
+  const url = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(name).toLowerCase()}?_action=UNLOCK&lockHandle=${encodeURIComponent(lockHandle)}`;
 
   return connection.makeAdtRequest({
     url,

--- a/src/core/behaviorDefinition/update.ts
+++ b/src/core/behaviorDefinition/update.ts
@@ -7,6 +7,7 @@ import type {
   IAbapConnection,
 } from '@mcp-abap-adt/interfaces';
 import { ACCEPT_SOURCE, CT_SOURCE } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
 import type { IUpdateBehaviorDefinitionParams } from './types';
 
@@ -58,7 +59,7 @@ export async function update(
     throw new Error('lockHandle is required');
   }
 
-  let url = `/sap/bc/adt/bo/behaviordefinitions/${params.name.toLowerCase()}/source/main?lockHandle=${encodeURIComponent(params.lockHandle)}`;
+  let url = `/sap/bc/adt/bo/behaviordefinitions/${encodeSapObjectName(params.name).toLowerCase()}/source/main?lockHandle=${encodeURIComponent(params.lockHandle)}`;
   if (params.transportRequest) {
     url += `&corrNr=${params.transportRequest}`;
   }


### PR DESCRIPTION
## Problem
Behavior definitions whose name lives in a SAP namespace could not be read, locked, updated, activated, checked, unlocked or deleted. The client built URLs with the raw name:

`/sap/bc/adt/bo/behaviordefinitions/${name.toLowerCase()}`

For a namespaced name that yields `…/behaviordefinitions//nsp/…` — the raw `/` characters break the ADT path, so SAP responds "… not found" even though the object exists.

## Fix
Wrap the name with `encodeSapObjectName(...)` (so `/` → `%2f`) across every path-based behavior-definition operation (lock, lockForUpdate, update, read, readSource, transport, activate, check, unlock, delete) — matching the existing class / interface / view clients. `create` is unaffected: it POSTs to the collection with the real name in the XML body. 

## Tests
Adds unit tests covering lock / lockForUpdate / update / unlock URL encoding for namespaced names and asserting plain names are unchanged. Full unit suite (146 tests) passes.