### PR TITLE
feat(functionInclude): read() returns source per IAdtObject contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.8.0] - 2026-06-17
+
+### Changed
+- **`getFunctionInclude().read()` now returns the include SOURCE**, matching the `IAdtObject` contract and the behaviour of `class`/`program`/`functionModule` `read()`. It previously returned the include's `finclude` metadata XML, which was inconsistent. The metadata is now obtained via **`readMetadata()`** (unchanged). `readSource()` remains available and `read()` is an alias of it. Internal create/update readiness polling and `readMetadata()` use a private metadata read, so the CRUD chain is unchanged. **Migration:** if you called `getFunctionInclude().read()` expecting metadata XML, switch to `readMetadata()`.
+
 ## [5.7.1] - 2026-06-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "5.7.1",
+      "version": "5.8.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "5.7.1",
+  "version": "5.8.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/unit/core/functionIncludeRead.test.ts
+++ b/src/__tests__/unit/core/functionIncludeRead.test.ts
@@ -1,0 +1,42 @@
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { AdtFunctionInclude } from '../../../core/functionInclude/AdtFunctionInclude';
+
+function makeConn() {
+  const calls: Array<{ url: string; method?: string }> = [];
+  const makeAdtRequest = jest.fn(
+    async (opts: { url: string; method?: string }) => {
+      calls.push(opts);
+      return { status: 200, data: 'DATA: gv TYPE i.' };
+    },
+  );
+  const connection = {
+    makeAdtRequest,
+    setSessionType: jest.fn(),
+    getSessionId: jest.fn(),
+  } as unknown as IAbapConnection;
+  return { connection, calls };
+}
+
+describe('AdtFunctionInclude read() vs readMetadata()', () => {
+  it('read() returns source (hits the /source/main endpoint)', async () => {
+    const { connection, calls } = makeConn();
+    const fi = new AdtFunctionInclude(connection);
+    const state = await fi.read({
+      functionGroupName: 'ZG',
+      includeName: 'LZG_C01',
+    });
+    expect(state?.readResult).toBeDefined();
+    expect(
+      calls.some((c) => c.url.toLowerCase().includes('/source/main')),
+    ).toBe(true);
+  });
+
+  it('readMetadata() reads the include metadata (NOT the source endpoint)', async () => {
+    const { connection, calls } = makeConn();
+    const fi = new AdtFunctionInclude(connection);
+    await fi.readMetadata({ functionGroupName: 'ZG', includeName: 'LZG_C01' });
+    const url = calls[0]?.url.toLowerCase() ?? '';
+    expect(url).toContain('/includes/lzg_c01');
+    expect(url).not.toContain('/source/main');
+  });
+});

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -267,9 +267,28 @@ export class AdtFunctionInclude
   }
 
   /**
-   * Read function include metadata.
+   * Read function include SOURCE code.
+   *
+   * Per the IAdtObject contract, `read()` returns source for objects that have
+   * it (metadata is available via `readMetadata()`). This object has source, so
+   * `read()` is an alias of `readSource()`. (Historically it returned metadata,
+   * which was inconsistent with class/program/function-module `read()`.)
    */
   async read(
+    config: Partial<IFunctionIncludeConfig>,
+    version?: 'active' | 'inactive',
+    _options?: IReadOptions,
+  ): Promise<IFunctionIncludeState | undefined> {
+    return this.readSource(config, version);
+  }
+
+  /**
+   * Low-level metadata read (the object's `finclude` XML), with 404 -> undefined.
+   * Used by readMetadata() and by the create/update readiness polling, which
+   * need metadata semantics and long-polling options (the source endpoint does
+   * not take them).
+   */
+  private async readMetadataRaw(
     config: Partial<IFunctionIncludeConfig>,
     version?: 'active' | 'inactive',
     options?: IReadOptions,
@@ -359,7 +378,7 @@ export class AdtFunctionInclude
       throw error;
     }
     try {
-      const readState = await this.read(
+      const readState = await this.readMetadataRaw(
         config,
         options?.version ?? 'active',
         options,
@@ -498,7 +517,7 @@ export class AdtFunctionInclude
         // Wait for object to be ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read(
+          await this.readMetadataRaw(
             {
               functionGroupName: fullConfig.functionGroupName,
               includeName: fullConfig.includeName,
@@ -548,7 +567,7 @@ export class AdtFunctionInclude
         state.activateResult = activateResponse;
 
         try {
-          const readState = await this.read(
+          const readState = await this.readMetadataRaw(
             {
               functionGroupName: fullConfig.functionGroupName,
               includeName: fullConfig.includeName,


### PR DESCRIPTION
## Change

`getFunctionInclude().read()` previously returned the include's **`finclude` metadata XML**, inconsistent with `class`/`program`/`functionModule` `read()` which return **source** (the `IAdtObject` contract documents `read()` as source, `readMetadata()` as metadata).

- **`read()`** now returns the include **source** (alias of `readSource()`).
- **`readMetadata()`** returns the `finclude` metadata XML (unchanged behaviour).
- A private metadata read backs `readMetadata()` and the create/update **readiness polling** (which needs metadata + long-polling), so the **CRUD chain is unchanged**.

## Migration

Callers that used `getFunctionInclude().read()` to obtain metadata XML must switch to `readMetadata()`.

## Verification

- **Unit (2):** `read()` hits the `/source/main` endpoint; `readMetadata()` hits the include metadata endpoint (not `/source/main`).
- Full unit suite green (194). Build clean.
- Source-read path itself was already confirmed on a real system (a package backup captured the TOP include source `FUNCTION-POOL …`); `read()` now delegates to that path.
- The existing `FunctionInclude` integration test already uses `readMetadata()` for existence and `readSource()` for source — consistent with this change.

## Why

Unblocks consistent consumption in `mcp-abap-adt-backup` (function-group include backup), so it can use the normal `read()` path like every other object type instead of a cast to `readSource()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)