### PR TITLE
feat(where-used): type filtering on getWhereUsedList (6.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.0] - 2026-06-26
+
+### Added
+- **`getWhereUsedList` type filtering** — new `enableOnlyTypes?: string[]` and `disableTypes?: string[]` on `IGetWhereUsedListParams`. `enableOnlyTypes` restricts the where-used search to specific ADT object types (e.g. `['TABL/DS', 'TABL/DT']`), so SAP applies the selection server-side and never searches — nor returns — the unwanted types (e.g. hundreds of `CLAS/OC`). `disableTypes` prunes types from the default scope. `enableOnlyTypes` takes precedence over `enableAllTypes`; `disableTypes` is applied on top.
+
+### Fixed
+- **`modifyWhereUsedScope` attribute-order bug** — the `enableOnly` / `enable` / `disable` options silently never matched, because the implementation assumed the scope XML emits `name` before `isSelected`, whereas SAP emits `isDefault isSelected name` (name LAST). Reworked to flip `isSelected` per `<usagereferences:type>` tag independent of attribute order, preserving tag order and the opaque `payload` blob. `enableAll` was unaffected.
+
 ## [6.0.0] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ for (const ref of result.references) {
   console.log(`${ref.name} (${ref.type}) in ${ref.packageName}`);
 }
 
+// Restrict to specific object types — SAP filters server-side, so it never
+// returns the unwanted types (e.g. hundreds of classes when you want structures)
+await utils.getWhereUsedList({
+  object_name: 'ZMY_TABLE',
+  object_type: 'table',
+  enableOnlyTypes: ['TABL/DS', 'TABL/DT']  // or disableTypes: ['CLAS/OC']
+});
+
 // Where-used with raw XML (legacy)
 await utils.getWhereUsed({ object_name: 'ZCL_TEST', object_type: 'class' });
 ```

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -164,7 +164,8 @@ Critical conventions used across object modules:
 Notably, where-used supports:
 - scope fetch (`getWhereUsedScope`),
 - local scope mutation (`modifyWhereUsedScope`),
-- execution (`getWhereUsed`) and parsed convenience (`getWhereUsedList`).
+- execution (`getWhereUsed`) and parsed convenience (`getWhereUsedList`),
+- server-side type filtering via `getWhereUsedList({ enableOnlyTypes, disableTypes })` — SAP searches (and returns) only the selected object types.
 
 ## Accept Negotiation (406 Recovery)
 

--- a/docs/usage/CLIENT_API_REFERENCE.md
+++ b/docs/usage/CLIENT_API_REFERENCE.md
@@ -323,6 +323,37 @@ const result = await utils.getWhereUsed({
 });
 ```
 
+`getWhereUsedList` is a convenience wrapper that performs the scope fetch, search, and
+XML parsing in one call and returns structured `references`. Use `enableOnlyTypes` to
+restrict the search to specific ADT object types — SAP applies the selection server-side,
+so it never searches (nor returns) the unwanted types, e.g. hundreds of `CLAS/OC`:
+
+```typescript
+const utils = client.getUtils();
+
+// Only structures/tables — not the dozens of other referencing types.
+const result = await utils.getWhereUsedList({
+  object_name: 'ZMY_TABLE',
+  object_type: 'table',
+  enableOnlyTypes: ['TABL/DS', 'TABL/DT'],
+});
+
+console.log(`Found ${result.totalReferences} references`);
+for (const ref of result.references) {
+  console.log(`${ref.name} (${ref.type}) in ${ref.packageName}`);
+}
+
+// Or keep the default SAP scope but prune a noisy type:
+await utils.getWhereUsedList({
+  object_name: 'ZMY_TABLE',
+  object_type: 'table',
+  disableTypes: ['CLAS/OC'],
+});
+
+// `enableAllTypes: true` selects every type (Eclipse "select all"); `enableOnlyTypes`
+// takes precedence over it, and `disableTypes` is applied on top.
+```
+
 ## AdtClientBatch
 
 `AdtClientBatch` wraps `AdtClient` with a recording connection that collects requests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -1733,6 +1733,15 @@ where_used:
         object_type: "table"
         include_raw_xml: true
 
