### PR TITLE
feat: configurable masterLanguage for created objects (default EN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - **metadata extension** create no longer emits a contradictory payload: `adtcore:language` was hardcoded to `EN` while `adtcore:masterLanguage` honoured the configured language. Both now use the resolved language. It also gained the missing `systemContext` fallback (previously only `config.masterLanguage`).
 - **behavior definition** create now passes the resolved master language (it previously ignored it and always created as `EN`).
+- **ServiceBinding** now receives `systemContext` (`getServiceBinding()` previously constructed it without one), so the global `IAdtClientOptions.masterLanguage`/`masterSystem`/`responsible` are honoured. Resolution order is `params → systemContext → getSystemInformation() auto-detect → default` — an explicit override now wins over auto-detection.
 
 ### Note
 
-- **ServiceBinding** already resolves `masterLanguage` via `getSystemInformation()` (`params.masterLanguage ?? systemInfo.language ?? 'EN'`), so it honours the logon language without `systemContext`; left as-is.
 - `package` is intentionally not covered — its `ICreatePackageParams` lives in `@mcp-abap-adt/interfaces` and will follow once that field is added upstream.
 
 ## [5.4.4] - 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] - 2026-06-12
+
+### Added
+
+- **Master/original language for newly created objects is now configurable** instead of always hardcoded to `EN`. `IAdtClientOptions.masterLanguage` (carried into `IAdtSystemContext.masterLanguage`) sets the `adtcore:masterLanguage` and `adtcore:language` attributes for `create` across object types: class, program, interface, view, domain, structure, table, table type, data element, function group, service definition, access control, transformation, enhancement. When unset it still defaults to `EN`, so existing behaviour is unchanged. Consumers are expected to source this from the logon language (`SAP_LANGUAGE`) and/or an explicit per-call override. Fixes objects being created with `masterLanguage=EN` regardless of the configured language. (fr0ster/mcp-abap-adt#105)
+- New optional `masterLanguage?` field on each `ICreate*Params` for the low-level create functions. Additive; no breaking change.
+
+### Note
+
+- `package` is intentionally not covered here — its `ICreatePackageParams` lives in `@mcp-abap-adt/interfaces` and will follow in a separate change once that field is added upstream.
+
 ## [5.4.4] - 2026-06-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Added
 
-- **Master/original language for newly created objects is now configurable** instead of always hardcoded to `EN`. `IAdtClientOptions.masterLanguage` (carried into `IAdtSystemContext.masterLanguage`) sets the `adtcore:masterLanguage` and `adtcore:language` attributes for `create` across object types: class, program, interface, view, domain, structure, table, table type, data element, function group, service definition, access control, transformation, enhancement. When unset it still defaults to `EN`, so existing behaviour is unchanged. Consumers are expected to source this from the logon language (`SAP_LANGUAGE`) and/or an explicit per-call override. Fixes objects being created with `masterLanguage=EN` regardless of the configured language. (fr0ster/mcp-abap-adt#105)
-- New optional `masterLanguage?` field on each `ICreate*Params` for the low-level create functions. Additive; no breaking change.
+- **Master/original language for newly created objects is now configurable** instead of always hardcoded to `EN`. `IAdtClientOptions.masterLanguage` is carried into `IAdtSystemContext.masterLanguage`, and every language-aware `create` now resolves `config.masterLanguage ?? this.systemContext.masterLanguage` and writes the result to **both** `adtcore:language` and `adtcore:masterLanguage`. Covered: class, program, interface, view, domain, structure, table, table type, data element, function group, service definition, access control, transformation, enhancement, behavior definition, metadata extension. When unset it still defaults to `EN`, so existing behaviour is unchanged. Consumers source this from the logon language (`SAP_LANGUAGE`) with an optional per-call `config.masterLanguage` override. (fr0ster/mcp-abap-adt#105)
+- Optional `masterLanguage?` on each `IXxxConfig` and `ICreate*Params`. Additive; no breaking change.
+
+### Fixed
+
+- **metadata extension** create no longer emits a contradictory payload: `adtcore:language` was hardcoded to `EN` while `adtcore:masterLanguage` honoured the configured language. Both now use the resolved language. It also gained the missing `systemContext` fallback (previously only `config.masterLanguage`).
+- **behavior definition** create now passes the resolved master language (it previously ignored it and always created as `EN`).
 
 ### Note
 
-- `package` is intentionally not covered here — its `ICreatePackageParams` lives in `@mcp-abap-adt/interfaces` and will follow in a separate change once that field is added upstream.
+- **ServiceBinding** already resolves `masterLanguage` via `getSystemInformation()` (`params.masterLanguage ?? systemInfo.language ?? 'EN'`), so it honours the logon language without `systemContext`; left as-is.
+- `package` is intentionally not covered — its `ICreatePackageParams` lives in `@mcp-abap-adt/interfaces` and will follow once that field is added upstream.
 
 ## [5.4.4] - 2026-06-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.4.4",
+      "version": "5.5.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.4.4",
+  "version": "5.5.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/unit/core/masterLanguage.test.ts
+++ b/src/__tests__/unit/core/masterLanguage.test.ts
@@ -3,6 +3,7 @@ import { create as createBehaviorDefinition } from '../../../core/behaviorDefini
 import { createMetadataExtension } from '../../../core/metadataExtension/create';
 import { AdtProgram } from '../../../core/program/AdtProgram';
 import { create as createProgram } from '../../../core/program/create';
+import { AdtServiceBinding } from '../../../core/service/AdtService';
 
 /**
  * Master/original language wiring (fr0ster/mcp-abap-adt#105).
@@ -83,6 +84,46 @@ describe('masterLanguage on create', () => {
         implementationType: 'managed',
       } as never);
       expect(bodyOf(c2)).toContain('adtcore:masterLanguage="EN"');
+    });
+  });
+
+  describe('ServiceBinding honours the global systemContext override', () => {
+    function bindingBody(connection: IAbapConnection): string {
+      const call = (connection.makeAdtRequest as jest.Mock).mock.calls.find(
+        (c) => String(c[0]?.data).includes('srvb:serviceBinding'),
+      );
+      return String(call?.[0]?.data);
+    }
+
+    const baseParams = {
+      bindingName: 'ZSB',
+      packageName: '$TMP',
+      description: 'x',
+      serviceDefinitionName: 'ZSD',
+      serviceName: 'ZSRV',
+      serviceVersion: '0001',
+      bindingVariant: 'ODATA_V4_UI',
+    } as never;
+
+    it('uses systemContext.masterLanguage (global option) when params omit it', async () => {
+      const c = mockConnection();
+      const binding = new AdtServiceBinding(c, undefined, {
+        masterLanguage: 'FR',
+      });
+      await binding.createServiceBinding(baseParams);
+      expect(bindingBody(c)).toContain('adtcore:masterLanguage="FR"');
+    });
+
+    it('explicit params.masterLanguage overrides the global option', async () => {
+      const c = mockConnection();
+      const binding = new AdtServiceBinding(c, undefined, {
+        masterLanguage: 'FR',
+      });
+      await binding.createServiceBinding({
+        ...(baseParams as object),
+        masterLanguage: 'ZH',
+      } as never);
+      expect(bindingBody(c)).toContain('adtcore:masterLanguage="ZH"');
     });
   });
 

--- a/src/__tests__/unit/core/masterLanguage.test.ts
+++ b/src/__tests__/unit/core/masterLanguage.test.ts
@@ -1,0 +1,115 @@
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { create as createBehaviorDefinition } from '../../../core/behaviorDefinition/create';
+import { createMetadataExtension } from '../../../core/metadataExtension/create';
+import { AdtProgram } from '../../../core/program/AdtProgram';
+import { create as createProgram } from '../../../core/program/create';
+
+/**
+ * Master/original language wiring (fr0ster/mcp-abap-adt#105).
+ *
+ * create payloads must carry the configured master language in BOTH
+ * adtcore:language and adtcore:masterLanguage, and fall back to EN when unset.
+ * High-level handlers resolve config.masterLanguage ?? systemContext.masterLanguage.
+ */
+describe('masterLanguage on create', () => {
+  function mockConnection() {
+    return {
+      makeAdtRequest: jest.fn().mockResolvedValue({ status: 201, data: '' }),
+      setSessionType: jest.fn(),
+      getSessionId: jest.fn().mockReturnValue('sess'),
+    } as unknown as IAbapConnection;
+  }
+
+  function bodyOf(connection: IAbapConnection): string {
+    const call = (connection.makeAdtRequest as jest.Mock).mock.calls[0][0];
+    return String(call.data);
+  }
+
+  describe('low-level program create', () => {
+    it('uses the given language for both language attributes', async () => {
+      const c = mockConnection();
+      await createProgram(c, {
+        programName: 'ZTEST',
+        packageName: '$TMP',
+        masterLanguage: 'ZH',
+      });
+      const body = bodyOf(c);
+      expect(body).toContain('adtcore:language="ZH"');
+      expect(body).toContain('adtcore:masterLanguage="ZH"');
+    });
+
+    it('falls back to EN when language is not provided', async () => {
+      const c = mockConnection();
+      await createProgram(c, { programName: 'ZTEST', packageName: '$TMP' });
+      const body = bodyOf(c);
+      expect(body).toContain('adtcore:language="EN"');
+      expect(body).toContain('adtcore:masterLanguage="EN"');
+    });
+  });
+
+  describe('low-level metadataExtension create', () => {
+    it('uses the language for BOTH attributes (no hardcoded EN language)', async () => {
+      const c = mockConnection();
+      await createMetadataExtension(c, {
+        name: 'ZMDE',
+        packageName: '$TMP',
+        description: 'x',
+        masterLanguage: 'ZH',
+      });
+      const body = bodyOf(c);
+      expect(body).toContain('adtcore:language="ZH"');
+      expect(body).toContain('adtcore:masterLanguage="ZH"');
+    });
+  });
+
+  describe('low-level behaviorDefinition create', () => {
+    it('uses the language for both attributes, EN otherwise', async () => {
+      const c1 = mockConnection();
+      await createBehaviorDefinition(c1, {
+        name: 'ZBDEF',
+        package: '$TMP',
+        description: 'x',
+        implementationType: 'managed',
+        language: 'ZH',
+      } as never);
+      expect(bodyOf(c1)).toContain('adtcore:masterLanguage="ZH"');
+      expect(bodyOf(c1)).toContain('adtcore:language="ZH"');
+
+      const c2 = mockConnection();
+      await createBehaviorDefinition(c2, {
+        name: 'ZBDEF',
+        package: '$TMP',
+        description: 'x',
+        implementationType: 'managed',
+      } as never);
+      expect(bodyOf(c2)).toContain('adtcore:masterLanguage="EN"');
+    });
+  });
+
+  describe('high-level AdtProgram.create resolution', () => {
+    it('uses systemContext.masterLanguage when config omits it', async () => {
+      const c = mockConnection();
+      const program = new AdtProgram(c, undefined, { masterLanguage: 'IT' });
+      await program.create({ programName: 'ZTEST', packageName: '$TMP' });
+      expect(bodyOf(c)).toContain('adtcore:masterLanguage="IT"');
+    });
+
+    it('config.masterLanguage overrides systemContext', async () => {
+      const c = mockConnection();
+      const program = new AdtProgram(c, undefined, { masterLanguage: 'IT' });
+      await program.create({
+        programName: 'ZTEST',
+        packageName: '$TMP',
+        masterLanguage: 'FR',
+      });
+      expect(bodyOf(c)).toContain('adtcore:masterLanguage="FR"');
+    });
+
+    it('falls back to EN with no language anywhere', async () => {
+      const c = mockConnection();
+      const program = new AdtProgram(c, undefined, {});
+      await program.create({ programName: 'ZTEST', packageName: '$TMP' });
+      expect(bodyOf(c)).toContain('adtcore:masterLanguage="EN"');
+    });
+  });
+});

--- a/src/clients/AdtClient.ts
+++ b/src/clients/AdtClient.ts
@@ -400,7 +400,11 @@ export class AdtClient {
    * @returns IAdtServiceBinding instance for ServiceBinding CRUD and lifecycle operations
    */
   getServiceBinding(): IAdtServiceBinding {
-    return new AdtServiceBinding(this.connection, this.logger);
+    return new AdtServiceBinding(
+      this.connection,
+      this.logger,
+      this.systemContext,
+    );
   }
 
   /**

--- a/src/clients/AdtClient.ts
+++ b/src/clients/AdtClient.ts
@@ -142,12 +142,16 @@ import { AdtView, type IViewConfig, type IViewState } from '../core/view';
 export interface IAdtSystemContext {
   masterSystem?: string;
   responsible?: string;
+  /** Master/original language for newly created objects (adtcore:masterLanguage). Sourced from SAP_LANGUAGE; defaults to EN when unset. */
+  masterLanguage?: string;
 }
 
 export interface IAdtClientOptions {
   enableAcceptCorrection?: boolean;
   masterSystem?: string;
   responsible?: string;
+  /** Master/original language for newly created objects. Falls back to EN when unset. */
+  masterLanguage?: string;
   contentTypes?: import('../core/shared/contentTypes').IAdtContentTypes;
   /** Whether the SAP system uses Unicode encoding. Affects Content-Type headers for source code operations. */
   unicode?: boolean;
@@ -174,6 +178,7 @@ export class AdtClient {
     this.systemContext = {
       masterSystem: options?.masterSystem,
       responsible: options?.responsible,
+      masterLanguage: options?.masterLanguage,
     };
     this.contentTypes = options?.contentTypes;
     if (options?.enableAcceptCorrection !== undefined) {

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -126,6 +126,7 @@ export class AdtAccessControl
         source_code: options?.sourceCode || config.sourceCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       this.logger?.info?.('Access control created');

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -126,7 +126,8 @@ export class AdtAccessControl
         source_code: options?.sourceCode || config.sourceCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       this.logger?.info?.('Access control created');

--- a/src/core/accessControl/create.ts
+++ b/src/core/accessControl/create.ts
@@ -30,7 +30,7 @@ export async function create(
     ? ` adtcore:masterSystem="${masterSystem}"`
     : '';
 
-  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><dcl:dclSource xmlns:dcl="http://www.sap.com/adt/acm/dclsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${accessControlName}" adtcore:type="DCLS/DL" adtcore:masterLanguage="EN"${masterSystemAttr} adtcore:responsible="${username}">
+  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><dcl:dclSource xmlns:dcl="http://www.sap.com/adt/acm/dclsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${args.masterLanguage || 'EN'}" adtcore:name="${accessControlName}" adtcore:type="DCLS/DL" adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr} adtcore:responsible="${username}">
   <adtcore:packageRef adtcore:name="${args.package_name.toUpperCase()}"/>
 </dcl:dclSource>`;
 

--- a/src/core/accessControl/types.ts
+++ b/src/core/accessControl/types.ts
@@ -26,6 +26,7 @@ export interface IDeleteAccessControlParams {
 // Builder configuration (camelCase)
 export interface IAccessControlConfig {
   accessControlName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string;
   transportRequest?: string;
   description?: string;

--- a/src/core/accessControl/types.ts
+++ b/src/core/accessControl/types.ts
@@ -9,6 +9,7 @@ export interface ICreateAccessControlParams {
   source_code?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateAccessControlParams {

--- a/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
+++ b/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
@@ -151,6 +151,7 @@ export class AdtBehaviorDefinition
         description: config.description,
         implementationType: config.implementationType,
         transportRequest: config.transportRequest,
+        language: config.masterLanguage ?? this.systemContext.masterLanguage,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
       });

--- a/src/core/behaviorDefinition/types.ts
+++ b/src/core/behaviorDefinition/types.ts
@@ -113,6 +113,7 @@ export interface ICheckRunResult {
 // rootEntity is required for validate operations
 export interface IBehaviorDefinitionConfig {
   name: string; // Required
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create/validate operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -152,6 +152,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
           create_protected: config.createProtected,
           master_system: config.masterSystem ?? this.systemContext.masterSystem,
           responsible: config.responsible ?? this.systemContext.responsible,
+          masterLanguage: this.systemContext.masterLanguage,
           template_xml: config.classTemplate,
         },
         this.logger,

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -152,7 +152,8 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
           create_protected: config.createProtected,
           master_system: config.masterSystem ?? this.systemContext.masterSystem,
           responsible: config.responsible ?? this.systemContext.responsible,
-          masterLanguage: this.systemContext.masterLanguage,
+          masterLanguage:
+            config.masterLanguage ?? this.systemContext.masterLanguage,
           template_xml: config.classTemplate,
         },
         this.logger,

--- a/src/core/class/create.ts
+++ b/src/core/class/create.ts
@@ -55,7 +55,7 @@ export async function create(
     ? `\n\n  ${args.template_xml}\n\n`
     : '\n\n';
 
-  const metadataXml = `<?xml version="1.0" encoding="UTF-8"?><class:abapClass xmlns:class="http://www.sap.com/adt/oo/classes" xmlns:adtcore="http://www.sap.com/adt/core"${abapSourceNamespace} adtcore:description="${description}" adtcore:language="EN" adtcore:name="${args.class_name}" adtcore:type="CLAS/OC" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr} class:final="${finalAttr}" class:visibility="${visibilityAttr}">
+  const metadataXml = `<?xml version="1.0" encoding="UTF-8"?><class:abapClass xmlns:class="http://www.sap.com/adt/oo/classes" xmlns:adtcore="http://www.sap.com/adt/core"${abapSourceNamespace} adtcore:description="${description}" adtcore:language="${args.masterLanguage || 'EN'}" adtcore:name="${args.class_name}" adtcore:type="CLAS/OC" adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr} class:final="${finalAttr}" class:visibility="${visibilityAttr}">
 
 
 

--- a/src/core/class/types.ts
+++ b/src/core/class/types.ts
@@ -15,6 +15,7 @@ export interface ICreateClassParams {
   transport_request?: string;
   master_system?: string;
   responsible?: string;
+  masterLanguage?: string;
   superclass?: string;
   final?: boolean;
   abstract?: boolean;

--- a/src/core/class/types.ts
+++ b/src/core/class/types.ts
@@ -33,6 +33,7 @@ export interface IDeleteClassParams {
 // description is required for create/validate operations
 export interface IClassConfig {
   className: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   description?: string; // Required for create/validate operations, optional for others
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter

--- a/src/core/dataElement/AdtDataElement.ts
+++ b/src/core/dataElement/AdtDataElement.ts
@@ -127,7 +127,8 @@ export class AdtDataElement
         set_get_parameter: config.setGetParameter,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       objectCreated = true;

--- a/src/core/dataElement/AdtDataElement.ts
+++ b/src/core/dataElement/AdtDataElement.ts
@@ -127,6 +127,7 @@ export class AdtDataElement
         set_get_parameter: config.setGetParameter,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       objectCreated = true;

--- a/src/core/dataElement/create.ts
+++ b/src/core/dataElement/create.ts
@@ -41,7 +41,7 @@ export async function create(
     ? ` adtcore:masterSystem="${masterSystem}"`
     : '';
   const responsibleAttr = username ? ` adtcore:responsible="${username}"` : '';
-  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><blue:wbobj xmlns:blue="http://www.sap.com/wbobj/dictionary/dtel" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${args.data_element_name.toUpperCase()}" adtcore:type="DTEL/DE" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><blue:wbobj xmlns:blue="http://www.sap.com/wbobj/dictionary/dtel" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${args.masterLanguage || 'EN'}" adtcore:name="${args.data_element_name.toUpperCase()}" adtcore:type="DTEL/DE" adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${args.package_name.toUpperCase()}"/>
 </blue:wbobj>`;
 

--- a/src/core/dataElement/types.ts
+++ b/src/core/dataElement/types.ts
@@ -89,6 +89,7 @@ export interface IDeleteDataElementParams {
 // description is required for create/validate operations
 export interface IDataElementConfig {
   dataElementName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/dataElement/types.ts
+++ b/src/core/dataElement/types.ts
@@ -24,6 +24,7 @@ export interface ICreateDataElementParams {
   transport_request?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
   type_kind?:
     | 'domain'
     | 'predefinedAbapType'

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -116,7 +116,8 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
         fixed_values: config.fixed_values,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       objectCreated = true;

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -116,6 +116,7 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
         fixed_values: config.fixed_values,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       objectCreated = true;

--- a/src/core/domain/create.ts
+++ b/src/core/domain/create.ts
@@ -35,7 +35,7 @@ export async function create(
     ? ` adtcore:masterSystem="${masterSystem}"`
     : '';
   const responsibleAttr = username ? ` adtcore:responsible="${username}"` : '';
-  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><doma:domain xmlns:doma="http://www.sap.com/dictionary/domain" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${args.domain_name.toUpperCase()}" adtcore:type="DOMA/DD" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><doma:domain xmlns:doma="http://www.sap.com/dictionary/domain" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${args.masterLanguage || 'EN'}" adtcore:name="${args.domain_name.toUpperCase()}" adtcore:type="DOMA/DD" adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${args.package_name.toUpperCase()}"/>
 </doma:domain>`;
 

--- a/src/core/domain/types.ts
+++ b/src/core/domain/types.ts
@@ -57,6 +57,7 @@ export interface IDeleteDomainParams {
 // description is required for create/update/validate operations
 export interface IDomainConfig {
   domainName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create/update operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/update/validate operations, optional for others

--- a/src/core/domain/types.ts
+++ b/src/core/domain/types.ts
@@ -17,6 +17,7 @@ export interface ICreateDomainParams {
   transport_request?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
   datatype?: string;
   length?: number;
   decimals?: number;

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -153,6 +153,7 @@ export class AdtEnhancement
           badi_definition: config.badiDefinition,
           masterSystem: this.systemContext.masterSystem,
           responsible: this.systemContext.responsible,
+          masterLanguage: this.systemContext.masterLanguage,
         },
         this.logger,
       );

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -153,7 +153,8 @@ export class AdtEnhancement
           badi_definition: config.badiDefinition,
           masterSystem: this.systemContext.masterSystem,
           responsible: this.systemContext.responsible,
-          masterLanguage: this.systemContext.masterLanguage,
+          masterLanguage:
+            config.masterLanguage ?? this.systemContext.masterLanguage,
         },
         this.logger,
       );

--- a/src/core/enhancement/create.ts
+++ b/src/core/enhancement/create.ts
@@ -58,10 +58,10 @@ function buildCreateXml(
   return `<?xml version="1.0" encoding="UTF-8"?>
 <enh:enhancement xmlns:enh="http://www.sap.com/adt/enhancements" xmlns:adtcore="http://www.sap.com/adt/core"
   adtcore:description="${description}"
-  adtcore:language="EN"
+  adtcore:language="${args.masterLanguage || 'EN'}"
   adtcore:name="${args.enhancement_name}"
   adtcore:type="${typeCode}"
-  adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${args.package_name}"/>
   ${enhancementSpecificXml}
 </enh:enhancement>`;

--- a/src/core/enhancement/types.ts
+++ b/src/core/enhancement/types.ts
@@ -46,6 +46,7 @@ export interface ICreateEnhancementParams {
   source_code?: string; // For enhoxhh only
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateEnhancementParams {

--- a/src/core/enhancement/types.ts
+++ b/src/core/enhancement/types.ts
@@ -83,6 +83,7 @@ export interface IValidateEnhancementParams {
  */
 export interface IEnhancementConfig {
   enhancementName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   enhancementType: EnhancementType;
   description?: string;
   packageName?: string;

--- a/src/core/functionGroup/AdtFunctionGroup.ts
+++ b/src/core/functionGroup/AdtFunctionGroup.ts
@@ -161,6 +161,7 @@ export class AdtFunctionGroup
           description: config.description,
           masterSystem: config.masterSystem ?? this.systemContext.masterSystem,
           responsible: config.responsible ?? this.systemContext.responsible,
+          masterLanguage: this.systemContext.masterLanguage,
         },
         this.logger,
         this.contentTypes,

--- a/src/core/functionGroup/AdtFunctionGroup.ts
+++ b/src/core/functionGroup/AdtFunctionGroup.ts
@@ -161,7 +161,8 @@ export class AdtFunctionGroup
           description: config.description,
           masterSystem: config.masterSystem ?? this.systemContext.masterSystem,
           responsible: config.responsible ?? this.systemContext.responsible,
-          masterLanguage: this.systemContext.masterLanguage,
+          masterLanguage:
+            config.masterLanguage ?? this.systemContext.masterLanguage,
         },
         this.logger,
         this.contentTypes,

--- a/src/core/functionGroup/create.ts
+++ b/src/core/functionGroup/create.ts
@@ -62,7 +62,7 @@ export async function create(
   const limitedDescription = limitDescription(params.description);
   // Build XML payload - no escaping (same as old working code)
   const xmlPayload = `<?xml version="1.0" encoding="UTF-8"?>
-<group:abapFunctionGroup xmlns:group="http://www.sap.com/adt/functions/groups" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${limitedDescription}" adtcore:language="EN" adtcore:name="${params.functionGroupName}" adtcore:type="FUGR/F" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+<group:abapFunctionGroup xmlns:group="http://www.sap.com/adt/functions/groups" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${limitedDescription}" adtcore:language="${params.masterLanguage || 'EN'}" adtcore:name="${params.functionGroupName}" adtcore:type="FUGR/F" adtcore:masterLanguage="${params.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${params.packageName}"/>
 </group:abapFunctionGroup>`;
 

--- a/src/core/functionGroup/types.ts
+++ b/src/core/functionGroup/types.ts
@@ -12,6 +12,7 @@ export interface ICreateFunctionGroupParams {
   transportRequest?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateFunctionGroupParams {

--- a/src/core/functionGroup/types.ts
+++ b/src/core/functionGroup/types.ts
@@ -32,6 +32,7 @@ export interface IDeleteFunctionGroupParams {
 // description is required for create/validate operations
 export interface IFunctionGroupConfig {
   functionGroupName: string; // Required
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -120,6 +120,7 @@ export class AdtInterface
           description: config.description,
           masterSystem: this.systemContext.masterSystem,
           responsible: this.systemContext.responsible,
+          masterLanguage: this.systemContext.masterLanguage,
         },
         this.logger,
       );

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -120,7 +120,8 @@ export class AdtInterface
           description: config.description,
           masterSystem: this.systemContext.masterSystem,
           responsible: this.systemContext.responsible,
-          masterLanguage: this.systemContext.masterLanguage,
+          masterLanguage:
+            config.masterLanguage ?? this.systemContext.masterLanguage,
         },
         this.logger,
       );

--- a/src/core/interface/create.ts
+++ b/src/core/interface/create.ts
@@ -54,7 +54,7 @@ export async function create(
     ? ` adtcore:responsible="${finalResponsible}"`
     : '';
 
-  const payload = `<?xml version="1.0" encoding="UTF-8"?><intf:abapInterface xmlns:intf="http://www.sap.com/adt/oo/interfaces" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${limitedDescription}" adtcore:language="EN" adtcore:name="${params.interfaceName}" adtcore:type="INTF/OI" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  const payload = `<?xml version="1.0" encoding="UTF-8"?><intf:abapInterface xmlns:intf="http://www.sap.com/adt/oo/interfaces" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${limitedDescription}" adtcore:language="${params.masterLanguage || 'EN'}" adtcore:name="${params.interfaceName}" adtcore:type="INTF/OI" adtcore:masterLanguage="${params.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
 
 
 

--- a/src/core/interface/types.ts
+++ b/src/core/interface/types.ts
@@ -15,6 +15,7 @@ export interface ICreateInterfaceParams {
   transportRequest?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateInterfaceSourceParams {

--- a/src/core/interface/types.ts
+++ b/src/core/interface/types.ts
@@ -34,6 +34,7 @@ export interface IDeleteInterfaceParams {
 // description is required for create/validate operations
 export interface IInterfaceConfig extends IAdtObjectConfig {
   interfaceName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/metadataExtension/AdtMetadataExtension.ts
+++ b/src/core/metadataExtension/AdtMetadataExtension.ts
@@ -125,7 +125,8 @@ export class AdtMetadataExtension
         packageName: config.packageName,
         transportRequest: config.transportRequest,
         description: config.description,
-        masterLanguage: config.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
         masterSystem: config.masterSystem ?? this.systemContext.masterSystem,
         responsible: config.responsible ?? this.systemContext.responsible,
       });

--- a/src/core/metadataExtension/create.ts
+++ b/src/core/metadataExtension/create.ts
@@ -52,7 +52,7 @@ export async function createMetadataExtension(
     ? ` adtcore:responsible="${responsible}"`
     : '';
 
-  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><ddlxsources:ddlxSource xmlns:ddlxsources="http://www.sap.com/adt/ddic/ddlxsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${params.name}" adtcore:type="DDLX/EX" adtcore:masterLanguage="${masterLanguage}"${masterSystemAttr}${responsibleAttr}>
+  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><ddlxsources:ddlxSource xmlns:ddlxsources="http://www.sap.com/adt/ddic/ddlxsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${masterLanguage}" adtcore:name="${params.name}" adtcore:type="DDLX/EX" adtcore:masterLanguage="${masterLanguage}"${masterSystemAttr}${responsibleAttr}>
     ${
       params.transportRequest
         ? `<adtcore:packageRef adtcore:name="${params.packageName}">

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -141,7 +141,8 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
           sourceCode: options?.sourceCode || config.sourceCode,
           masterSystem: this.systemContext.masterSystem,
           responsible: this.systemContext.responsible,
-          masterLanguage: this.systemContext.masterLanguage,
+          masterLanguage:
+            config.masterLanguage ?? this.systemContext.masterLanguage,
         },
         this.contentTypes,
       );

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -141,6 +141,7 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
           sourceCode: options?.sourceCode || config.sourceCode,
           masterSystem: this.systemContext.masterSystem,
           responsible: this.systemContext.responsible,
+          masterLanguage: this.systemContext.masterLanguage,
         },
         this.contentTypes,
       );

--- a/src/core/program/create.ts
+++ b/src/core/program/create.ts
@@ -93,13 +93,14 @@ export async function create(
 
   const masterSystem = args.masterSystem || '';
   const username = args.responsible || '';
+  const lang = args.masterLanguage || 'EN';
 
   const masterSystemAttr = masterSystem
     ? ` adtcore:masterSystem="${masterSystem}"`
     : '';
   const responsibleAttr = username ? ` adtcore:responsible="${username}"` : '';
 
-  const metadataXml = `<?xml version="1.0" encoding="UTF-8"?><program:abapProgram xmlns:program="http://www.sap.com/adt/programs/programs" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${args.programName}" adtcore:type="PROG/P" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr} program:programType="${programType}" program:application="${application}">
+  const metadataXml = `<?xml version="1.0" encoding="UTF-8"?><program:abapProgram xmlns:program="http://www.sap.com/adt/programs/programs" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${lang}" adtcore:name="${args.programName}" adtcore:type="PROG/P" adtcore:masterLanguage="${lang}"${masterSystemAttr}${responsibleAttr} program:programType="${programType}" program:application="${application}">
   <adtcore:packageRef adtcore:name="${args.packageName}"/>
 </program:abapProgram>`;
 

--- a/src/core/program/types.ts
+++ b/src/core/program/types.ts
@@ -12,6 +12,7 @@ export interface ICreateProgramParams {
   transportRequest?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
   programType?: string;
   application?: string;
   sourceCode?: string;

--- a/src/core/program/types.ts
+++ b/src/core/program/types.ts
@@ -35,6 +35,7 @@ export interface IDeleteProgramParams {
 // description is required for create/validate operations
 export interface IProgramConfig {
   programName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/service/AdtService.ts
+++ b/src/core/service/AdtService.ts
@@ -5,6 +5,7 @@ import type {
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import { XMLParser } from 'fast-xml-parser';
+import type { IAdtSystemContext } from '../../clients/AdtClient';
 import {
   ACCEPT_CHECK_MESSAGES,
   ACCEPT_DELETION,
@@ -41,12 +42,18 @@ import { resolveBindingVariant } from './types';
 export class AdtServiceBinding implements IAdtServiceBinding {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
+  private readonly systemContext: IAdtSystemContext;
 
   public readonly objectType: string = 'ServiceBinding';
 
-  constructor(connection: IAbapConnection, logger?: ILogger) {
+  constructor(
+    connection: IAbapConnection,
+    logger?: ILogger,
+    systemContext?: IAdtSystemContext,
+  ) {
     this.connection = connection;
     this.logger = logger;
+    this.systemContext = systemContext ?? {};
   }
 
   private parser = new XMLParser({
@@ -682,9 +689,19 @@ export class AdtServiceBinding implements IAdtServiceBinding {
     const systemInfo = await getSystemInformation(this.connection);
     const createParams: ICreateServiceBindingParams = {
       ...params,
-      masterLanguage: params.masterLanguage ?? systemInfo?.language ?? 'EN',
-      masterSystem: params.masterSystem ?? systemInfo?.systemID,
-      responsible: params.responsible ?? systemInfo?.userName,
+      masterLanguage:
+        params.masterLanguage ??
+        this.systemContext.masterLanguage ??
+        systemInfo?.language ??
+        'EN',
+      masterSystem:
+        params.masterSystem ??
+        this.systemContext.masterSystem ??
+        systemInfo?.systemID,
+      responsible:
+        params.responsible ??
+        this.systemContext.responsible ??
+        systemInfo?.userName,
     };
 
     const queryParams = params.transportRequest

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -130,6 +130,7 @@ export class AdtServiceDefinition
         source_code: options?.sourceCode || config.sourceCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       this.logger?.info?.('Service definition created');

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -130,7 +130,8 @@ export class AdtServiceDefinition
         source_code: options?.sourceCode || config.sourceCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       this.logger?.info?.('Service definition created');

--- a/src/core/serviceDefinition/create.ts
+++ b/src/core/serviceDefinition/create.ts
@@ -35,7 +35,7 @@ export async function create(
     ? ` adtcore:masterSystem="${masterSystem}"`
     : '';
 
-  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><srvd:srvdSource xmlns:srvd="http://www.sap.com/adt/ddic/srvdsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${serviceDefinitionName}" adtcore:type="SRVD/SRV" adtcore:masterLanguage="EN"${masterSystemAttr} adtcore:responsible="${username}" srvd:srvdSourceType="S">
+  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><srvd:srvdSource xmlns:srvd="http://www.sap.com/adt/ddic/srvdsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${args.masterLanguage || 'EN'}" adtcore:name="${serviceDefinitionName}" adtcore:type="SRVD/SRV" adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr} adtcore:responsible="${username}" srvd:srvdSourceType="S">
   <adtcore:packageRef adtcore:name="${args.package_name.toUpperCase()}"/>
 </srvd:srvdSource>`;
 

--- a/src/core/serviceDefinition/types.ts
+++ b/src/core/serviceDefinition/types.ts
@@ -13,6 +13,7 @@ export interface ICreateServiceDefinitionParams {
   source_code?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateServiceDefinitionParams {

--- a/src/core/serviceDefinition/types.ts
+++ b/src/core/serviceDefinition/types.ts
@@ -30,6 +30,7 @@ export interface IDeleteServiceDefinitionParams {
 // Builder configuration (camelCase)
 export interface IServiceDefinitionConfig {
   serviceDefinitionName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -122,7 +122,8 @@ export class AdtStructure
         description: config.description,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -122,6 +122,7 @@ export class AdtStructure
         description: config.description,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/structure/create.ts
+++ b/src/core/structure/create.ts
@@ -34,7 +34,7 @@ export async function create(
     ? ` adtcore:responsible="${responsible}"`
     : '';
 
-  const structureXml = `<?xml version="1.0" encoding="UTF-8"?><blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${limitedDescription}" adtcore:language="EN" adtcore:name="${params.structureName.toUpperCase()}" adtcore:type="TABL/DS" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  const structureXml = `<?xml version="1.0" encoding="UTF-8"?><blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${limitedDescription}" adtcore:language="${params.masterLanguage || 'EN'}" adtcore:name="${params.structureName.toUpperCase()}" adtcore:type="TABL/DS" adtcore:masterLanguage="${params.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${params.packageName.toUpperCase()}"/>
 </blue:blueSource>`;
 

--- a/src/core/structure/types.ts
+++ b/src/core/structure/types.ts
@@ -48,6 +48,7 @@ export interface IDeleteStructureParams {
 // description is required for create/validate operations
 export interface IStructureConfig {
   structureName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/structure/types.ts
+++ b/src/core/structure/types.ts
@@ -29,6 +29,7 @@ export interface ICreateStructureParams {
   transportRequest?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateStructureParams {

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -100,7 +100,8 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
         ddl_code: options?.sourceCode || config.ddlCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -100,6 +100,7 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
         ddl_code: options?.sourceCode || config.ddlCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/table/create.ts
+++ b/src/core/table/create.ts
@@ -43,7 +43,7 @@ export async function createTable(
   // Create empty table with POST
   const createUrl = `/sap/bc/adt/ddic/tables${params.transport_request ? `?corrNr=${params.transport_request}` : ''}`;
 
-  const tableXml = `<?xml version="1.0" encoding="UTF-8"?><blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${params.table_name.toUpperCase()}" adtcore:type="TABL/DT" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  const tableXml = `<?xml version="1.0" encoding="UTF-8"?><blue:blueSource xmlns:blue="http://www.sap.com/wbobj/blue" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${params.masterLanguage || 'EN'}" adtcore:name="${params.table_name.toUpperCase()}" adtcore:type="TABL/DT" adtcore:masterLanguage="${params.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
 
   <adtcore:packageRef adtcore:name="${params.package_name.toUpperCase()}"/>
 

--- a/src/core/table/types.ts
+++ b/src/core/table/types.ts
@@ -32,6 +32,7 @@ export interface IDeleteTableParams {
 // description is required for create/validate operations
 export interface ITableConfig {
   tableName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   ddlCode?: string;

--- a/src/core/table/types.ts
+++ b/src/core/table/types.ts
@@ -12,6 +12,7 @@ export interface ICreateTableParams {
   ddl_code?: string; // Optional - can be added via update() later
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateTableParams {

--- a/src/core/tabletype/AdtDdicTableType.ts
+++ b/src/core/tabletype/AdtDdicTableType.ts
@@ -103,7 +103,8 @@ export class AdtDdicTableType
         transport_request: config.transportRequest,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/tabletype/AdtDdicTableType.ts
+++ b/src/core/tabletype/AdtDdicTableType.ts
@@ -103,6 +103,7 @@ export class AdtDdicTableType
         transport_request: config.transportRequest,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/tabletype/create.ts
+++ b/src/core/tabletype/create.ts
@@ -46,7 +46,7 @@ export async function createTableType(
   const createUrl = `/sap/bc/adt/ddic/tabletypes${params.transport_request ? `?corrNr=${params.transport_request}` : ''}`;
 
   // Empty table type XML (rowType added via update)
-  const tableTypeXml = `<?xml version="1.0" encoding="UTF-8"?><ttyp:tableType xmlns:ttyp="http://www.sap.com/dictionary/tabletype" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${params.tabletype_name.toUpperCase()}" adtcore:type="TTYP/DA" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  const tableTypeXml = `<?xml version="1.0" encoding="UTF-8"?><ttyp:tableType xmlns:ttyp="http://www.sap.com/dictionary/tabletype" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${params.masterLanguage || 'EN'}" adtcore:name="${params.tabletype_name.toUpperCase()}" adtcore:type="TTYP/DA" adtcore:masterLanguage="${params.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
     
   <adtcore:packageRef adtcore:name="${params.package_name.toUpperCase()}"/>
   

--- a/src/core/tabletype/types.ts
+++ b/src/core/tabletype/types.ts
@@ -50,6 +50,7 @@ export interface IDeleteTableTypeParams {
 // description is required for create/validate operations
 export interface ITableTypeConfig {
   tableTypeName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   // XML-based TableType parameters (TableType is XML-based entity like Domain/DataElement)

--- a/src/core/tabletype/types.ts
+++ b/src/core/tabletype/types.ts
@@ -12,6 +12,7 @@ export interface ICreateTableTypeParams {
   transport_request?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateTableTypeParams {

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -138,7 +138,8 @@ export class AdtTransformation
         description: config.description,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       this.logger?.info?.('Transformation created');

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -138,6 +138,7 @@ export class AdtTransformation
         description: config.description,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       state.createResult = createResponse;
       this.logger?.info?.('Transformation created');

--- a/src/core/transformation/create.ts
+++ b/src/core/transformation/create.ts
@@ -30,7 +30,7 @@ export async function create(
     ? ` adtcore:masterSystem="${masterSystem}"`
     : '';
 
-  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><trans:transformation xmlns:trans="http://www.sap.com/adt/transformation" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${transformationName}" adtcore:type="XSLT/VT" adtcore:masterLanguage="EN"${masterSystemAttr} adtcore:responsible="${username}" trans:transformationType="${args.transformation_type}">
+  const xmlBody = `<?xml version="1.0" encoding="UTF-8"?><trans:transformation xmlns:trans="http://www.sap.com/adt/transformation" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${args.masterLanguage || 'EN'}" adtcore:name="${transformationName}" adtcore:type="XSLT/VT" adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr} adtcore:responsible="${username}" trans:transformationType="${args.transformation_type}">
   <adtcore:packageRef adtcore:name="${args.package_name.toUpperCase()}"/>
 </trans:transformation>`;
 

--- a/src/core/transformation/types.ts
+++ b/src/core/transformation/types.ts
@@ -11,6 +11,7 @@ export interface ICreateTransformationParams {
   transport_request?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateTransformationParams {

--- a/src/core/transformation/types.ts
+++ b/src/core/transformation/types.ts
@@ -28,6 +28,7 @@ export interface IDeleteTransformationParams {
 // Builder configuration (camelCase)
 export interface ITransformationConfig {
   transformationName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   transformationType: TransformationType;
   packageName?: string;
   transportRequest?: string;

--- a/src/core/view/AdtView.ts
+++ b/src/core/view/AdtView.ts
@@ -118,7 +118,8 @@ export class AdtView implements IAdtObject<IViewConfig, IViewState> {
         ddl_source: options?.sourceCode || config.ddlSource,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
-        masterLanguage: this.systemContext.masterLanguage,
+        masterLanguage:
+          config.masterLanguage ?? this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/view/AdtView.ts
+++ b/src/core/view/AdtView.ts
@@ -118,6 +118,7 @@ export class AdtView implements IAdtObject<IViewConfig, IViewState> {
         ddl_source: options?.sourceCode || config.ddlSource,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
+        masterLanguage: this.systemContext.masterLanguage,
       });
       objectCreated = true;
       state.createResult = createResponse;

--- a/src/core/view/create.ts
+++ b/src/core/view/create.ts
@@ -36,7 +36,7 @@ async function createDDLSObject(
     ? ` adtcore:responsible="${responsible}"`
     : '';
 
-  const metadataXml = `<?xml version="1.0" encoding="UTF-8"?><ddl:ddlSource xmlns:ddl="http://www.sap.com/adt/ddic/ddlsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${args.view_name}" adtcore:type="DDLS/DF" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+  const metadataXml = `<?xml version="1.0" encoding="UTF-8"?><ddl:ddlSource xmlns:ddl="http://www.sap.com/adt/ddic/ddlsources" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${args.masterLanguage || 'EN'}" adtcore:name="${args.view_name}" adtcore:type="DDLS/DF" adtcore:masterLanguage="${args.masterLanguage || 'EN'}"${masterSystemAttr}${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${args.package_name}"/>
 </ddl:ddlSource>`;
 

--- a/src/core/view/types.ts
+++ b/src/core/view/types.ts
@@ -34,6 +34,7 @@ export interface IDeleteViewParams {
 // description is required for create/validate operations
 export interface IViewConfig {
   viewName: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   packageName?: string; // Required for create operations, optional for others
   transportRequest?: string; // Only optional parameter
   description?: string; // Required for create/validate operations, optional for others

--- a/src/core/view/types.ts
+++ b/src/core/view/types.ts
@@ -13,6 +13,7 @@ export interface ICreateViewParams {
   description?: string;
   masterSystem?: string;
   responsible?: string;
+  masterLanguage?: string;
 }
 
 export interface IUpdateViewSourceParams {


### PR DESCRIPTION
## What

Make the master/original language of newly created objects configurable instead of hardcoded `EN`.

## Why

Every `core/<type>/create.ts` hardcoded `adtcore:language="EN"` and `adtcore:masterLanguage="EN"`, so objects were always created as EN-original regardless of the configured logon language (fr0ster/mcp-abap-adt#105: `SAP_LANGUAGE=ZH` → object still EN). Unlike `masterSystem`/`responsible`, there was no channel to carry a language.

## Change

- `IAdtClientOptions.masterLanguage` → `IAdtSystemContext.masterLanguage`.
- Each `AdtXxx.create()` passes `this.systemContext.masterLanguage` into the low-level create params.
- New optional `masterLanguage?` on each `ICreate*Params`.
- `create.ts` uses `args.masterLanguage || 'EN'` for both `adtcore:language` and `adtcore:masterLanguage`.
- **Default stays `EN`** — additive, nothing breaks; `masterSystem`/`responsible` untouched.

Covers 14 object types: class, program, interface, view, domain, structure, table, table type, data element, function group, service definition, access control, transformation, enhancement.

## Design (language semantics)

Master language is meant to track the **logon language** (`SAP_LANGUAGE`) so the object's original language matches the session — this avoids SAP's *original-vs-logon* edit conflict (object created in DE, edited while logged in IT → edits become a translation). The consumer resolves `master_language (per-call override) → SAP_LANGUAGE → EN` and passes the result as the `masterLanguage` option; the library just writes it.

## Out of scope

`package` — its `ICreatePackageParams` lives in `@mcp-abap-adt/interfaces`; covering it needs a separate upstream change (follow-up).

## Verification

`npm run build` (biome + tsc) clean; 141 unit tests pass.

Closes #40
Refs fr0ster/mcp-abap-adt#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
