### PR TITLE
fix: keep session stateful through lock→unlock chain (423 on older BASIS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.4] - 2026-06-11
+
+### Fixed
+
+- Object writes (update/delete) no longer fail with `423 … not locked (invalid lock handle)` on older ABAP systems (e.g. BASIS 7.55) over HTTP. The handlers acquired the lock in a **stateful** request but then immediately switched the connection back to **stateless** (`setSessionType('stateless')`) before sending the lock-bound PUT, so the lock handle was no longer valid on kernels where it is only honoured inside stateful requests. The connection now stays **stateful for the whole lock→check→update→unlock chain**; `unlock()` (and error/cleanup paths) restores stateless afterwards. Newer kernels (758/816) tolerated the stateless write, which is why this only surfaced on older BASIS. Applied uniformly across all object types — both the standalone `lock()` methods and the inline create/update/delete chains (class, interface, program, function module/group/include, domain, package, table, structure, view, table type, data element, service definition, metadata extension, access control, transformation, behavior definition, enhancement, authorization field, feature toggle). `AdtClassLegacy` already followed this pattern. (#106)
+
 ## [5.4.3] - 2026-05-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.4.3",
+      "version": "5.4.4",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -303,7 +303,6 @@ export class AdtAccessControl
         this.connection,
         config.accessControlName,
       );
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Access control locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -574,7 +573,6 @@ export class AdtAccessControl
       this.connection,
       config.accessControlName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/authorizationField/AdtAuthorizationField.ts
+++ b/src/core/authorizationField/AdtAuthorizationField.ts
@@ -308,7 +308,6 @@ export class AdtAuthorizationField
         fullConfig.authorizationFieldName,
         this.logger,
       );
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       fullConfig.onLock?.(lockHandle);
       this.logger?.info?.('Authorization field locked, handle:', lockHandle);
@@ -573,7 +572,6 @@ export class AdtAuthorizationField
       config.authorizationFieldName,
       this.logger,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
+++ b/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
@@ -359,7 +359,6 @@ export class AdtBehaviorDefinition
       this.logger?.info?.('Step 1: Locking behavior definition');
       this.connection.setSessionType('stateful');
       lockHandle = await lock(this.connection, config.name);
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       this.logger?.info?.('Behavior definition locked, handle:', lockHandle);
 
@@ -634,7 +633,6 @@ export class AdtBehaviorDefinition
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lock(this.connection, config.name);
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -333,11 +333,13 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
     };
 
     try {
-      // 1. Lock (update always starts with lock, stateful only for lock)
+      // 1. Lock — stay stateful for the whole lock→check→update→unlock chain.
+      // On older BASIS (#106) the lock handle is only valid inside stateful
+      // requests; a stateless write in between fails with 423. unlock() below
+      // restores stateless.
       this.logger?.info?.('Step 1: Locking class');
       this.connection.setSessionType('stateful');
       lockHandle = await lockClass(this.connection, config.className);
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       this.logger?.info?.('Class locked, handle:', lockHandle);
 
@@ -688,10 +690,12 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
       throw new Error('Class name is required');
     }
 
+    // Stay stateful while the lock is held — the caller must release it via
+    // unlock(), which restores stateless. On older BASIS (#106) the lock handle
+    // is only valid inside stateful requests, so a stateless write between lock
+    // and unlock fails with 423.
     this.connection.setSessionType('stateful');