+    - name: "where_used_list_filtered"
+      enabled: true
+      available_in: ["onprem", "cloud"]
+      description: "Compare enableAllTypes (everything) vs enableOnlyTypes (narrowed to one type). ZAC_SHR_VTABL is referenced by the CDS view ZAC_SHR_CDSUT_DDLS (DDLS/DF)."
+      params:
+        object_name: "ZAC_SHR_VTABL"  # → referenced by ZAC_SHR_CDSUT_DDLS
+        object_type: "table"
+        enable_only_types: ["DDLS/DF"]  # keep only CDS DDL sources
+
 # Read Accept (read methods should return 2xx; 406 is error)
 read_accept:
   test_cases:

--- a/src/__tests__/integration/shared/whereUsed.test.ts
+++ b/src/__tests__/integration/shared/whereUsed.test.ts
@@ -590,10 +590,27 @@ describe('Shared - getWhereUsed', () => {
       expect(kept.references.length).toBeGreaterThan(0);
     }
 
-    // Step 2b (EXCLUDE): narrow to a type that is NOT referenced — the result
-    // must collapse, demonstrating the filter is applied server-side.
-    const KNOWN_TYPES = ['CLAS/OC', 'INTF/OI', 'PROG/1P', 'FUGR/FF', 'DOMA/DD'];
-    const absentType = KNOWN_TYPES.find((t) => !allTypes.includes(t));
+    // Step 2b (EXCLUDE): narrow to a type that SAP CAN search for this object
+    // (it is offered in the scope) but which the object does not reference.
+    // Deriving the candidate from the live scope — not a hardcoded list —
+    // guarantees enableOnlyTypes actually selects a searchable type, so a zero
+    // result proves the filter excluded the referenced type rather than simply
+    // selecting nothing.
+    const scopeResponse = await utils.getWhereUsedScope({
+      object_name: objectName,
+      object_type: objectType,
+    });
+    const scopeTypes = [
+      ...new Set(
+        [...String(scopeResponse.data).matchAll(/name="([^"]+)"/g)].map(
+          (m) => m[1],
+        ),
+      ),
+    ];
+    const absentType = scopeTypes.find((t) => !allTypes.includes(t));
+    testsLogger.info?.(
+      `🔎 Scope offers ${scopeTypes.length} types; picking absent-but-searchable: ${absentType}`,
+    );
     if (absentType) {
       logTestStep(`where-used: ONLY [${absentType}] (absent)`, testsLogger);
       const excluded = await utils.getWhereUsedList({

--- a/src/__tests__/integration/shared/whereUsed.test.ts
+++ b/src/__tests__/integration/shared/whereUsed.test.ts
@@ -7,12 +7,12 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createAbapConnection, type SapConfig } from '@mcp-abap-adt/connection';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
 import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
 import { isCloudEnvironment } from '../../../utils/systemInfo';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { TestConfigResolver } from '../../helpers/TestConfigResolver';
 import { createTestsLogger } from '../../helpers/testLogger';
 import { logTestSkip, logTestStep } from '../../helpers/testProgressLogger';
@@ -26,64 +26,6 @@ if (fs.existsSync(envPath)) {
 }
 
 const testsLogger = createTestsLogger();
-
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    // Add refresh credentials for auto-refresh (if available)
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
 
 describe('Shared - getWhereUsed', () => {
   let connection: IAbapConnection;
@@ -569,4 +511,108 @@ describe('Shared - getWhereUsed', () => {
     testsLogger.info?.(`📊 Raw XML size: ${result.rawXml?.length} bytes`);
     testsLogger.info?.('✅ Test complete: raw XML included');
   }, 30000);
+
+  it('narrows results to selected object types (enableOnlyTypes vs enableAllTypes)', async () => {
+    if (!hasConfig) {
+      testsLogger.warn?.(
+        '⚠️ Skipping test: No .env file or SAP configuration found',
+      );
+      return;
+    }
+
+    const resolver = new TestConfigResolver({
+      isCloud: isCloudSystem,
+      isLegacy,
+      logger: testsLogger,
+      handlerName: 'where_used',
+      testCaseName: 'where_used_list_filtered',
+    });
+    if (!resolver.isAvailableForEnvironment()) {
+      logTestSkip(
+        testsLogger,
+        'Shared - getWhereUsed',
+        'Test not available for current environment',
+      );
+      return;
+    }
+
+    const params = resolver.getParams();
+    const objectName =
+      params.object_name || resolver.getObjectName('object_name', 'table');
+    const objectType = params.object_type || 'table';
+    const onlyTypes: string[] = params.enable_only_types || ['DDLS/DF'];
+    if (!objectName) {
+      logTestSkip(testsLogger, 'Shared - getWhereUsed', 'No object configured');
+      return;
+    }
+
+    const utils = client.getUtils();
+
+    // Step 1: search ALL types — the "select all" baseline.
+    logTestStep('where-used: ALL types (baseline)', testsLogger);
+    const all = await utils.getWhereUsedList({
+      object_name: objectName,
+      object_type: objectType,
+      enableAllTypes: true,
+    });
+    const allTypes = [...new Set(all.references.map((r) => r.type))].sort();
+    testsLogger.info?.(
+      `📊 ALL: ${all.references.length} refs across types [${allTypes.join(', ')}]`,
+    );
+
+    // The baseline must actually reference the type we keep, otherwise the
+    // "keep" comparison below proves nothing about server-side filtering.
+    const keepType =
+      onlyTypes.find((t) => allTypes.includes(t)) ||
+      allTypes[0] ||
+      onlyTypes[0];
+
+    // Step 2a (KEEP): narrow to a type that IS referenced — count is unchanged
+    // for that type, and no other type leaks in.
+    logTestStep(`where-used: ONLY [${keepType}] (present)`, testsLogger);
+    const kept = await utils.getWhereUsedList({
+      object_name: objectName,
+      object_type: objectType,
+      enableOnlyTypes: [keepType],
+    });
+    const keptTypes = [...new Set(kept.references.map((r) => r.type))].sort();
+    testsLogger.info?.(
+      `📊 KEEP [${keepType}]: ${kept.references.length} refs across types [${keptTypes.join(', ')}]`,
+    );
+
+    // Every returned reference must be the type we asked for — proves SAP did
+    // not search (and did not return) any of the other ~40 object types.
+    for (const ref of kept.references) {
+      expect(ref.type).toBe(keepType);
+    }
+    expect(kept.references.length).toBeLessThanOrEqual(all.references.length);
+    if (allTypes.includes(keepType)) {
+      expect(kept.references.length).toBeGreaterThan(0);
+    }
+
+    // Step 2b (EXCLUDE): narrow to a type that is NOT referenced — the result
+    // must collapse, demonstrating the filter is applied server-side.
+    const KNOWN_TYPES = ['CLAS/OC', 'INTF/OI', 'PROG/1P', 'FUGR/FF', 'DOMA/DD'];
+    const absentType = KNOWN_TYPES.find((t) => !allTypes.includes(t));
+    if (absentType) {
+      logTestStep(`where-used: ONLY [${absentType}] (absent)`, testsLogger);
+      const excluded = await utils.getWhereUsedList({
+        object_name: objectName,
+        object_type: objectType,
+        enableOnlyTypes: [absentType],
+      });
+      testsLogger.info?.(
+        `📊 EXCLUDE [${absentType}]: ${excluded.references.length} refs (baseline had ${all.references.length})`,
+      );
+      // Filtering to a type the object does not reference yields no results,
+      // even though enableAllTypes returned matches.
+      expect(excluded.references.length).toBe(0);
+    } else {
+      testsLogger.warn?.(
+        '⚠️ Could not pick an absent type — skipping the exclude assertion',
+      );
+    }
+
+    testsLogger.info?.('✅ Test complete: type filtering verified against SAP');
+  }, 45000);
 });

--- a/src/__tests__/unit/shared/getWhereUsedList.test.ts
+++ b/src/__tests__/unit/shared/getWhereUsedList.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit test for getWhereUsedList type-filtering options.
+ *
+ * Uses a fake IAbapConnection that returns a captured scope response and
+ * records the search request body, so we can assert which object types the
+ * search was actually restricted to — without touching a live SAP system.
+ */
+
+import type { IAbapConnection, IAdtResponse } from '@mcp-abap-adt/interfaces';
+import { getWhereUsedList } from '../../../core/shared/whereUsed';
+
+// Real attribute order from SAP: isDefault, isSelected, name (name LAST).
+const SCOPE_XML = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageScopeResult xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences"><usagereferences:objectIdentifier displayName="ZAC_SHR_BTABL (Database Table)" globalType="TABL/DT"/><usagereferences:grade definitions="false" elements="true" indirectReferences="false"/><usagereferences:objectTypes><usagereferences:type isDefault="true" isSelected="true" name="CLAS/OC"/><usagereferences:type isDefault="true" isSelected="true" name="INTF/OI"/><usagereferences:type isDefault="false" isSelected="false" name="TABL/DS"/><usagereferences:type isDefault="false" isSelected="false" name="TABL/DT"/></usagereferences:objectTypes><usagereferences:payload>BASE64BLOB==</usagereferences:payload></usagereferences:usageScopeResult>`;
+
+const RESULT_XML = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageReferenceResult xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences" numberOfResults="0" resultDescription="Found 0"><usagereferences:referencedObjects/></usagereferences:usageReferenceResult>`;
+
+/** Type names selected in a search request body. */
+function selectedTypes(xml: string): string[] {
+  const selected: string[] = [];
+  for (const m of xml.matchAll(/<usagereferences:type\b[^>]*\/>/g)) {
+    if (/isSelected="true"/.test(m[0])) {
+      const name = m[0].match(/name="([^"]+)"/);
+      if (name) selected.push(name[1]);
+    }
+  }
+  return selected;
+}
+
+function makeFakeConnection(): {
+  connection: IAbapConnection;
+  searchBodies: string[];
+} {
+  const searchBodies: string[] = [];
+  const connection = {
+    makeAdtRequest: async (options: any): Promise<IAdtResponse> => {
+      if (options.url.includes('/usageReferences/scope')) {
+        return { data: SCOPE_XML, status: 200, headers: {} } as IAdtResponse;
+      }
+      // Actual search request — record its body.
+      searchBodies.push(String(options.data));
+      return { data: RESULT_XML, status: 200, headers: {} } as IAdtResponse;
+    },
+  } as unknown as IAbapConnection;
+  return { connection, searchBodies };
+}
+
+describe('getWhereUsedList type filtering', () => {
+  it('enableOnlyTypes restricts the search request to the given types', async () => {
+    const { connection, searchBodies } = makeFakeConnection();
+
+    await getWhereUsedList(connection, {
+      object_name: 'ZAC_SHR_BTABL',
+      object_type: 'table',
+      enableOnlyTypes: ['TABL/DS'],
+    });
+
+    expect(searchBodies).toHaveLength(1);
+    expect(selectedTypes(searchBodies[0]).sort()).toEqual(['TABL/DS']);
+  });
+
+  it('disableTypes removes types from the default scope', async () => {
+    const { connection, searchBodies } = makeFakeConnection();
+
+    await getWhereUsedList(connection, {
+      object_name: 'ZAC_SHR_BTABL',
+      object_type: 'table',
+      disableTypes: ['CLAS/OC'],
+    });
+
+    expect(searchBodies).toHaveLength(1);
+    expect(selectedTypes(searchBodies[0]).sort()).toEqual(['INTF/OI']);
+  });
+});

--- a/src/__tests__/unit/shared/modifyWhereUsedScope.test.ts
+++ b/src/__tests__/unit/shared/modifyWhereUsedScope.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit test for modifyWhereUsedScope.
+ *
+ * Uses a fixture captured from a real SAP system, where the attribute order
+ * inside <usagereferences:type> is `isDefault isSelected name` (name LAST).
+ * The selection logic must be independent of attribute ordering.
+ */
+
+import { modifyWhereUsedScope } from '../../../core/shared/whereUsed';
+
+// Real attribute order: isDefault, isSelected, name (name is the LAST attribute).
+const SCOPE_XML = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageScopeResult xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences"><usagereferences:objectIdentifier displayName="ZAC_SHR_BTABL (Database Table)" globalType="TABL/DT"/><usagereferences:grade definitions="false" elements="true" indirectReferences="false"/><usagereferences:objectTypes><usagereferences:type isDefault="true" isSelected="true" name="CLAS/OC"/><usagereferences:type isDefault="true" isSelected="true" name="INTF/OI"/><usagereferences:type isDefault="false" isSelected="false" name="TABL/DS"/><usagereferences:type isDefault="false" isSelected="false" name="TABL/DT"/></usagereferences:objectTypes><usagereferences:payload>BASE64BLOB==</usagereferences:payload></usagereferences:usageScopeResult>`;
+
+/** Extract the set of type names currently selected (isSelected="true"). */
+function selectedTypes(xml: string): string[] {
+  const selected: string[] = [];
+  const tagRe = /<usagereferences:type\b[^>]*\/>/g;
+  for (const m of xml.matchAll(tagRe)) {
+    const tag = m[0];
+    if (/isSelected="true"/.test(tag)) {
+      const name = tag.match(/name="([^"]+)"/);
+      if (name) selected.push(name[1]);
+    }
+  }
+  return selected;
+}
+
+describe('modifyWhereUsedScope (real attribute order: name last)', () => {
+  it('enableAll selects every type', () => {
+    const result = modifyWhereUsedScope(SCOPE_XML, { enableAll: true });
+    expect(selectedTypes(result).sort()).toEqual(
+      ['CLAS/OC', 'INTF/OI', 'TABL/DS', 'TABL/DT'].sort(),
+    );
+  });
+
+  it('enableOnly restricts selection to the given types regardless of attribute order', () => {
+    const result = modifyWhereUsedScope(SCOPE_XML, {
+      enableOnly: ['TABL/DS', 'TABL/DT'],
+    });
+    expect(selectedTypes(result).sort()).toEqual(['TABL/DS', 'TABL/DT'].sort());
+  });
+
+  it('enable adds a type while keeping existing selections', () => {
+    const result = modifyWhereUsedScope(SCOPE_XML, { enable: ['TABL/DS'] });
+    expect(selectedTypes(result).sort()).toEqual(
+      ['CLAS/OC', 'INTF/OI', 'TABL/DS'].sort(),
+    );
+  });
+
+  it('disable removes a type while keeping the rest', () => {
+    const result = modifyWhereUsedScope(SCOPE_XML, { disable: ['CLAS/OC'] });
+    expect(selectedTypes(result).sort()).toEqual(['INTF/OI'].sort());
+  });
+
+  it('preserves the opaque payload blob untouched', () => {
+    const result = modifyWhereUsedScope(SCOPE_XML, {
+      enableOnly: ['TABL/DS'],
+    });
+    expect(result).toContain(
+      '<usagereferences:payload>BASE64BLOB==</usagereferences:payload>',
+    );
+  });
+});

