### PR TITLE
test(105): config-driven master-language integration test

### DIFF
--- a/src/__tests__/helpers/sessionConfig.ts
+++ b/src/__tests__/helpers/sessionConfig.ts
@@ -130,17 +130,27 @@ export async function resolveSystemContext(
   connection: IAbapConnection,
   isCloud: boolean,
 ): Promise<
-  Pick<IAdtClientOptions, 'masterSystem' | 'responsible' | 'unicode'>
+  Pick<
+    IAdtClientOptions,
+    'masterSystem' | 'responsible' | 'unicode' | 'masterLanguage'
+  >
 > {
+  const { getEnvironmentConfig } = require('./test-helper');
+  // Optional master/original language for created objects (e.g. "DE", "ZH").
+  // Empty/undefined → the library defaults to EN. Sourced from test-config so
+  // each system can pin a language it actually has installed.
+  const masterLanguage =
+    getEnvironmentConfig().default_master_language || undefined;
+
   if (isCloud) {
     const systemInfo = await getSystemInformation(connection);
     return {
       masterSystem: systemInfo?.systemID,
       responsible: systemInfo?.userName,
       unicode: true,
+      masterLanguage,
     };
   }
-  const { getEnvironmentConfig } = require('./test-helper');
   const envConfig = getEnvironmentConfig();
   const rawUnicode = process.env.SAP_UNICODE;
   const unicode = rawUnicode
@@ -150,6 +160,7 @@ export async function resolveSystemContext(
     masterSystem: envConfig.default_master_system,
     responsible: process.env.SAP_USERNAME,
     unicode,
+    masterLanguage,
   };
 }
 

--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -88,6 +88,7 @@ environment:
   default_package: "ZADT_TEST"               # ← CHANGE: your dev package (Z*/Y*) or "$TMP" for local
   default_transport: ""                       # ← CHANGE: transport request (leave "" for $TMP/local packages)
   default_master_system: ""                   # ← CHANGE: SAP system ID (on-prem only, cloud gets it automatically)
+  default_master_language: ""                 # Master/original language for created objects (e.g. "DE", "ZH"). "" → EN. Must be a language installed on the system, else SAP normalizes it to the system default.
   skip_cleanup: false    # Skip cleanup after test (objects left for analysis) - can be overridden per test case
   # connection_type: "rfc"  # Transport mechanism: "rfc" or "http". RFC works on any system type.
   # is_legacy: true         # Uncomment for BASIS < 7.50 systems (e.g. E77). Also set SAP_UNICODE=false in .env for non-unicode systems.

