### PR TITLE
ci(release): drop duplicate '## What's Changed' placeholder in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,5 @@ jobs:
             ```bash
             npm install -g ./${{ steps.package.outputs.filename }}
             ```
-
-            ## What's Changed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow set a `body` ending in an empty `## What's Changed` while `generate_release_notes: true` already appends GitHub's own "What's Changed" — producing a duplicated heading (seen in the v6.0.0 release notes). Removes the manual placeholder so future releases have a single, populated "What's Changed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)