### PR TITLE
fix(functionInclude): delete() must not mask a server-refused deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.7.1] - 2026-06-16
+
+### Fixed
+- **`getFunctionInclude().delete()` no longer reports a phantom success.** The ADT deletion service answers HTTP 200 even when it refuses to delete (e.g. `<del:object del:isDeleted="false"><del:message del:type="E"><del:text>Only delete function module includes using Function Builder</del:text>`); the low-level `deleteFunctionInclude` previously hardcoded `{ success: true }` and ignored the result. It now parses `del:deletionResult` and throws with the server's message when `isDeleted` is not `true` (verified against a real system). Lets callers distinguish a real delete from a server-refused one (some FUGR includes can only be removed via the Function Builder).
+
 ## [5.7.0] - 2026-06-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.7.0",
+      "version": "5.7.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/unit/core/functionIncludeDelete.test.ts
+++ b/src/__tests__/unit/core/functionIncludeDelete.test.ts
@@ -1,0 +1,49 @@
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { deleteFunctionInclude } from '../../../core/functionInclude/delete';
+
+function connReturning(xml: string): IAbapConnection {
+  const makeAdtRequest = jest.fn(async () => ({ status: 200, data: xml }));
+  return { makeAdtRequest } as unknown as IAbapConnection;
+}
+
+const OK_XML =
+  '<?xml version="1.0" encoding="utf-8"?><del:deletionResult xmlns:del="http://www.sap.com/adt/deletion" xmlns:adtcore="http://www.sap.com/adt/core"><del:object del:isDeleted="true" adtcore:type="FUGR/I" adtcore:name="LZG_C01"/></del:deletionResult>';
+
+// Real shape observed on the system: HTTP 200, isDeleted="false", error message
+// with a nested longtext atom:link inside del:text.
+const REFUSED_XML =
+  '<?xml version="1.0" encoding="utf-8"?><del:deletionResult xmlns:del="http://www.sap.com/adt/deletion"><del:object del:isDeleted="false" adtcore:type="FUGR/I" adtcore:name="LZG_T01" xmlns:adtcore="http://www.sap.com/adt/core"><del:message del:priority="0" del:type="E"><del:text>Only delete function module includes using Function Builder</del:text><atom:link href="/x" rel="longtext" type="text/html" xmlns:atom="http://www.w3.org/2005/Atom"/></del:message></del:object></del:deletionResult>';
+
+describe('deleteFunctionInclude', () => {
+  it('resolves with a success payload when the server reports isDeleted="true"', async () => {
+    const conn = connReturning(OK_XML);
+    const res = await deleteFunctionInclude(conn, {
+      function_group_name: 'ZG',
+      include_name: 'LZG_C01',
+    });
+    expect((res.data as any).success).toBe(true);
+    expect((res.data as any).include_name).toBe('LZG_C01');
+  });
+
+  it('throws the server message when isDeleted="false" (does not mask as success)', async () => {
+    const conn = connReturning(REFUSED_XML);
+    await expect(
+      deleteFunctionInclude(conn, {
+        function_group_name: 'ZG',
+        include_name: 'LZG_T01',
+      }),
+    ).rejects.toThrow(
+      'Only delete function module includes using Function Builder',
+    );
+  });
+
+  it('throws (not silent success) on an empty/unparseable body', async () => {
+    const conn = connReturning('');
+    await expect(
+      deleteFunctionInclude(conn, {
+        function_group_name: 'ZG',
+        include_name: 'LZG_X',
+      }),
+    ).rejects.toThrow('was not deleted');
+  });
+});