--- a/src/__tests__/integration/core/masterLanguage/MasterLanguage.test.ts
+++ b/src/__tests__/integration/core/masterLanguage/MasterLanguage.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration test for master/original language on create (fr0ster/mcp-abap-adt#105).
+ *
+ * Verifies that the language configured via `environment.default_master_language`
+ * in test-config.yaml is:
+ *   1. sent on the create request (adtcore:language + adtcore:masterLanguage), and
+ *   2. persisted on the created object (round-trip read).
+ *
+ * On a system where the configured language is not installed, SAP normalizes the
+ * master language to the system default — so set `default_master_language` only to
+ * a language the target system actually has (leave "" → EN, which every system has).
+ *
+ * Run: npm test -- integration/core/masterLanguage
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import * as dotenv from 'dotenv';
+import type { AdtClient } from '../../../../clients/AdtClient';
+import { isCloudEnvironment } from '../../../../utils/systemInfo';
+import {
+  createTestAdtClient,
+  getConfig,
+  getConnectionOptions,
+  resolveSystemContext,
+} from '../../../helpers/sessionConfig';
+
+const {
+  resolvePackageName,
+  getTimeout,
+} = require('../../../helpers/test-helper');
+
+const envPath =
+  process.env.MCP_ENV_PATH || path.resolve(__dirname, '../../../../.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath, quiet: true });
+}
+
+const silentLogger: ILogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function masterLangOf(xml: string): string | undefined {
+  return xml.match(/adtcore:masterLanguage="([^"]*)"/)?.[1];
+}
+
+describe('Master language on create (#105)', () => {
+  let connection: IAbapConnection;
+  let client: AdtClient;
+  let hasConfig = false;
+  let expectedLang = 'EN';
+  let sentLang: string | undefined;
+  const className = 'ZCL_AC_MASTERLANG_IT';
+  let packageName = 'ZADT_BLD_PKG03';
+
+  beforeAll(async () => {
+    if (!process.env.SAP_URL) {
+      return;
+    }
+    hasConfig = true;
+    const config = getConfig();
+    connection = createAbapConnection(
+      config,
+      silentLogger,
+      undefined,
+      undefined,
+      getConnectionOptions(),
+    );
+    await (connection as { connect(): Promise<void> }).connect();
+
+    const isCloud = await isCloudEnvironment(connection);
+    const systemContext = await resolveSystemContext(connection, isCloud);
+    expectedLang = systemContext.masterLanguage || 'EN';
+    packageName = resolvePackageName();
+
+    // Capture the language actually sent on the class create POST.
+    const original = connection.makeAdtRequest.bind(connection);
+    (connection as { makeAdtRequest: typeof original }).makeAdtRequest = async (
+      options,
+    ) => {
+      const body = String((options as { data?: unknown }).data ?? '');
+      if (
+        (options as { method?: string }).method === 'POST' &&
+        body.includes('class:abapClass')
+      ) {
+        sentLang = masterLangOf(body);
+      }
+      return original(options);
+    };
+
+    ({ client } = await createTestAdtClient(
+      connection,
+      silentLogger,
+      systemContext,
+    ));
+  }, getTimeout('connection') ?? 60000);
+
+  it(
+    'creates a class whose master language matches test-config default_master_language',
+    async () => {
+      if (!hasConfig) {
+        console.warn('No SAP config — skipping master language test');
+        return;
+      }
+
+      const cls = client.getClass();
+      // idempotent: remove any leftover from a previous run
+      try {
+        await cls.delete({ className });
+      } catch {
+        /* not present */
+      }
+
+      try {
+        await cls.create({
+          className,
+          packageName,
+          description: 'master language integration probe',
+        });
+
+        // 1. The create request must carry the configured language.
+        expect(sentLang).toBe(expectedLang);
+
+        // 2. Round-trip: the persisted master language must match — but only
+        //    when the configured language is installed on the system (else SAP
+        //    normalizes it). Metadata of a freshly created inactive object may
+        //    not be immediately readable, so retry a few times; if it stays
+        //    unreadable, the wire assertion above already proves the feature.
+        let persisted: string | undefined;
+        for (let attempt = 0; attempt < 8 && !persisted; attempt++) {
+          try {
+            const meta = await cls.readMetadata({ className });
+            persisted = masterLangOf(String(meta.metadataResult?.data ?? ''));
+          } catch {
+            /* not ready yet */
+          }
+          if (!persisted) {
+            await new Promise((r) => setTimeout(r, 2000));
+          }
+        }
+        if (persisted !== undefined) {
+          expect(persisted).toBe(expectedLang);
+        } else {
+          console.warn(
+            `Could not read back metadata for ${className} — persistence check skipped (wire language was "${sentLang}")`,
+          );
+        }
+      } finally {
+        try {
+          await cls.delete({ className });
+        } catch {
+          /* best effort cleanup */
+        }
+      }
+    },
+    getTimeout('create') ?? 120000,
+  );
+});


### PR DESCRIPTION
## What

A config-driven integration test for the master/original language feature (#40/#41), plus the test-config plumbing it needs.

## Change

- `environment.default_master_language` added to `test-config.yaml.template` (e.g. `"DE"`, `"ZH"`; `""` → EN).
- `resolveSystemContext()` now sources `masterLanguage` from it, so every test-created object uses the configured language.
- New `integration/core/masterLanguage/MasterLanguage.test.ts`:
  - **Hard assertion** — the class create POST carries the configured `adtcore:masterLanguage` (deterministic; proves the wire path on any system).
  - **Round-trip** — the persisted master language must equal the configured one when the object's metadata is readable. Skipped with a warning when a freshly created inactive object's metadata isn't immediately readable (e.g. EN-only BTP trial).

## Verified

Ran on BTP ABAP trial: the create POST carries the configured language. Trial is effectively EN-only, so it normalizes any non-installed master language to the system default — set `default_master_language` to an installed language on a multi-language system to get the hard persistence check.

Refs fr0ster/mcp-abap-adt#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
