### PR TITLE
release(5.6.0): package master language (#105) + behaviorDefinition namespace fix (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.0] - 2026-06-13
+
+### Added
+- **`package` create now honours the configurable master language** (fr0ster/mcp-abap-adt#105). `IPackageConfig.masterLanguage` + `ICreatePackageParams.master_language` (interfaces 7.3.0) feed both `adtcore:language` and `adtcore:masterLanguage`; resolves `config.masterLanguage → systemContext.masterLanguage → EN`, with blank (empty/whitespace) treated as unset and surrounding spaces trimmed. Default stays EN. Brings `package` in line with the other object types.
+
+### Changed
+- Bumped `@mcp-abap-adt/interfaces` from `^7.0.0` to `^7.3.0` (adds `ICreatePackageParams.master_language`).
+
+### Fixed
+- **behaviorDefinition: URL-encode namespaced object names in ADT paths** (#37, thanks @eseuve). Namespaced behavior definitions (`/NSP/…`) could not be read/locked/updated/activated/checked/unlocked/deleted because the raw `/` broke the ADT path; names are now wrapped with `encodeSapObjectName(...)` across all path-based operations, matching class/interface/view.
+
 ## [5.5.0] - 2026-06-12
 
 ### Added

--- a/docs/superpowers/plans/2026-06-13-package-master-language.md
+++ b/docs/superpowers/plans/2026-06-13-package-master-language.md
@@ -1,0 +1,225 @@
+# Package master-language Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cover the `package` object type with the configurable master language (#105), shipped in adt-clients 5.6.0, bundled with the external behaviorDefinition namespace fix (PR #37) when that is merged first.
+
+**Architecture:** `package` create params come from `@mcp-abap-adt/interfaces` (`ICreatePackageParams`, now with `master_language` in 7.3.0). The high-level `AdtPackage.create()` resolves `config.masterLanguage?.trim() || systemContext.masterLanguage?.trim() || undefined`; the low-level `create.ts` writes `params.master_language?.trim() || 'EN'` into both `adtcore:language` and `adtcore:masterLanguage`. Blank (empty/whitespace) = unset.
+
+**Tech Stack:** TypeScript, Jest, Biome. Worktree `~/prj/mcp-abap-adt-clients-pkg`, branch `feat/package-master-language`. Spec: `docs/superpowers/specs/2026-06-13-package-master-language-design.md`.
+
+---
+
+### Task 1: Bundle base — merge #37, rebase, bump interfaces dep
+
+**Files:** `package.json`, `package-lock.json`
+
+- [ ] **Step 1: Merge PR #37 into main** (skip this task's #37 steps if not bundling)
+
+```bash
+gh pr merge 37 --repo fr0ster/mcp-abap-adt-clients --squash --delete-branch
+```
+Expected: state MERGED. If CI is `action_required` (fork), approve the run, confirm green, then merge.
+
+- [ ] **Step 2: Rebase the worktree onto updated main**
+
+```bash
+cd ~/prj/mcp-abap-adt-clients-pkg
+git fetch origin && git rebase origin/main
+```
+Expected: clean rebase; branch now includes #37.
+
+- [ ] **Step 3: Bump interfaces dep to ^7.3.0 and install**
+
+Set in `package.json`: `"@mcp-abap-adt/interfaces": "^7.3.0",` then:
+```bash
+npm install
+```
+
+- [ ] **Step 4: Verify install**
+
+```bash
+grep '"version"' node_modules/@mcp-abap-adt/interfaces/package.json | head -1
+grep -c '"link": true' package-lock.json
+grep -n "master_language" node_modules/@mcp-abap-adt/interfaces/dist/adt/IAdtPackage.d.ts
+```
+Expected: `7.3.0`; `0`; `master_language?: string` present.
+
+---
+
+### Task 2: Failing unit tests (full contract)
+
+**Files:** Modify `src/__tests__/unit/core/masterLanguage.test.ts`
+
+- [ ] **Step 1: Add imports** at the top of the file:
+
+```typescript
+import { AdtPackage } from '../../../core/package/AdtPackage';
+import { createPackage } from '../../../core/package/create';
+```
+
+- [ ] **Step 2: Add the package describe block** inside the top-level `describe('masterLanguage on create', ...)`:
+
+```typescript
+  describe('package create master language', () => {
+    function pkgBody(connection: IAbapConnection): string {
+      const call = (connection.makeAdtRequest as jest.Mock).mock.calls.find(
+        (c) => String(c[0]?.data).includes('pak:package'),
+      );
+      return String(call?.[0]?.data);
+    }
+
+    const baseParams = {
+      package_name: 'ZAC_PKG_ML',
+      super_package: 'ZLOCAL',
+      description: 'master language probe',
+      software_component: 'ZLOCAL',
+      record_changes: false,
+    };
+    const baseConfig = {
+      packageName: 'ZAC_PKG_ML',
+      superPackage: 'ZLOCAL',
+      description: 'master language probe',
+      softwareComponent: 'ZLOCAL',
+    };
+
+    // High-level AdtPackage.create() resolution (cases 1-7)
+    it('high-level: config language in both attributes', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, {}).create({ ...baseConfig, masterLanguage: 'DE' } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="DE"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="DE"');
+    });
+    it('high-level: systemContext fallback', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({ ...baseConfig } as never);
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="IT"');
+    });
+    it('high-level: config overrides systemContext', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({ ...baseConfig, masterLanguage: 'FR' } as never);
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="FR"');
+    });
+    it('high-level: neither set → EN', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, {}).create({ ...baseConfig } as never);
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="EN"');
+    });
+    it('high-level: empty config falls through to systemContext', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({ ...baseConfig, masterLanguage: '' } as never);
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="IT"');
+    });
+    it('high-level: whitespace config falls through to systemContext', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({ ...baseConfig, masterLanguage: '   ' } as never);
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="IT"');
+    });
+    it('high-level: surrounding spaces are trimmed', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, {}).create({ ...baseConfig, masterLanguage: ' DE ' } as never);
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="DE"');
+    });
+
+    // Low-level createPackage() defensive trim (case 8)
+    it('low-level: blank → EN, surrounding spaces trimmed', async () => {
+      const c1 = mockConnection();
+      await createPackage(c1, { ...baseParams, master_language: '   ' } as never);
+      expect(pkgBody(c1)).toContain('adtcore:masterLanguage="EN"');
+      const c2 = mockConnection();
+      await createPackage(c2, { ...baseParams, master_language: ' DE ' } as never);
+      expect(pkgBody(c2)).toContain('adtcore:masterLanguage="DE"');
+    });
+  });
+```
+
+- [ ] **Step 3: Run, verify they fail**
+
+Run: `npx jest src/__tests__/unit/core/masterLanguage.test.ts -t "package create master language"`
+Expected: FAIL — `create.ts` hardcodes `="EN"`; `IPackageConfig`/`AdtPackage.create()` don't yet carry `masterLanguage`.
+
+---
+
+### Task 3: Implement
+
+**Files:** `src/core/package/types.ts`, `src/core/package/AdtPackage.ts`, `src/core/package/create.ts`
+
+- [ ] **Step 1: `IPackageConfig` += masterLanguage** — in `src/core/package/types.ts`, after `masterSystem?: string;`:
+
+```typescript
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
+```
+
+- [ ] **Step 2: `AdtPackage.create()`** — in the `await createPackage(this.connection, { ... })` params object, after `master_system: this.systemContext.masterSystem,`:
+
+```typescript
+        master_language:
+          config.masterLanguage?.trim() ||
+          this.systemContext.masterLanguage?.trim() ||
+          undefined,
+```
+
+- [ ] **Step 3: `create.ts`** — after `const masterSystem = params.master_system;`:
+
+```typescript
+  const lang = params.master_language?.trim() || 'EN';
+```
+Then in `xmlBody`: `adtcore:language="EN"` → `adtcore:language="${lang}"` and `adtcore:masterLanguage="EN"` → `adtcore:masterLanguage="${lang}"`.
+
+---
+
+### Task 4: Verify
+
+- [ ] **Step 1: Build** — `npm run build` → biome + tsc clean. (If biome flags formatting: `npm run lint`, then re-run.)
+- [ ] **Step 2: Package tests** — `npx jest src/__tests__/unit/core/masterLanguage.test.ts -t "package create master language"` → PASS (8 cases).
+- [ ] **Step 3: Full unit suite** — `npx jest src/__tests__/unit` → all PASS (prior + new package + #37 Namespace tests).
+
+---
+
+### Task 5: Version + CHANGELOG + lock
+
+**Files:** `package.json`, `package-lock.json`, `CHANGELOG.md`
+
+- [ ] **Step 1: Bump to 5.6.0** — `package.json` `"version": "5.6.0"`; `package-lock.json` root version (lines 3 and 9) → `5.6.0`.
+- [ ] **Step 2: CHANGELOG** — add at top:
+
+```markdown
+## [5.6.0] - 2026-06-13
+
+### Added
+- **`package` create honours the configurable master language** (fr0ster/mcp-abap-adt#105). `IPackageConfig.masterLanguage` + `ICreatePackageParams.master_language` (interfaces 7.3.0) feed both `adtcore:language` and `adtcore:masterLanguage`; resolves `config.masterLanguage → systemContext.masterLanguage → EN`, treating blank (empty/whitespace) as unset. Default stays EN.
+
+### Changed
+- Bumped `@mcp-abap-adt/interfaces` from `^7.0.0` to `^7.3.0`.
+
+### Fixed
+- **behaviorDefinition: URL-encode namespaced object names in ADT paths** (#37). Wrapped names with `encodeSapObjectName(...)` across all path-based ops (lock/unlock/update/read/check/activate/delete). *(Include only if #37 was bundled.)*
+```
+
+- [ ] **Step 3: Verify lockfile** — `grep -cE '"link": true|"file:' package-lock.json` → `0`.
+
+---
+
+### Task 6: Commit, push, PR
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add src/core/package src/__tests__/unit/core/masterLanguage.test.ts docs/superpowers package.json package-lock.json CHANGELOG.md
+git commit -m "feat(5.6.0): master language for package create (+ behaviorDefinition namespace fix #37 if bundled)"
+```
+(Do NOT stage the restored `docs/superpowers/specs/2026-04-14-*.md` — they are unchanged.)
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin feat/package-master-language
+gh pr create --repo fr0ster/mcp-abap-adt-clients --base main --head feat/package-master-language --title "feat(5.6.0): package master language (+ behaviorDefinition namespace fix #37)" --body "<summary + Refs #105>"
+```
+After merge: tag `v5.6.0`; user publishes.
+
+---
+
+## Out of scope
+- Consumer (`mcp-abap-adt`) inbound `X-SAP-Language` header override + per-call `master_language` tool param.
+- Realigning the 14 local `ICreate*Params` to `@mcp-abap-adt/interfaces`.

--- a/docs/superpowers/specs/2026-06-13-package-master-language-design.md
+++ b/docs/superpowers/specs/2026-06-13-package-master-language-design.md
@@ -1,0 +1,121 @@
+# adt-clients: master language for `package` create — design
+
+**Scope:** `@mcp-abap-adt/adt-clients` only. Issue fr0ster/mcp-abap-adt#105.
+
+## Context
+
+#105 makes the master/original language of created objects configurable
+instead of hardcoded `EN`. The language is delivered via the **create payload**
+(`adtcore:language` / `adtcore:masterLanguage`).
+
+**Resolution semantics (fixed, consistent at every step):** a *blank* value —
+empty **or whitespace-only** — is treated as *unset* and falls through;
+a non-blank value is **trimmed** and used. Each tier evaluates `value?.trim()`:
+truthy → use the trimmed value, else fall to the next tier; floor is `'EN'`:
+
+```
+config.masterLanguage?.trim() || systemContext.masterLanguage?.trim() || 'EN'
+```
+
+So `''` and `'  '` fall through (do not shadow a lower tier), `' DE '` →
+`'DE'`. `?.trim()` is applied at every layer that resolves the value (both the
+high-level `AdtPackage.create()` and the low-level `create.ts`), so a blank can
+never reach the XML. This is intentionally stricter than the `||`/`??` pattern
+the 14 already-shipped types use; unifying them is part of the deferred
+interface-realignment follow-up.
+
+This shipped in **adt-clients 5.5.0** for every language-aware object type
+**except `package`**. Consumer-side wiring (the `SAP_LANGUAGE` default, the
+inbound `X-SAP-Language` header override, and the per-call `master_language`
+tool parameter) is a separate effort and **out of scope here**.
+
+## Why package was missed
+
+`package` is the only object type whose create params (`ICreatePackageParams`)
+are sourced from `@mcp-abap-adt/interfaces` rather than defined locally in
+adt-clients. #105 added `masterLanguage` to the local copies, so package was not
+covered. (Realigning the other local copies to the interface-first pattern is a
+separate, deferred follow-up — not this spec.)
+
+The interface field is already in place: **interfaces 7.3.0** added
+`ICreatePackageParams.master_language` (and dropped the unused
+`ISapConfig.language`). This spec consumes that.
+
+## Change (adt-clients)
+
+Dependency: bump `@mcp-abap-adt/interfaces` to `^7.3.0`.
+
+1. **`src/core/package/types.ts`** — `IPackageConfig`: add `masterLanguage?: string`.
+   (`ICreatePackageParams` stays re-exported from interfaces; its
+   `master_language` now exists upstream.)
+2. **`src/core/package/AdtPackage.ts`** — in `create()`, pass into the
+   `createPackage(...)` params object (next to `master_system` / `responsible`):
+   `master_language: config.masterLanguage?.trim() || this.systemContext.masterLanguage?.trim() || undefined`.
+   Blank (empty/whitespace) `config.masterLanguage` falls through to
+   `systemContext`; both blank → `undefined` (the low-level applies the `EN`
+   floor).
+3. **`src/core/package/create.ts`** — replace the hardcoded
+   `adtcore:language="EN"` and `adtcore:masterLanguage="EN"` with a single
+   `const lang = params.master_language?.trim() || 'EN'` used for **both**
+   attributes (defensive trim here too, so a direct low-level caller can't put a
+   blank into the XML).
+
+No behaviour change when `masterLanguage` is unset (still `EN`). Additive.
+
+## Bundled in the same release (not part of this design)
+
+**PR #37** — `fix(behaviorDefinition): URL-encode namespaced object names in ADT
+paths` (external contributor, commit `ff59b2f`, currently only on branch
+`fix/bdef-namespace-url-encoding` — **NOT yet in `main`**). Independent,
+self-contained bugfix with its own unit tests.
+
+In scope of this release: **merge #37 into `main` first**, then branch the
+package change off the updated `main` (so the package build/tests also exercise
+#37). Both ship in 5.6.0 to avoid two publish cycles. If #37 is not merged, the
+package change releases on its own and this bundling note does not apply.
+
+## Release
+
+**adt-clients 5.6.0** (minor: additive package language support; **plus the #37
+behaviorDefinition fix if it is merged into `main` first** — see the bundling
+section. If #37 is not bundled, 5.6.0 ships the package change alone and the
+CHANGELOG omits the #37 entry).
+Release checklist (mirrors 5.5.0): bump `version` in `package.json`, update root
+`version` in `package-lock.json` (×2), add a `CHANGELOG.md` entry, verify the
+lockfile has no `link:true`/`file:` entries. Bump + release (merge + tag) by the
+assistant; `npm publish` by the user.
+
+## Testing
+
+- Extend `src/__tests__/unit/core/masterLanguage.test.ts` with package cases
+  that lock the **full contract** (deterministic, mock connection, no live
+  system):
+  1. given `config.masterLanguage='DE'` → create POST has **both**
+     `adtcore:language="DE"` **and** `adtcore:masterLanguage="DE"`;
+  2. no config, `systemContext.masterLanguage='IT'` → both attributes `IT`
+     (systemContext fallback);
+  3. `config.masterLanguage='FR'` over `systemContext='IT'` → both `FR`
+     (config priority);
+  4. neither set → both `EN` (floor);
+  5. `config.masterLanguage=''` with `systemContext='IT'` → both `IT`
+     (empty treated as unset);
+  6. `config.masterLanguage='   '` (whitespace) with `systemContext='IT'` →
+     both `IT` (whitespace treated as unset — guards the `.trim()` path);
+  7. `config.masterLanguage=' DE '` → both `DE` (trimmed value used).
+
+  Cases 1–7 exercise the high-level `AdtPackage.create()` resolution. Add a
+  **low-level** case that calls `createPackage(...)` directly (no `AdtPackage`),
+  guarding the defensive trim in `create.ts`:
+  8. `createPackage({ …, master_language: '   ' })` → both attributes `EN`;
+     `createPackage({ …, master_language: ' DE ' })` → both `DE`.
+- Existing integration coverage (`MasterLanguage.test.ts`, config-driven) is
+  class-based; package persistence is verifiable on a multi-language system but
+  not required for this change (wire assertion suffices, mirroring 5.5.0).
+
+## Out of scope
+
+- Consumer (`mcp-abap-adt`) tiers: `SAP_LANGUAGE` default (already shipped in
+  7.0.2), inbound `X-SAP-Language` header override, per-call `master_language`
+  tool parameter.
+- Realigning the 14 local `ICreate*Params` to `@mcp-abap-adt/interfaces`.
+- Any outbound SAP session language.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^7.0.0",
+        "@mcp-abap-adt/interfaces": "^7.3.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.13.6",
         "fast-xml-parser": "^5.4.1",
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.0.0.tgz",
-      "integrity": "sha512-R5z3xSKKNWGvmebdsOGc3koNaRGj7lrkurTPY+6D4xmnVBmYqXGDvGHoi2OxsPaaaNGqT3DnqW1noxUeGE5bgg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.3.0.tgz",
+      "integrity": "sha512-9Q7L/min183Zq/0WUoHXyzB4QzeYMoizYsyDlechk9CoAq8VGJ7AYxh/EUQIS8y6lPpugtAK9McKgolImnefVA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -67,7 +67,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^7.0.0",
+    "@mcp-abap-adt/interfaces": "^7.3.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.13.6",
     "fast-xml-parser": "^5.4.1",

--- a/src/__tests__/unit/core/masterLanguage.test.ts
+++ b/src/__tests__/unit/core/masterLanguage.test.ts
@@ -1,6 +1,8 @@
 import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
 import { create as createBehaviorDefinition } from '../../../core/behaviorDefinition/create';
 import { createMetadataExtension } from '../../../core/metadataExtension/create';
+import { AdtPackage } from '../../../core/package/AdtPackage';
+import { createPackage } from '../../../core/package/create';
 import { AdtProgram } from '../../../core/program/AdtProgram';
 import { create as createProgram } from '../../../core/program/create';
 import { AdtServiceBinding } from '../../../core/service/AdtService';
@@ -124,6 +126,106 @@ describe('masterLanguage on create', () => {
         masterLanguage: 'ZH',
       } as never);
       expect(bindingBody(c)).toContain('adtcore:masterLanguage="ZH"');
+    });
+  });
+
+  describe('package create master language', () => {
+    function pkgBody(connection: IAbapConnection): string {
+      const call = (connection.makeAdtRequest as jest.Mock).mock.calls.find(
+        (c) => String(c[0]?.data).includes('pak:package'),
+      );
+      return String(call?.[0]?.data);
+    }
+
+    const baseParams = {
+      package_name: 'ZAC_PKG_ML',
+      super_package: 'ZLOCAL',
+      description: 'master language probe',
+      software_component: 'ZLOCAL',
+      record_changes: false,
+    };
+    const baseConfig = {
+      packageName: 'ZAC_PKG_ML',
+      superPackage: 'ZLOCAL',
+      description: 'master language probe',
+      softwareComponent: 'ZLOCAL',
+      responsible: 'TESTUSER',
+    };
+
+    it('high-level: config language in both attributes', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, {}).create({
+        ...baseConfig,
+        masterLanguage: 'DE',
+      } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="DE"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="DE"');
+    });
+    it('high-level: systemContext fallback', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({
+        ...baseConfig,
+      } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="IT"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="IT"');
+    });
+    it('high-level: config overrides systemContext', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({
+        ...baseConfig,
+        masterLanguage: 'FR',
+      } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="FR"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="FR"');
+    });
+    it('high-level: neither set -> EN', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, {}).create({ ...baseConfig } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="EN"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="EN"');
+    });
+    it('high-level: empty config falls through to systemContext', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({
+        ...baseConfig,
+        masterLanguage: '',
+      } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="IT"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="IT"');
+    });
+    it('high-level: whitespace config falls through to systemContext', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, { masterLanguage: 'IT' }).create({
+        ...baseConfig,
+        masterLanguage: '   ',
+      } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="IT"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="IT"');
+    });
+    it('high-level: surrounding spaces are trimmed', async () => {
+      const c = mockConnection();
+      await new AdtPackage(c, undefined, {}).create({
+        ...baseConfig,
+        masterLanguage: ' DE ',
+      } as never);
+      expect(pkgBody(c)).toContain('adtcore:language="DE"');
+      expect(pkgBody(c)).toContain('adtcore:masterLanguage="DE"');
+    });
+    it('low-level: blank -> EN, surrounding spaces trimmed', async () => {
+      const c1 = mockConnection();
+      await createPackage(c1, {
+        ...baseParams,
+        master_language: '   ',
+      } as never);
+      expect(pkgBody(c1)).toContain('adtcore:language="EN"');
+      expect(pkgBody(c1)).toContain('adtcore:masterLanguage="EN"');
+      const c2 = mockConnection();
+      await createPackage(c2, {
+        ...baseParams,
+        master_language: ' DE ',
+      } as never);
+      expect(pkgBody(c2)).toContain('adtcore:language="DE"');
+      expect(pkgBody(c2)).toContain('adtcore:masterLanguage="DE"');
     });
   });
 

--- a/src/core/package/AdtPackage.ts
+++ b/src/core/package/AdtPackage.ts
@@ -145,6 +145,10 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
         application_component: config.applicationComponent,
         responsible: config.responsible ?? this.systemContext.responsible,
         master_system: this.systemContext.masterSystem,
+        master_language:
+          config.masterLanguage?.trim() ||
+          this.systemContext.masterLanguage?.trim() ||
+          undefined,
         record_changes: config.recordChanges ?? false,
       });
       this.logger?.info?.('Package created');

--- a/src/core/package/create.ts
+++ b/src/core/package/create.ts
@@ -39,6 +39,7 @@ export async function createPackage(
   const packageType = params.package_type || 'development';
 
   const masterSystem = params.master_system;
+  const lang = params.master_language?.trim() || 'EN';
   const responsibleUser = params.responsible || '';
 
   // Software component is required for package creation
@@ -67,7 +68,7 @@ export async function createPackage(
     : '';
 
   const xmlBody = `<?xml version="1.0" encoding="UTF-8"?>
-<pak:package xmlns:pak="http://www.sap.com/adt/packages" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="EN" adtcore:name="${escapeXml(params.package_name)}" adtcore:type="DEVC/K" adtcore:version="active" adtcore:masterLanguage="EN"${masterSystemAttr}${responsibleAttr}>
+<pak:package xmlns:pak="http://www.sap.com/adt/packages" xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="${description}" adtcore:language="${lang}" adtcore:name="${escapeXml(params.package_name)}" adtcore:type="DEVC/K" adtcore:version="active" adtcore:masterLanguage="${lang}"${masterSystemAttr}${responsibleAttr}>
   <adtcore:packageRef adtcore:name="${escapeXml(params.package_name)}"/>
   <pak:attributes pak:isEncapsulated="false" pak:packageType="${packageType}" pak:recordChanges="${params.record_changes ? 'true' : 'false'}"/>
   ${superPackageXml}

--- a/src/core/package/types.ts
+++ b/src/core/package/types.ts
@@ -26,6 +26,7 @@ export interface IPackageConfig {
   applicationComponent?: string;
   responsible?: string;
   masterSystem?: string;
+  masterLanguage?: string; // Original/master language for create; falls back to systemContext (SAP_LANGUAGE), then EN
   recordChanges?: boolean;
   onLock?: (lockHandle: string) => void;
 }


### PR DESCRIPTION
## What

**adt-clients 5.6.0** — `package` create now honours the configurable master language (#105), bundled with the behaviorDefinition namespace fix (#37, already merged to `main`).

## Changes

### package master language (#105)
- `@mcp-abap-adt/interfaces` bumped `^7.0.0` → `^7.3.0` (adds `ICreatePackageParams.master_language`).
- `IPackageConfig.masterLanguage?` added.
- `AdtPackage.create()` resolves `config.masterLanguage?.trim() || systemContext.masterLanguage?.trim() || undefined`.
- `package/create.ts` writes `params.master_language?.trim() || 'EN'` into **both** `adtcore:language` and `adtcore:masterLanguage`.
- Blank (empty/whitespace) = unset; surrounding spaces trimmed; default stays `EN`. `package` is now in line with the other object types.
- 8 unit cases (high-level resolution incl. systemContext fallback / config priority / blank+whitespace fall-through / trim; low-level defensive trim), asserting **both** attributes.

### bundled: #37 (already in `main`)
- behaviorDefinition: URL-encode namespaced object names in ADT paths (thanks @eseuve). Included so 5.6.0 ships both in one publish.

## Verification
`npm run build` (biome + tsc) clean; full unit suite **163/163** pass (package + #37 Namespace tests).

Design docs: `docs/superpowers/specs/2026-06-13-package-master-language-design.md`, `docs/superpowers/plans/2026-06-13-package-master-language.md`.

Refs #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