--- a/src/__tests__/unit/core/functionIncludeDelete.test.ts
+++ b/src/__tests__/unit/core/functionIncludeDelete.test.ts
@@ -9,6 +9,11 @@ function connReturning(xml: string): IAbapConnection {
 const OK_XML =
   '<?xml version="1.0" encoding="utf-8"?><del:deletionResult xmlns:del="http://www.sap.com/adt/deletion" xmlns:adtcore="http://www.sap.com/adt/core"><del:object del:isDeleted="true" adtcore:type="FUGR/I" adtcore:name="LZG_C01"/></del:deletionResult>';
 
+// Exact success response observed on the system for a real custom FUGR include:
+// isDeleted="true" with a type="S" message and an empty <del:text/>.
+const OK_XML_WITH_S_MESSAGE =
+  '<?xml version="1.0" encoding="UTF-8"?><del:deletionResult xmlns:del="http://www.sap.com/adt/deletion"><del:object xmlns:adtcore="http://www.sap.com/adt/core" del:isDeleted="true" adtcore:uri="/sap/bc/adt/functions/groups/zok_test_fg_01/includes/lzok_test_fg_01zok" adtcore:type="FUGR/I" adtcore:name="LZOK_TEST_FG_01ZOK" adtcore:packageName="ZOK_TEST"><del:message del:priority="0" del:type="S"><del:text/></del:message></del:object></del:deletionResult>';
+
 // Real shape observed on the system: HTTP 200, isDeleted="false", error message
 // with a nested longtext atom:link inside del:text.
 const REFUSED_XML =
@@ -23,6 +28,15 @@ describe('deleteFunctionInclude', () => {
     });
     expect((res.data as any).success).toBe(true);
     expect((res.data as any).include_name).toBe('LZG_C01');
+  });
+
+  it('resolves on the real success response shape (isDeleted="true" + type="S" empty message)', async () => {
+    const conn = connReturning(OK_XML_WITH_S_MESSAGE);
+    const res = await deleteFunctionInclude(conn, {
+      function_group_name: 'ZOK_TEST_FG_01',
+      include_name: 'LZOK_TEST_FG_01ZOK',
+    });
+    expect((res.data as any).success).toBe(true);
   });
 
   it('throws the server message when isDeleted="false" (does not mask as success)', async () => {

--- a/src/core/functionInclude/delete.ts
+++ b/src/core/functionInclude/delete.ts
@@ -6,6 +6,7 @@ import type {
   IAdtResponse as AxiosResponse,
   IAbapConnection,
 } from '@mcp-abap-adt/interfaces';
+import { XMLParser } from 'fast-xml-parser';
 import {
   ACCEPT_DELETION,
   ACCEPT_DELETION_CHECK,
@@ -14,6 +15,59 @@ import {
 } from '../../constants/contentTypes';
 import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
+
+/**
+ * Parse a `del:deletionResult` and throw if the server did not delete.
+ *
+ * The ADT deletion service answers HTTP 200 even when it refuses to delete:
+ * `<del:object del:isDeleted="false"><del:message del:type="E"><del:text>…`.
+ * Some function-group includes can only be removed via the Function Builder, so
+ * we MUST surface that instead of reporting a phantom success.
+ */
+function assertDeleted(responseData: unknown, includeName: string): void {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+  });
+  let deleteObject: Record<string, unknown> | undefined;
+  try {
+    const result = parser.parse(String(responseData ?? '')) as Record<
+      string,
+      unknown
+    >;
+    const deletionResult = (result['del:deletionResult'] ??
+      (result as Record<string, unknown>).deletionResult) as
+      | Record<string, unknown>
+      | undefined;
+    deleteObject = (deletionResult?.['del:object'] ??
+      (deletionResult as Record<string, unknown>)?.object) as
+      | Record<string, unknown>
+      | undefined;
+  } catch {
+    // Malformed/empty body — treat as a failed parse below.
+    deleteObject = undefined;
+  }
+
+  const isDeleted =
+    (deleteObject as Record<string, unknown>)?.['@_del:isDeleted'] === 'true' ||
+    (deleteObject as Record<string, unknown>)?.['@_isDeleted'] === 'true';
+  if (isDeleted) {
+    return;
+  }
+
+  // `del:text` may be a plain string, or an object ({ '#text', atom:link }) when
+  // the message carries a longtext link — normalize both to the text.
+  const rawText =
+    (deleteObject as any)?.['del:message']?.['del:text'] ??
+    (deleteObject as any)?.message?.text;
+  const message =
+    typeof rawText === 'string'
+      ? rawText
+      : (rawText?.['#text'] as string | undefined);
+  throw new Error(
+    `Function include ${includeName} was not deleted${message ? `: ${message}` : ' (server reported isDeleted=false)'}`,
+  );
+}
 
 export interface IDeleteFunctionIncludeParams {
   function_group_name: string;
@@ -96,6 +150,10 @@ export async function deleteFunctionInclude(
       'Content-Type': CT_DELETION,
     },
   });
+
+  // The service returns HTTP 200 even when it refuses to delete; verify the
+  // result element instead of assuming success.
+  assertDeleted(response.data, params.include_name);
 
   return {
     ...response,


### PR DESCRIPTION
## Problem

`getFunctionInclude().delete()` reported success even when the server refused to delete. The ADT deletion service answers **HTTP 200** with a refusal in the body:

```xml
<del:object del:isDeleted="false" adtcore:type="FUGR/I" adtcore:name="...">
  <del:message del:type="E"><del:text>Only delete function module includes using Function Builder</del:text></del:message>
</del:object>
```

The low-level `deleteFunctionInclude` ignored this and hardcoded `{ success: true }`, so the caller saw a phantom success while the include stayed on the system.

## Fix

Parse `del:deletionResult` and **throw with the server's message** when `del:isDeleted` is not `"true"` (mirrors the existing `package/delete.ts` handling). On a genuine delete (`isDeleted="true"`) the prior success payload is unchanged.

## Verification

- **Unit (3):** `isDeleted="true"` → resolves; `isDeleted="false"` + message → throws the server text (incl. the real nested `del:text`/`atom:link` shape); empty body → throws (no silent success).
- **Real system (BTP trial):** `delete(LZAC_SHR_FUGRT01)` now throws `Function include LZAC_SHR_FUGRT01 was not deleted: Only delete function module includes using Function Builder` instead of lying.
- Full unit suite green (191), build clean.

## Notes

- `functionModule/delete.ts` has the same masking pattern but normally returns `isDeleted="true"`, so it is left unchanged here to avoid altering a widely-used delete's contract.
- Unblocks the function-group backup work (a reliable `delete` is needed for idempotent restore/overwrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)