-    const lockHandle = await lockClass(this.connection, config.className);
-    this.connection.setSessionType('stateless');
-    return lockHandle;
+    return await lockClass(this.connection, config.className);
   }
 
   /**
@@ -725,10 +729,10 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
     if (!config.className) {
       throw new Error('Class name is required');
     }
+    // Stay stateful while the lock is held (see lock()); unlockTestClasses()
+    // restores stateless. Avoids 423 on older BASIS (#106).
     this.connection.setSessionType('stateful');
-    const lockHandle = await lockClass(this.connection, config.className);
-    this.connection.setSessionType('stateless');
-    return lockHandle;
+    return await lockClass(this.connection, config.className);
   }
 
   /**
@@ -796,7 +800,6 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
       this.logger?.info?.('Step 1: Locking parent class');
       this.connection.setSessionType('stateful');
       lockHandle = await lockClass(this.connection, config.className);
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Parent class locked, handle:', lockHandle);
 
       // 2. Update test classes (uses parent class lock handle)

--- a/src/core/dataElement/AdtDataElement.ts
+++ b/src/core/dataElement/AdtDataElement.ts
@@ -318,7 +318,6 @@ export class AdtDataElement
         this.connection,
         config.dataElementName,
       );
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       this.logger?.info?.('Data element locked, handle:', lockHandle);
 
@@ -649,7 +648,6 @@ export class AdtDataElement
       this.connection,
       config.dataElementName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -288,7 +288,6 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
       this.logger?.info?.('lock');
       this.connection.setSessionType('stateful');
       lockHandle = await lockDomain(this.connection, config.domainName);
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       this.logger?.info?.('locked');
 
@@ -600,7 +599,6 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lockDomain(this.connection, config.domainName);
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -434,7 +434,6 @@ export class AdtEnhancement
         config.enhancementType,
         config.enhancementName,
       );
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       this.logger?.info?.('Enhancement locked, handle:', lockHandle);
 
@@ -765,7 +764,6 @@ export class AdtEnhancement
       config.enhancementType,
       config.enhancementName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/featureToggle/AdtFeatureToggle.ts
+++ b/src/core/featureToggle/AdtFeatureToggle.ts
@@ -159,7 +159,6 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
           config.featureToggleName,
           this.logger,
         );
-        this.connection.setSessionType('stateless');
         state.lockHandle = lockHandle;
         config.onLock?.(lockHandle);
         this.logger?.info?.('Feature toggle locked, handle:', lockHandle);
@@ -384,7 +383,6 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
         fullConfig.featureToggleName,
         this.logger,
       );
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       fullConfig.onLock?.(lockHandle);
       this.logger?.info?.('Feature toggle locked, handle:', lockHandle);
@@ -664,7 +662,6 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
       config.featureToggleName,
       this.logger,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/functionGroup/AdtFunctionGroup.ts
+++ b/src/core/functionGroup/AdtFunctionGroup.ts
@@ -476,7 +476,6 @@ export class AdtFunctionGroup
         config.functionGroupName,
         sessionId,
       );
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Function group locked, handle:', lockHandle);
 
       // 2. Update metadata (description)
@@ -723,7 +722,6 @@ export class AdtFunctionGroup
       this.connection,
       config.functionGroupName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -186,7 +186,6 @@ export class AdtFunctionInclude
           config.includeName,
           this.logger,
         );
-        this.connection.setSessionType('stateless');
         state.lockHandle = lockHandle;
         config.onLock?.(lockHandle);
 
@@ -452,7 +451,6 @@ export class AdtFunctionInclude
         fullConfig.includeName,
         this.logger,
       );
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       fullConfig.onLock?.(lockHandle);
       this.logger?.info?.('Function include locked, handle:', lockHandle);
@@ -743,7 +741,6 @@ export class AdtFunctionInclude
       config.includeName,
       this.logger,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/functionModule/AdtFunctionModule.ts
+++ b/src/core/functionModule/AdtFunctionModule.ts
@@ -344,7 +344,6 @@ export class AdtFunctionModule
         config.functionGroupName,
         config.functionModuleName,
       );
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Function module locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -640,7 +639,6 @@ export class AdtFunctionModule
       config.functionGroupName,
       config.functionModuleName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -275,7 +275,6 @@ export class AdtInterface
         this.connection,
         config.interfaceName,
       );
-      this.connection.setSessionType('stateless');
       lockHandle = lockResult.lockHandle;
       state.lockHandle = lockHandle;
       this.logger?.info?.('Interface locked, handle:', lockHandle);
@@ -592,7 +591,6 @@ export class AdtInterface
 
     this.connection.setSessionType('stateful');
     const result = await lockInterface(this.connection, config.interfaceName);
-    this.connection.setSessionType('stateless');
     return result.lockHandle;
   }
 

--- a/src/core/metadataExtension/AdtMetadataExtension.ts
+++ b/src/core/metadataExtension/AdtMetadataExtension.ts
@@ -311,7 +311,6 @@ export class AdtMetadataExtension
       this.logger?.info?.('Step 1: Locking metadata extension');
       this.connection.setSessionType('stateful');
       lockHandle = await lockMetadataExtension(this.connection, config.name);
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Metadata extension locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -579,7 +578,6 @@ export class AdtMetadataExtension
       this.connection,
       config.name,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/package/AdtPackage.ts
+++ b/src/core/package/AdtPackage.ts
@@ -376,7 +376,6 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
       const lockResult = await lockPackage(this.connection, config.packageName);
       lockHandle = lockResult.lockHandle;
       lockCorrNr = lockResult.corrNr;
-      this.connection.setSessionType('stateless');
       this.logger?.info?.(
         `Package locked, handle: ${lockHandle}, corrNr: ${lockCorrNr}`,
       );
@@ -575,7 +574,6 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
 
     this.connection.setSessionType('stateful');
     const lockResult = await lockPackage(this.connection, config.packageName);
-    this.connection.setSessionType('stateless');
     return lockResult.lockHandle;
   }
 

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -296,7 +296,6 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
       this.logger?.info?.('Step 1: Locking program');
       this.connection.setSessionType('stateful');
       lockHandle = await lockProgram(this.connection, config.programName);
-      this.connection.setSessionType('stateless');
       state.lockHandle = lockHandle;
       this.logger?.info?.('Program locked, handle:', lockHandle);
 
@@ -616,7 +615,6 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lockProgram(this.connection, config.programName);
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -309,7 +309,6 @@ export class AdtServiceDefinition
         this.connection,
         config.serviceDefinitionName,
       );
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Service definition locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -581,7 +580,6 @@ export class AdtServiceDefinition
       this.connection,
       config.serviceDefinitionName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -305,7 +305,6 @@ export class AdtStructure
       this.logger?.info?.('Step 1: Locking structure');
       this.connection.setSessionType('stateful');
       lockHandle = await lockStructure(this.connection, config.structureName);
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Structure locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -572,7 +571,6 @@ export class AdtStructure
       this.connection,
       config.structureName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -286,7 +286,6 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
         this.connection,
         config.tableName,
       );
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Table locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -534,7 +533,6 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
       this.connection,
       config.tableName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/tabletype/AdtDdicTableType.ts
+++ b/src/core/tabletype/AdtDdicTableType.ts
@@ -299,7 +299,6 @@ export class AdtDdicTableType
         this.connection,
         config.tableTypeName,
       );
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Table type locked, handle:', lockHandle);
 
       // 2. Check inactive (TableType is XML-based, no source code check needed)
@@ -581,7 +580,6 @@ export class AdtDdicTableType
       this.connection,
       config.tableTypeName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -315,7 +315,6 @@ export class AdtTransformation
         this.connection,
         config.transformationName,
       );
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('Transformation locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -581,7 +580,6 @@ export class AdtTransformation
       this.connection,
       config.transformationName,
     );
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 

--- a/src/core/view/AdtView.ts
+++ b/src/core/view/AdtView.ts
@@ -303,7 +303,6 @@ export class AdtView implements IAdtObject<IViewConfig, IViewState> {
       this.logger?.info?.('Step 1: Locking view');
       this.connection.setSessionType('stateful');
       lockHandle = await lockDDLS(this.connection, config.viewName);
-      this.connection.setSessionType('stateless');
       this.logger?.info?.('View locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -557,7 +556,6 @@ export class AdtView implements IAdtObject<IViewConfig, IViewState> {
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lockDDLS(this.connection, config.viewName);
-    this.connection.setSessionType('stateless');
     return lockHandle;
   }
 


### PR DESCRIPTION
## What

Keep the SAP connection **stateful for the whole `lock → check → update → unlock` chain** across all object types, instead of switching back to `stateless` immediately after acquiring the lock.

## Why

On older ABAP kernels (e.g. **BASIS 7.55**) the lock handle is only valid inside stateful requests. The handlers acquired the lock statefully but then called `setSessionType('stateless')` before the lock-bound PUT, so the write was rejected with **HTTP 423 — not locked (invalid lock handle)**. Newer kernels (758/816) tolerated the stateless write, which is why this only surfaced on older systems.

The bug was **systemic** — the same `stateful → lock → stateless` toggle was duplicated across ~20 object types, in both the standalone `lock()` methods and the inline `create/update/delete` chains. `AdtClassLegacy` already kept the chain stateful and was unaffected.

## Change

- Removed the eager post-lock `setSessionType('stateless')` in all object types (42 sites, 20 files).
- `unlock()` and the error/cleanup paths still restore stateless, so the resting state is unchanged.
- `lock()` now leaves the connection stateful while the lock is held (caller releases via `unlock()`).
- Bumped to 5.4.4, CHANGELOG updated.

`stateful` is accepted by all kernel versions, so the change is universally safe.

## Verification

- `npm run build` (biome + tsc) clean; 141 unit tests pass.
- Behaviour confirmed on DS4 (BASIS 755) per consumer report fr0ster/mcp-abap-adt#106: keeping the session stateful through the write makes the same class on the same system succeed and activate instead of 423.
- Full integration run on a 755 system still pending (no mocks; needs real system).

Closes #38
Refs fr0ster/mcp-abap-adt#106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