--- a/src/core/shared/types.ts
+++ b/src/core/shared/types.ts
@@ -155,6 +155,19 @@ export interface IGetWhereUsedListParams {
    */
   enableAllTypes?: boolean;
   /**
+   * Restrict the search to ONLY these object types (e.g. ['TABL/DS', 'TABL/DT']).
+   * All other types are deselected, so SAP does not search them at all — this is
+   * how you avoid getting 1000 classes back when you only want structures/tables.
+   * Type names are the ADT global types from the scope (e.g. 'CLAS/OC', 'STRU/DT').
+   * Takes precedence over `enableAllTypes`. Ignored if empty.
+   */
+  enableOnlyTypes?: string[];
+  /**
+   * Remove these object types from the default SAP scope, keeping the rest.
+   * Applied on top of the default scope (or after `enableOnlyTypes`/`enableAllTypes`).
+   */
+  disableTypes?: string[];
+  /**
    * Include raw XML in response
    * Default: false
    */

--- a/src/core/shared/whereUsed.ts
+++ b/src/core/shared/whereUsed.ts
@@ -67,45 +67,48 @@ export function modifyWhereUsedScope(
     disable?: string[];
   },
 ): string {
-  let result = scopeXml;
+  // Each available type is a self-closing <usagereferences:type .../> tag.
+  // We rewrite ONLY the isSelected attribute per tag and never touch the
+  // opaque <usagereferences:payload> blob or attribute ordering — SAP emits
+  // attributes as `isDefault isSelected name`, so logic must read `name`
+  // wherever it appears, not assume it precedes isSelected.
+  const typeTagRegex = /<usagereferences:type\b[^>]*?\/>/g;
 
-  if (options.enableAll) {
-    // Enable all object types
-    result = result.replace(/isSelected="false"/g, 'isSelected="true"');
-  } else if (options.enableOnly) {
-    // First disable all, then enable only specified
-    result = result.replace(/isSelected="true"/g, 'isSelected="false"');
-    for (const typeName of options.enableOnly) {
-      const typeRegex = new RegExp(
-        `(<usagereferences:type[^>]*name="${typeName.replace(/\//g, '\\/')})"[^>]*(isSelected=)"false"`,
-        'g',
-      );
-      result = result.replace(typeRegex, '$1 $2"true"');
+  return scopeXml.replace(typeTagRegex, (tag) => {
+    const nameMatch = tag.match(/\bname="([^"]*)"/);
+    const name = nameMatch ? nameMatch[1] : '';
+
+    let selected: boolean | undefined;
+    if (options.enableAll) {
+      selected = true;
+    } else if (options.enableOnly) {
+      selected = options.enableOnly.includes(name);
+    } else {
+      if (options.enable?.includes(name)) selected = true;
+      if (options.disable?.includes(name)) selected = false;
     }
-  } else {
-    // Enable specific types (keep existing selections)
-    if (options.enable) {
-      for (const typeName of options.enable) {
-        const typeRegex = new RegExp(
-          `(<usagereferences:type[^>]*name="${typeName.replace(/\//g, '\\/')})"[^>]*(isSelected=)"false"`,
-          'g',
-        );
-        result = result.replace(typeRegex, '$1 $2"true"');
-      }
-    }
-    // Disable specific types
-    if (options.disable) {
-      for (const typeName of options.disable) {
-        const typeRegex = new RegExp(
-          `(<usagereferences:type[^>]*name="${typeName.replace(/\//g, '\\/')})"[^>]*(isSelected=)"true"`,
-          'g',
-        );
-        result = result.replace(typeRegex, '$1 $2"false"');
-      }
-    }
+
+    if (selected === undefined) return tag;
+    return setIsSelected(tag, selected);
+  });
+}
+
+/**
+ * Set the isSelected attribute on a single <usagereferences:type> tag,
+ * inserting it if absent. Leaves all other attributes and their order intact.
+ */
+function setIsSelected(typeTag: string, selected: boolean): string {
+  const value = selected ? 'true' : 'false';
+  if (/\bisSelected="(?:true|false)"/.test(typeTag)) {
+    return typeTag.replace(
+      /\bisSelected="(?:true|false)"/,
+      `isSelected="${value}"`,
+    );
   }
-
-  return result;
+  return typeTag.replace(
+    /<usagereferences:type\b/,
+    `<usagereferences:type isSelected="${value}"`,
+  );
 }
 
 /**
@@ -294,14 +297,23 @@ export async function getWhereUsed(
  *
  * @example
  * ```typescript
- * const result = await getWhereUsedList(connection, {
+ * // Search every object type (Eclipse 'select all') — may return many results
+ * const all = await getWhereUsedList(connection, {
  *   object_name: 'ZMY_TABLE',
  *   object_type: 'table',
  *   enableAllTypes: true
  * });
  *
- * console.log(`Found ${result.totalReferences} references`);
- * for (const ref of result.references) {
+ * // Or restrict to just the types you care about (e.g. only structures/tables),
+ * // so SAP never searches — and never returns — hundreds of classes.
+ * const structuresOnly = await getWhereUsedList(connection, {
+ *   object_name: 'ZMY_TABLE',
+ *   object_type: 'table',
+ *   enableOnlyTypes: ['TABL/DS', 'TABL/DT']
+ * });
+ *
+ * console.log(`Found ${structuresOnly.totalReferences} references`);
+ * for (const ref of structuresOnly.references) {
  *   console.log(`${ref.name} (${ref.type}) in package ${ref.packageName}`);
  * }
  * ```
@@ -319,13 +331,32 @@ export async function getWhereUsedList(
 
   let scopeXml: string | undefined;
 
-  // If enableAllTypes, fetch scope and modify it
-  if (params.enableAllTypes) {
+  // Fetch and modify the scope only when the caller wants to constrain which
+  // object types are searched. Otherwise getWhereUsed() falls back to SAP's
+  // default scope.
+  const enableOnly = params.enableOnlyTypes?.length
+    ? params.enableOnlyTypes
+    : undefined;
+  const disable = params.disableTypes?.length ? params.disableTypes : undefined;
+
+  if (params.enableAllTypes || enableOnly || disable) {
     const scopeResponse = await getWhereUsedScope(connection, {
       object_name: params.object_name,
       object_type: params.object_type,
     });
-    scopeXml = modifyWhereUsedScope(scopeResponse.data, { enableAll: true });
+
+    // enableOnly wins over enableAll; disable is then applied on top so callers
+    // can both narrow to a set and prune one of those, in a single pass.
+    let modified = scopeResponse.data;
+    if (enableOnly) {
+      modified = modifyWhereUsedScope(modified, { enableOnly });
+    } else if (params.enableAllTypes) {
+      modified = modifyWhereUsedScope(modified, { enableAll: true });
+    }
+    if (disable) {
+      modified = modifyWhereUsedScope(modified, { disable });
+    }
+    scopeXml = modified;
   }
 
   // Execute where-used search


### PR DESCRIPTION
## Why

`getWhereUsedList` only offered `enableAllTypes` (all types) or the default SAP scope. On a heavily-referenced object that means getting back hundreds of `CLAS/OC` references when you only care about, say, structures — and the oversized result gets truncated downstream.

## What

- **New options on `IGetWhereUsedListParams`:**
  - `enableOnlyTypes?: string[]` — restrict the search to specific ADT object types (e.g. `['TABL/DS', 'TABL/DT']`). SAP applies the selection **server-side**, so unwanted types are never searched nor returned. Takes precedence over `enableAllTypes`.
  - `disableTypes?: string[]` — prune types from the default scope; applied on top.
- **Bug fix — `modifyWhereUsedScope` attribute order:** the existing `enableOnly` / `enable` / `disable` options silently never matched. They assumed the scope XML emits `name` before `isSelected`, but SAP emits `isDefault isSelected name` (name **last**). Reworked to flip `isSelected` per `<usagereferences:type>` tag independent of attribute order, preserving tag order and the opaque `payload` blob. `enableAll` was unaffected.

Backward-compatible (only optional fields added). No change to `@mcp-abap-adt/interfaces` — `IGetWhereUsedListParams` is local to this package.

## Tests

- **Unit** (no SAP needed): `modifyWhereUsedScope` and `getWhereUsedList` against a fixture captured in real SAP attribute order (`isDefault isSelected name`). The order-fix tests fail on the old implementation.
- **Integration** (cloud trial polygon, `ZAC_SHR_VTABL`): ALL vs KEEP(present type) vs EXCLUDE(absent type). EXCLUDE → **0** refs while ALL → matches, proving server-side filtering. All 8 where-used integration cases green.
- Also switched the test file to the shared `sessionConfig.getConfig` — the local copy defaulted to basic auth and **skipped every case on JWT systems** (trial).

## Release

Bumps to **6.1.0** (minor — new feature + fix). Merging makes `main` release-ready; tag `v6.1.0` triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)