### PR TITLE
feat(versions)!: object version history (getVersions/getVersionSource); interfaces ^9.0.0 — 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0] - 2026-06-28
+
+### Added
+- **Object version history.** Every object handler now implements `getVersions(config)` (list the SAP version history as `IObjectVersion[]`) and `getVersionSource(contentUri)` (fetch a specific version's source). Each handler owns its own version endpoint: source-bearing types GET `<sourceUri>/versions` (classes use `/includes/{type}/versions`) as an Atom feed; non-source types and types without a version resource throw `AdtOperationError(code = UNSUPPORTED_OPERATION)` — raw HTTP is never surfaced. Trial-verified end-to-end for table, class, interface, and serviceDefinition; other source types build a candidate URL that safely degrades to `UNSUPPORTED_OPERATION` where the endpoint is absent.
+
+### Changed (BREAKING)
+- **Requires `@mcp-abap-adt/interfaces@^9.0.0`** (up from `^7.3.0`), which adds the required `getVersions`/`getVersionSource` methods and `IObjectVersion`/`AdtObjectErrorCodes.UNSUPPORTED_OPERATION` to `IAdtObject`. Consumers that implement `IAdtObject` themselves must add the two methods; consumers pinned to an older `interfaces` major must upgrade. Major bump.
+
 ## [6.1.0] - 2026-06-26
 
 ### Added

--- a/docs/usage/CLIENT_API_REFERENCE.md
+++ b/docs/usage/CLIENT_API_REFERENCE.md
@@ -293,6 +293,42 @@ await utils.readObjectMetadata(metadataType, 'ZOK_I_CDS_TEST');
 await utils.readObjectSource(sourceType, 'ZOK_I_CDS_TEST', undefined, 'active');
 ```
 
+### Object version history
+
+Every object handler exposes `getVersions(config)` (list the SAP version history)
+and `getVersionSource(contentUri)` (fetch a specific version's source). Identity is
+passed per call, like the other handler methods.
+
+```typescript
+import { AdtObjectErrorCodes, type AdtOperationError } from '@mcp-abap-adt/interfaces';
+
+const versions = await client.getClass().getVersions({ className: 'ZCL_MY_CLASS' });
+for (const v of versions) {
+  console.log(`${v.versionId} by ${v.author ?? '?'} at ${v.updatedAt ?? '?'}`);
+}
+
+// Fetch the source of a specific version via its opaque contentUri.
+if (versions.length > 0) {
+  const src = await client.getClass().getVersionSource(versions[0].contentUri);
+  console.log(src);
+}
+```
+
+Object types that do not expose a version resource (e.g. packages, transports, or a
+type whose version endpoint is not available on the target system) throw
+`AdtOperationError` with `code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION` — the
+raw HTTP error is never surfaced:
+
+```typescript
+try {
+  await client.getPackage().getVersions({ packageName: 'ZMY_PKG' });
+} catch (e) {
+  if ((e as AdtOperationError).code === AdtObjectErrorCodes.UNSUPPORTED_OPERATION) {
+    // this object has no version history
+  }
+}
+```
+
 ### AdtUtils (Where-used)
 
 Where-used is a two-step flow:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^7.3.0",
+        "@mcp-abap-adt/interfaces": "^9.0.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.13.6",
         "fast-xml-parser": "^5.4.1",
@@ -216,6 +216,16 @@
       },
       "optionalDependencies": {
         "@mcp-abap-adt/sap-rfc-lite": "^0.1.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/@mcp-abap-adt/interfaces": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.3.0.tgz",
+      "integrity": "sha512-9Q7L/min183Zq/0WUoHXyzB4QzeYMoizYsyDlechk9CoAq8VGJ7AYxh/EUQIS8y6lPpugtAK9McKgolImnefVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mcp-abap-adt/connection/node_modules/@mcp-abap-adt/sap-rfc-lite": {
@@ -1551,9 +1561,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-7.3.0.tgz",
-      "integrity": "sha512-9Q7L/min183Zq/0WUoHXyzB4QzeYMoizYsyDlechk9CoAq8VGJ7AYxh/EUQIS8y6lPpugtAK9McKgolImnefVA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.0.0.tgz",
+      "integrity": "sha512-jXRdXIMFnXfkK8mTARUEc7HMiQezesnGo9PxKMtF/mc98PdsPCYMxGEJXXrnyRLqErelfElJx3E6b1JhWs7rpA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "6.1.0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^7.3.0",
+    "@mcp-abap-adt/interfaces": "^9.0.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.13.6",
     "fast-xml-parser": "^5.4.1",

--- a/src/__tests__/integration/core/versions/versions.test.ts
+++ b/src/__tests__/integration/core/versions/versions.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Integration test for object version history (getVersions / getVersionSource).
+ *
+ * Covers the types whose version URL is verified end-to-end on the cloud trial:
+ * table, class, interface, serviceDefinition. Other source types build a
+ * candidate URL that degrades to UNSUPPORTED_OPERATION where unsupported.
+ *
+ * Self-skips when no .env / SAP config is present.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import * as dotenv from 'dotenv';
+import type { AdtClient } from '../../../../clients/AdtClient';
+import { createTestAdtClient, getConfig } from '../../../helpers/sessionConfig';
+import { createTestsLogger } from '../../../helpers/testLogger';
+
+const envPath =
+  process.env.MCP_ENV_PATH || path.resolve(__dirname, '../../../../../.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath, quiet: true });
+}
+
+const logger = createTestsLogger();
+
+describe('Object version history', () => {
+  let connection: IAbapConnection;
+  let client: AdtClient;
+  let hasConfig = false;
+
+  beforeAll(async () => {
+    try {
+      connection = createAbapConnection(getConfig(), logger);
+      await (connection as any).connect();
+      const { client: c } = await createTestAdtClient(connection, logger);
+      client = c;
+      hasConfig = true;
+    } catch {
+      hasConfig = false;
+    }
+  }, 60000);
+
+  afterAll(async () => {
+    if (connection) (connection as any).reset?.();
+  });
+
+  const cases: Array<{ label: string; list: () => Promise<any[]> }> = [
+    {
+      label: 'table',
+      list: () => client.getTable().getVersions({ tableName: 'ZAC_SHR_BTABL' }),
+    },
+    {
+      label: 'class',
+      list: () => client.getClass().getVersions({ className: 'ZAC_SHR_DMP01' }),
+    },
+    {
+      label: 'interface',
+      list: () =>
+        client.getInterface().getVersions({ interfaceName: 'ZAC_SHR_IF01' }),
+    },
+    {
+      label: 'serviceDefinition',
+      list: () =>
+        client
+          .getServiceDefinition()
+          .getVersions({ serviceDefinitionName: 'ZAC_SHR_SRVD01' }),
+    },
+  ];
+
+  for (const tc of cases) {
+    it(`lists versions and fetches a version's source for ${tc.label}`, async () => {
+      if (!hasConfig) return;
+      const versions = await tc.list();
+      expect(Array.isArray(versions)).toBe(true);
+      expect(versions.length).toBeGreaterThan(0);
+      const v = versions[0];
+      expect(typeof v.versionId).toBe('string');
+      expect(typeof v.contentUri).toBe('string');
+      expect(v.contentUri.length).toBeGreaterThan(0);
+
+      // getVersionSource is the same opaque-URI fetch on every handler.
+      const src = await client.getTable().getVersionSource(v.contentUri);
+      expect(typeof src).toBe('string');
+      expect(src.length).toBeGreaterThan(0);
+    }, 60000);
+  }
+});

--- a/src/__tests__/integration/shared/nodeStructure.test.ts
+++ b/src/__tests__/integration/shared/nodeStructure.test.ts
@@ -62,6 +62,14 @@ class NodeStructureObject
     );
   }
 
+  getVersions() {
+    return this.rejectUnsupported<never>('getVersions');
+  }
+
+  getVersionSource() {
+    return this.rejectUnsupported<never>('getVersionSource');
+  }
+
   validate(_config: Partial<INodeStructureParams>): Promise<AxiosResponse> {
     return this.rejectUnsupported('validate');
   }

--- a/src/__tests__/integration/shared/objectStructure.test.ts
+++ b/src/__tests__/integration/shared/objectStructure.test.ts
@@ -60,6 +60,14 @@ class ObjectStructureObject
     );
   }
 
+  getVersions() {
+    return this.rejectUnsupported<never>('getVersions');
+  }
+
+  getVersionSource() {
+    return this.rejectUnsupported<never>('getVersionSource');
+  }
+
   validate(_config: Partial<IObjectStructureParams>): Promise<AxiosResponse> {
     return this.rejectUnsupported('validate');
   }

--- a/src/__tests__/integration/shared/packageHierarchy.test.ts
+++ b/src/__tests__/integration/shared/packageHierarchy.test.ts
@@ -59,6 +59,14 @@ class PackageHierarchyObject
     );
   }
 
+  getVersions() {
+    return this.rejectUnsupported<never>('getVersions');
+  }
+
+  getVersionSource() {
+    return this.rejectUnsupported<never>('getVersionSource');
+  }
+
   validate(_config: Partial<IPackageHierarchyParams>): Promise<any> {
     return this.rejectUnsupported('validate');
   }

--- a/src/__tests__/integration/shared/virtualFoldersContents.test.ts
+++ b/src/__tests__/integration/shared/virtualFoldersContents.test.ts
@@ -64,6 +64,14 @@ class VirtualFoldersContentsObject
     );
   }
 
+  getVersions() {
+    return this.rejectUnsupported<never>('getVersions');
+  }
+
+  getVersionSource() {
+    return this.rejectUnsupported<never>('getVersionSource');
+  }
+
   validate(
     _config: Partial<GetVirtualFoldersContentsParams>,
   ): Promise<AxiosResponse> {

--- a/src/__tests__/unit/classVersions.test.ts
+++ b/src/__tests__/unit/classVersions.test.ts
@@ -1,0 +1,53 @@
+import type { IAbapConnection, IAdtResponse } from '@mcp-abap-adt/interfaces';
+import { AdtClass } from '../../core/class/AdtClass';
+import { AdtLocalTypes } from '../../core/class/AdtLocalTypes';
+import { getClassIncludeVersions } from '../../core/class/versions';
+
+const FEED = `<?xml version="1.0"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom"><atom:title>Version List of ZCL (CLAS)</atom:title><atom:entry><atom:content type="text/plain" src="/sap/bc/adt/oo/classes/zcl/includes/main/versions/1/00000/content"/><atom:id>00000</atom:id></atom:entry></atom:feed>`;
+
+function conn(handler: (o: any) => Promise<IAdtResponse>): IAbapConnection {
+  return {
+    makeAdtRequest: handler,
+    setSessionType: () => {},
+  } as unknown as IAbapConnection;
+}
+
+describe('getClassIncludeVersions', () => {
+  it('targets the main include by default via AdtClass.getVersions', async () => {
+    let seen: any;
+    const c = conn(async (o) => {
+      seen = o;
+      return { data: FEED, status: 200, headers: {} } as IAdtResponse;
+    });
+    const cls = new AdtClass(c);
+    const list = await cls.getVersions({ className: 'ZCL' });
+    expect(seen.url).toBe('/sap/bc/adt/oo/classes/ZCL/includes/main/versions');
+    expect(seen.headers.Accept).toContain('application/atom+xml;type=feed');
+    expect(list).toHaveLength(1);
+  });
+
+  it('AdtLocalTypes targets the implementations include', async () => {
+    let seen: any;
+    const c = conn(async (o) => {
+      seen = o;
+      return { data: FEED, status: 200, headers: {} } as IAdtResponse;
+    });
+    const local = new AdtLocalTypes(c);
+    await local.getVersions({ className: 'ZCL' });
+    expect(seen.url).toBe(
+      '/sap/bc/adt/oo/classes/ZCL/includes/implementations/versions',
+    );
+  });
+
+  it('translates a 404 into UNSUPPORTED_OPERATION', async () => {
+    expect.assertions(1);
+    const c = conn(async () => {
+      const err: any = new Error('not found');
+      err.response = { status: 404 };
+      throw err;
+    });
+    await expect(
+      getClassIncludeVersions(c, 'ZCL', 'main'),
+    ).rejects.toMatchObject({ code: 'ADT_UNSUPPORTED_OPERATION' });
+  });
+});

--- a/src/__tests__/unit/interfaceVersions.test.ts
+++ b/src/__tests__/unit/interfaceVersions.test.ts
@@ -1,0 +1,34 @@
+import type { IAbapConnection, IAdtResponse } from '@mcp-abap-adt/interfaces';
+import { getInterfaceVersions } from '../../core/interface/versions';
+
+const FEED = `<?xml version="1.0"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom"><atom:title>Version List of ZIF (INTF)</atom:title><atom:entry><atom:content type="text/plain" src="/sap/bc/adt/oo/interfaces/zif/source/main/versions/1/00000/content"/><atom:id>00000</atom:id></atom:entry></atom:feed>`;
+
+function conn(handler: (o: any) => Promise<IAdtResponse>): IAbapConnection {
+  return { makeAdtRequest: handler } as unknown as IAbapConnection;
+}
+
+describe('getInterfaceVersions', () => {
+  it('builds the interface source/main/versions URL with the feed Accept', async () => {
+    let seen: any;
+    const c = conn(async (o) => {
+      seen = o;
+      return { data: FEED, status: 200, headers: {} } as IAdtResponse;
+    });
+    const list = await getInterfaceVersions(c, { interfaceName: 'ZIF' });
+    expect(seen.url).toBe('/sap/bc/adt/oo/interfaces/ZIF/source/main/versions');
+    expect(seen.headers.Accept).toContain('application/atom+xml;type=feed');
+    expect(list).toHaveLength(1);
+  });
+
+  it('translates a 406 into UNSUPPORTED_OPERATION', async () => {
+    expect.assertions(1);
+    const c = conn(async () => {
+      const err: any = new Error('not acceptable');
+      err.response = { status: 406 };
+      throw err;
+    });
+    await expect(
+      getInterfaceVersions(c, { interfaceName: 'ZIF' }),
+    ).rejects.toMatchObject({ code: 'ADT_UNSUPPORTED_OPERATION' });
+  });
+});

--- a/src/__tests__/unit/packageVersions.test.ts
+++ b/src/__tests__/unit/packageVersions.test.ts
@@ -1,0 +1,21 @@
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { AdtPackage } from '../../core/package/AdtPackage';
+
+describe('AdtPackage version history (non-source)', () => {
+  it('throws UNSUPPORTED_OPERATION without any HTTP call', async () => {
+    expect.assertions(2);
+    let called = false;
+    const c = {
+      makeAdtRequest: async () => {
+        called = true;
+        return { data: '', status: 200, headers: {} } as any;
+      },
+      setSessionType: () => {},
+    } as unknown as IAbapConnection;
+    const pkg = new AdtPackage(c);
+    await expect(
+      pkg.getVersions({ packageName: 'ZPKG' }),
+    ).rejects.toMatchObject({ code: 'ADT_UNSUPPORTED_OPERATION' });
+    expect(called).toBe(false);
+  });
+});

--- a/src/__tests__/unit/programVersions.test.ts
+++ b/src/__tests__/unit/programVersions.test.ts
@@ -1,0 +1,58 @@
+import type { IAbapConnection, IAdtResponse } from '@mcp-abap-adt/interfaces';
+import {
+  getProgramVersionSource,
+  getProgramVersions,
+} from '../../core/program/versions';
+
+const FEED = `<?xml version="1.0"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom"><atom:title>Version List of ZPROG (PROG)</atom:title><atom:entry><atom:content type="text/plain" src="/sap/bc/adt/programs/programs/zprog/source/main/versions/1/00000/content"/><atom:id>00000</atom:id></atom:entry></atom:feed>`;
+
+function conn(handler: (o: any) => Promise<IAdtResponse>): IAbapConnection {
+  return { makeAdtRequest: handler } as unknown as IAbapConnection;
+}
+
+describe('getProgramVersions', () => {
+  it('GETs source/main/versions with the atom-feed Accept and parses it', async () => {
+    let seen: any;
+    const c = conn(async (o) => {
+      seen = o;
+      return { data: FEED, status: 200, headers: {} } as IAdtResponse;
+    });
+    const list = await getProgramVersions(c, { programName: 'ZPROG' });
+    expect(seen.url).toBe(
+      '/sap/bc/adt/programs/programs/ZPROG/source/main/versions',
+    );
+    expect(seen.headers.Accept).toContain('application/atom+xml;type=feed');
+    expect(list).toHaveLength(1);
+    expect(list[0].contentUri).toContain('/00000/content');
+  });
+
+  it('translates a 404 into UNSUPPORTED_OPERATION (no raw HTTP outward)', async () => {
+    expect.assertions(1);
+    const c = conn(async () => {
+      const err: any = new Error('not found');
+      err.response = { status: 404 };
+      throw err;
+    });
+    await expect(
+      getProgramVersions(c, { programName: 'ZPROG' }),
+    ).rejects.toMatchObject({ code: 'ADT_UNSUPPORTED_OPERATION' });
+  });
+});
+
+describe('getProgramVersionSource', () => {
+  it('GETs the opaque contentUri as text/plain', async () => {
+    let seen: any;
+    const c = conn(async (o) => {
+      seen = o;
+      return {
+        data: 'REPORT zprog.',
+        status: 200,
+        headers: {},
+      } as IAdtResponse;
+    });
+    const src = await getProgramVersionSource(c, '/sap/bc/adt/x/00000/content');
+    expect(seen.url).toBe('/sap/bc/adt/x/00000/content');
+    expect(seen.headers.Accept).toBe('text/plain');
+    expect(src).toContain('REPORT');
+  });
+});

--- a/src/__tests__/unit/tableVersions.test.ts
+++ b/src/__tests__/unit/tableVersions.test.ts
@@ -1,0 +1,56 @@
+import type { IAbapConnection, IAdtResponse } from '@mcp-abap-adt/interfaces';
+import {
+  getTableVersionSource,
+  getTableVersions,
+} from '../../core/table/versions';
+
+const FEED = `<?xml version="1.0"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom"><atom:title>Version List of ZT (TABL)</atom:title><atom:entry><atom:content type="text/plain" src="/sap/bc/adt/ddic/tables/zt/source/main/versions/1/00000/content"/><atom:id>00000</atom:id></atom:entry></atom:feed>`;
+
+function conn(handler: (o: any) => Promise<IAdtResponse>): IAbapConnection {
+  return { makeAdtRequest: handler } as unknown as IAbapConnection;
+}
+
+describe('getTableVersions', () => {
+  it('GETs source/main/versions with the atom-feed Accept and parses it', async () => {
+    let seen: any;
+    const c = conn(async (o) => {
+      seen = o;
+      return { data: FEED, status: 200, headers: {} } as IAdtResponse;
+    });
+    const list = await getTableVersions(c, { tableName: 'ZT' });
+    expect(seen.url).toBe('/sap/bc/adt/ddic/tables/ZT/source/main/versions');
+    expect(seen.headers.Accept).toContain('application/atom+xml;type=feed');
+    expect(list).toHaveLength(1);
+    expect(list[0].contentUri).toContain('/00000/content');
+  });
+
+  it('translates a 404 into UNSUPPORTED_OPERATION (no raw HTTP outward)', async () => {
+    expect.assertions(1);
+    const c = conn(async () => {
+      const err: any = new Error('not found');
+      err.response = { status: 404 };
+      throw err;
+    });
+    await expect(
+      getTableVersions(c, { tableName: 'ZT' }),
+    ).rejects.toMatchObject({ code: 'ADT_UNSUPPORTED_OPERATION' });
+  });
+});
+
+describe('getTableVersionSource', () => {
+  it('GETs the opaque contentUri as text/plain', async () => {
+    let seen: any;
+    const c = conn(async (o) => {
+      seen = o;
+      return {
+        data: 'DEFINE TABLE zt ...',
+        status: 200,
+        headers: {},
+      } as IAdtResponse;
+    });
+    const src = await getTableVersionSource(c, '/sap/bc/adt/x/00000/content');
+    expect(seen.url).toBe('/sap/bc/adt/x/00000/content');
+    expect(seen.headers.Accept).toBe('text/plain');
+    expect(src).toContain('DEFINE TABLE');
+  });
+});

--- a/src/__tests__/unit/versionsParse.test.ts
+++ b/src/__tests__/unit/versionsParse.test.ts
@@ -1,0 +1,66 @@
+import { AdtOperationError } from '@mcp-abap-adt/interfaces';
+import {
+  parseVersionsFeed,
+  throwUnsupportedVersions,
+  throwVersionsError,
+} from '../../core/shared/versions';
+
+const FEED = `<?xml version="1.0" encoding="utf-8"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom" xmlns:adtcore="http://www.sap.com/adt/core"><atom:title>Version List of ZAC_SHR_BTABL (TABL)</atom:title><atom:entry><atom:author><atom:name>CB9980008038</atom:name></atom:author><atom:content type="text/plain" src="/sap/bc/adt/ddic/tables/zac_shr_btabl/source/main/versions/19700101101123/00000/content"/><atom:id>00000</atom:id><atom:updated>2026-06-14T16:25:57Z</atom:updated></atom:entry></atom:feed>`;
+
+const EMPTY = `<?xml version="1.0"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom"><atom:title>Version List of X</atom:title></atom:feed>`;
+
+describe('parseVersionsFeed', () => {
+  it('parses a single-entry feed', () => {
+    const v = parseVersionsFeed(FEED);
+    expect(v).toHaveLength(1);
+    expect(v[0]).toEqual({
+      versionId: '00000',
+      author: 'CB9980008038',
+      updatedAt: '2026-06-14T16:25:57Z',
+      title: 'Version List of ZAC_SHR_BTABL (TABL)',
+      contentUri:
+        '/sap/bc/adt/ddic/tables/zac_shr_btabl/source/main/versions/19700101101123/00000/content',
+    });
+  });
+
+  it('returns [] for a feed with no entries', () => {
+    expect(parseVersionsFeed(EMPTY)).toEqual([]);
+  });
+});
+
+describe('throwUnsupportedVersions', () => {
+  it('throws AdtOperationError with UNSUPPORTED_OPERATION', () => {
+    expect(() => throwUnsupportedVersions('ZPACK')).toThrow();
+    try {
+      throwUnsupportedVersions('ZPACK');
+    } catch (e: any) {
+      expect(e.code).toBe('ADT_UNSUPPORTED_OPERATION');
+    }
+  });
+});
+
+describe('throwVersionsError', () => {
+  it('maps 404/406 to UNSUPPORTED_OPERATION', () => {
+    expect.assertions(2);
+    for (const status of [404, 406]) {
+      try {
+        throwVersionsError({ response: { status } }, 'ZT');
+      } catch (e: any) {
+        expect(e.code).toBe('ADT_UNSUPPORTED_OPERATION');
+      }
+    }
+  });
+
+  it('wraps any other failure in AdtOperationError (status + originalError, no raw axios)', () => {
+    expect.assertions(4);
+    const original = { response: { status: 500 }, message: 'boom' };
+    try {
+      throwVersionsError(original, 'ZT');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(AdtOperationError);
+      expect(e.code).toBeUndefined();
+      expect(e.status).toBe(500);
+      expect(e.originalError).toBe(original);
+    }
+  });
+});

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -43,6 +43,10 @@ import { unlockAccessControl } from './unlock';
 import { updateAccessControl } from './update';
 import { validateAccessControlName } from './validation';
 
+import {
+  getAccessControlVersionSource,
+  getAccessControlVersions,
+} from './versions';
 export class AdtAccessControl
   implements IAdtObject<IAccessControlConfig, IAccessControlState>
 {
@@ -600,5 +604,13 @@ export class AdtAccessControl
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IAccessControlConfig>) {
+    return getAccessControlVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getAccessControlVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/accessControl/versions.ts
+++ b/src/core/accessControl/versions.ts
@@ -1,0 +1,48 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IAccessControlConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getAccessControlVersions(
+  connection: IAbapConnection,
+  config: Partial<IAccessControlConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.accessControlName)
+    throw new Error('accessControlName is required');
+  const encodedName = encodeSapObjectName(
+    config.accessControlName.toLowerCase(),
+  );
+  const url = `/sap/bc/adt/acm/dcl/sources/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `access control ${config.accessControlName}`);
+  }
+}
+
+export async function getAccessControlVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/appendStructure/AdtAppendStructure.ts
+++ b/src/core/appendStructure/AdtAppendStructure.ts
@@ -29,6 +29,10 @@ import { validateAppendStructureName } from './validation';
 
 const VALIDATION_UNSUPPORTED_STATUSES = new Set([404, 405, 501]);
 
+import {
+  getAppendStructureVersionSource,
+  getAppendStructureVersions,
+} from './versions';
 export class AdtAppendStructure
   implements IAdtObject<IAppendStructureConfig, IAppendStructureState>
 {
@@ -377,5 +381,13 @@ export class AdtAppendStructure
     } finally {
       this.connection.setSessionType('stateless');
     }
+  }
+
+  getVersions(config: Partial<IAppendStructureConfig>) {
+    return getAppendStructureVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getAppendStructureVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/appendStructure/versions.ts
+++ b/src/core/appendStructure/versions.ts
@@ -1,0 +1,48 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IAppendStructureConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getAppendStructureVersions(
+  connection: IAbapConnection,
+  config: Partial<IAppendStructureConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.appendStructureName)
+    throw new Error('appendStructureName is required');
+  const encodedName = encodeSapObjectName(
+    config.appendStructureName.toLowerCase(),
+  );
+  const url = `/sap/bc/adt/ddic/structures/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `append structure ${config.appendStructureName}`);
+  }
+}
+
+export async function getAppendStructureVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/authorizationField/AdtAuthorizationField.ts
+++ b/src/core/authorizationField/AdtAuthorizationField.ts
@@ -21,9 +21,11 @@ import type {
   IAdtObject,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { activateAuthorizationField } from './activation';
 import { checkAuthorizationField } from './check';
 import { create as createAuthorizationField } from './create';
@@ -42,7 +44,6 @@ import type {
 import { unlockAuthorizationField } from './unlock';
 import { updateAuthorizationField } from './update';
 import { validateAuthorizationFieldName } from './validation';
-
 export class AdtAuthorizationField
   implements IAdtObject<IAuthorizationFieldConfig, IAuthorizationFieldState>
 {
@@ -594,5 +595,15 @@ export class AdtAuthorizationField
     );
     this.connection.setSessionType('stateless');
     return { errors: [] };
+  }
+
+  async getVersions(
+    _config: Partial<IAuthorizationFieldConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('authorization field');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('authorization field');
   }
 }

--- a/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
+++ b/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
@@ -46,6 +46,10 @@ import { unlock } from './unlock';
 import { update } from './update';
 import { validate } from './validation';
 
+import {
+  getBehaviorDefinitionVersionSource,
+  getBehaviorDefinitionVersions,
+} from './versions';
 export class AdtBehaviorDefinition
   implements IAdtObject<IBehaviorDefinitionConfig, IBehaviorDefinitionState>
 {
@@ -655,5 +659,13 @@ export class AdtBehaviorDefinition
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IBehaviorDefinitionConfig>) {
+    return getBehaviorDefinitionVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getBehaviorDefinitionVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/behaviorDefinition/versions.ts
+++ b/src/core/behaviorDefinition/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IBehaviorDefinitionConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getBehaviorDefinitionVersions(
+  connection: IAbapConnection,
+  config: Partial<IBehaviorDefinitionConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.name) throw new Error('name is required');
+  const encodedName = encodeSapObjectName(config.name).toLowerCase();
+  const url = `/sap/bc/adt/bo/behaviordefinitions/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `behavior definition ${config.name}`);
+  }
+}
+
+export async function getBehaviorDefinitionVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
+++ b/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
@@ -47,6 +47,10 @@ import type {
 import { updateBehaviorImplementation } from './update';
 import { validateBehaviorImplementationName } from './validation';
 
+import {
+  getBehaviorImplementationVersionSource,
+  getBehaviorImplementationVersions,
+} from './versions';
 export class AdtBehaviorImplementation
   implements
     IAdtObject<IBehaviorImplementationConfig, IBehaviorImplementationState>
@@ -648,5 +652,13 @@ ENDCLASS.`;
       unlockResult: unlockState.unlockResult,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IBehaviorImplementationConfig>) {
+    return getBehaviorImplementationVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getBehaviorImplementationVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/behaviorImplementation/versions.ts
+++ b/src/core/behaviorImplementation/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IBehaviorImplementationConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getBehaviorImplementationVersions(
+  connection: IAbapConnection,
+  config: Partial<IBehaviorImplementationConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.className) throw new Error('className is required');
+  const encodedName = encodeSapObjectName(config.className);
+  const url = `/sap/bc/adt/oo/classes/${encodedName}/includes/implementations/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `behavior implementation ${config.className}`);
+  }
+}
+
+export async function getBehaviorImplementationVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -26,6 +26,7 @@ import {
   type IAdtObject,
   type IAdtOperationOptions,
   type ILogger,
+  type IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage, safeStringify } from '../../utils/internalUtils';
@@ -45,6 +46,11 @@ import type { IClassConfig, IClassState } from './types';
 import { unlockClass } from './unlock';
 import { updateClass } from './update';
 import { validateClassName } from './validation';
+import {
+  type ClassIncludeType,
+  getClassIncludeVersions,
+  getClassVersionSource,
+} from './versions';
 
 export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
   protected readonly connection: IAbapConnection;
@@ -901,5 +907,22 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
       this.logger?.error('Read transport failed:', safeErrorMessage(err));
       throw err;
     }
+  }
+
+  getVersions(config: Partial<IClassConfig>): Promise<IObjectVersion[]> {
+    if (!config.className) throw new Error('className is required');
+    return getClassIncludeVersions(this.connection, config.className, 'main');
+  }
+
+  getVersionSource(contentUri: string): Promise<string> {
+    return getClassVersionSource(this.connection, contentUri);
+  }
+
+  /** Shared by local-include subclasses to target their own include. */
+  protected getIncludeVersions(
+    className: string,
+    includeType: ClassIncludeType,
+  ): Promise<IObjectVersion[]> {
+    return getClassIncludeVersions(this.connection, className, includeType);
   }
 }

--- a/src/core/class/AdtLocalDefinitions.ts
+++ b/src/core/class/AdtLocalDefinitions.ts
@@ -5,7 +5,11 @@
  * All operations require the parent class to be locked.
  */
 
-import type { HttpError, IAdtOperationOptions } from '@mcp-abap-adt/interfaces';
+import type {
+  HttpError,
+  IAdtOperationOptions,
+  IObjectVersion,
+} from '@mcp-abap-adt/interfaces';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IReadOptions } from '../shared/types';
 import { AdtClass } from './AdtClass';
@@ -349,4 +353,11 @@ export class AdtLocalDefinitions extends AdtClass {
   // - Eclipse ADT logs show parent class lock is used before updating local includes
   // - Delete operation currently uses update() with empty code, but validation prevents empty strings
   // - Consider: Should delete() bypass validation or use a different approach?
+
+  getVersions(
+    config: Partial<{ className: string }>,
+  ): Promise<IObjectVersion[]> {
+    if (!config.className) throw new Error('className is required');
+    return this.getIncludeVersions(config.className, 'definitions');
+  }
 }

--- a/src/core/class/AdtLocalMacros.ts
+++ b/src/core/class/AdtLocalMacros.ts
@@ -6,7 +6,11 @@
  * All operations require the parent class to be locked.
  */
 
-import type { HttpError, IAdtOperationOptions } from '@mcp-abap-adt/interfaces';
+import type {
+  HttpError,
+  IAdtOperationOptions,
+  IObjectVersion,
+} from '@mcp-abap-adt/interfaces';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IReadOptions } from '../shared/types';
 import { AdtClass } from './AdtClass';
@@ -336,4 +340,11 @@ export class AdtLocalMacros extends AdtClass {
   // - Eclipse ADT logs show parent class lock is used before updating local includes
   // - Delete operation currently uses update() with empty code, but validation prevents empty strings
   // - Consider: Should delete() bypass validation or use a different approach?
+
+  getVersions(
+    config: Partial<{ className: string }>,
+  ): Promise<IObjectVersion[]> {
+    if (!config.className) throw new Error('className is required');
+    return this.getIncludeVersions(config.className, 'macros');
+  }
 }

--- a/src/core/class/AdtLocalTestClass.ts
+++ b/src/core/class/AdtLocalTestClass.ts
@@ -5,7 +5,11 @@
  * All operations require the parent class to be locked.
  */
 
-import type { HttpError, IAdtOperationOptions } from '@mcp-abap-adt/interfaces';
+import type {
+  HttpError,
+  IAdtOperationOptions,
+  IObjectVersion,
+} from '@mcp-abap-adt/interfaces';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IReadOptions } from '../shared/types';
 import { AdtClass } from './AdtClass';
@@ -363,4 +367,11 @@ export class AdtLocalTestClass extends AdtClass {
   // - Need to verify if /includes/testclasses?_action=LOCK endpoint exists in ADT discovery
   // - Delete operation currently uses update() with empty code, but validation prevents empty strings
   // - Consider: Should delete() bypass validation or use a different approach?
+
+  getVersions(
+    config: Partial<{ className: string }>,
+  ): Promise<IObjectVersion[]> {
+    if (!config.className) throw new Error('className is required');
+    return this.getIncludeVersions(config.className, 'testclasses');
+  }
 }

--- a/src/core/class/AdtLocalTypes.ts
+++ b/src/core/class/AdtLocalTypes.ts
@@ -5,7 +5,11 @@
  * All operations require the parent class to be locked.
  */
 
-import type { HttpError, IAdtOperationOptions } from '@mcp-abap-adt/interfaces';
+import type {
+  HttpError,
+  IAdtOperationOptions,
+  IObjectVersion,
+} from '@mcp-abap-adt/interfaces';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IReadOptions } from '../shared/types';
 import { AdtClass } from './AdtClass';
@@ -336,4 +340,11 @@ export class AdtLocalTypes extends AdtClass {
   // - Eclipse ADT logs show parent class lock is used before updating local includes
   // - Delete operation currently uses update() with empty code, but validation prevents empty strings
   // - Consider: Should delete() bypass validation or use a different approach?
+
+  getVersions(
+    config: Partial<{ className: string }>,
+  ): Promise<IObjectVersion[]> {
+    if (!config.className) throw new Error('className is required');
+    return this.getIncludeVersions(config.className, 'implementations');
+  }
 }

--- a/src/core/class/versions.ts
+++ b/src/core/class/versions.ts
@@ -1,0 +1,52 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+/** Class source lives in includes, not a single source/main resource. */
+export type ClassIncludeType =
+  | 'main'
+  | 'definitions'
+  | 'implementations'
+  | 'testclasses'
+  | 'macros';
+
+export async function getClassIncludeVersions(
+  connection: IAbapConnection,
+  className: string,
+  includeType: ClassIncludeType,
+): Promise<IObjectVersion[]> {
+  if (!className) throw new Error('className is required');
+  const encodedName = encodeSapObjectName(className);
+  const url = `/sap/bc/adt/oo/classes/${encodedName}/includes/${includeType}/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `class ${className} (${includeType})`);
+  }
+}
+
+export async function getClassVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/dataElement/AdtDataElement.ts
+++ b/src/core/dataElement/AdtDataElement.ts
@@ -24,10 +24,12 @@ import type {
   IAdtObject,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IReadOptions } from '../shared/types';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { activateDataElement } from './activation';
 import { checkDataElement } from './check';
 import { create as createDataElement } from './create';
@@ -38,7 +40,6 @@ import type { IDataElementConfig, IDataElementState } from './types';
 import { unlockDataElement } from './unlock';
 import { updateDataElement } from './update';
 import { validateDataElementName } from './validation';
-
 export class AdtDataElement
   implements IAdtObject<IDataElementConfig, IDataElementState>
 {
@@ -675,5 +676,15 @@ export class AdtDataElement
       unlockResult: result,
       errors: [],
     };
+  }
+
+  async getVersions(
+    _config: Partial<IDataElementConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('data element');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('data element');
   }
 }

--- a/src/core/ddl/AdtDdl.ts
+++ b/src/core/ddl/AdtDdl.ts
@@ -42,6 +42,7 @@ import { unlockDDLS } from './unlock';
 import { updateDdl } from './update';
 import { validateDdlName } from './validation';
 
+import { getDdlVersionSource, getDdlVersions } from './versions';
 export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
@@ -586,5 +587,13 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IDdlConfig>) {
+    return getDdlVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getDdlVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/ddl/versions.ts
+++ b/src/core/ddl/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IDdlConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getDdlVersions(
+  connection: IAbapConnection,
+  config: Partial<IDdlConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.ddlName) throw new Error('ddlName is required');
+  const encodedName = encodeSapObjectName(config.ddlName);
+  const url = `/sap/bc/adt/ddic/ddl/sources/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `DDL source ${config.ddlName}`);
+  }
+}
+
+export async function getDdlVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -24,10 +24,12 @@ import type {
   IAdtObject,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IReadOptions } from '../shared/types';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { activateDomain } from './activation';
 import { checkDomainSyntax } from './check';
 import { create as createDomain } from './create';
@@ -38,7 +40,6 @@ import type { IDomainConfig, IDomainState } from './types';
 import { unlockDomain } from './unlock';
 import { updateDomain } from './update';
 import { validateDomainName } from './validation';
-
 export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
@@ -626,5 +627,15 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
       unlockResult: result,
       errors: [],
     };
+  }
+
+  async getVersions(
+    _config: Partial<IDomainConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('domain');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('domain');
   }
 }

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -54,6 +54,10 @@ import { unlockEnhancement } from './unlock';
 import { update } from './update';
 import { validate } from './validation';
 
+import {
+  getEnhancementVersionSource,
+  getEnhancementVersions,
+} from './versions';
 export class AdtEnhancement
   implements IAdtObject<IEnhancementConfig, IEnhancementState>
 {
@@ -793,5 +797,13 @@ export class AdtEnhancement
       errors: [],
       enhancementType: config.enhancementType,
     };
+  }
+
+  getVersions(config: Partial<IEnhancementConfig>) {
+    return getEnhancementVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getEnhancementVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/enhancement/versions.ts
+++ b/src/core/enhancement/versions.ts
@@ -1,0 +1,44 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import { getEnhancementUri, type IEnhancementConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getEnhancementVersions(
+  connection: IAbapConnection,
+  config: Partial<IEnhancementConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.enhancementName) throw new Error('enhancementName is required');
+  if (!config.enhancementType) throw new Error('enhancementType is required');
+  const url = `${getEnhancementUri(config.enhancementType, config.enhancementName)}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `enhancement ${config.enhancementName}`);
+  }
+}
+
+export async function getEnhancementVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/featureToggle/AdtFeatureToggle.ts
+++ b/src/core/featureToggle/AdtFeatureToggle.ts
@@ -24,9 +24,11 @@ import type {
   IAbapConnection,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { activateFeatureToggle } from './activation';
 import { checkFeatureToggle } from './check';
 import { checkFeatureToggleState } from './checkState';
@@ -49,7 +51,6 @@ import { unlockFeatureToggle } from './unlock';
 import { updateFeatureToggle } from './update';
 import { uploadFeatureToggleSource } from './updateSource';
 import { validateFeatureToggleName } from './validation';
-
 export class AdtFeatureToggle implements IFeatureToggleObject {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
@@ -803,5 +804,15 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
       throw new Error('Feature toggle name is required');
     }
     return config.featureToggleName;
+  }
+
+  async getVersions(
+    _config: Partial<IFeatureToggleConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('feature toggle');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('feature toggle');
   }
 }

--- a/src/core/functionGroup/AdtFunctionGroup.ts
+++ b/src/core/functionGroup/AdtFunctionGroup.ts
@@ -27,11 +27,13 @@ import type {
   IAdtObject,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IAdtContentTypes } from '../shared/contentTypes';
 import type { IReadOptions } from '../shared/types';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { activateFunctionGroup } from './activation';
 import { checkFunctionGroup } from './check';
 import { create as createFunctionGroup } from './create';
@@ -41,7 +43,6 @@ import { getFunctionGroup, getFunctionGroupTransport } from './read';
 import type { IFunctionGroupConfig, IFunctionGroupState } from './types';
 import { updateFunctionGroup } from './update';
 import { validateFunctionGroupName } from './validation';
-
 export class AdtFunctionGroup
   implements IAdtObject<IFunctionGroupConfig, IFunctionGroupState>
 {
@@ -749,5 +750,15 @@ export class AdtFunctionGroup
       unlockResult: result,
       errors: [],
     };
+  }
+
+  async getVersions(
+    _config: Partial<IFunctionGroupConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('function group');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('function group');
   }
 }

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -46,6 +46,10 @@ import { updateFunctionInclude } from './update';
 import { uploadFunctionIncludeSource } from './updateSource';
 import { validateFunctionIncludeName } from './validation';
 
+import {
+  getFunctionIncludeVersionSource,
+  getFunctionIncludeVersions,
+} from './versions';
 export class AdtFunctionInclude
   implements IAdtObject<IFunctionIncludeConfig, IFunctionIncludeState>
 {
@@ -783,5 +787,13 @@ export class AdtFunctionInclude
     );
     this.connection.setSessionType('stateless');
     return { errors: [] };
+  }
+
+  getVersions(config: Partial<IFunctionIncludeConfig>) {
+    return getFunctionIncludeVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getFunctionIncludeVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/functionInclude/versions.ts
+++ b/src/core/functionInclude/versions.ts
@@ -1,0 +1,50 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IFunctionIncludeConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getFunctionIncludeVersions(
+  connection: IAbapConnection,
+  config: Partial<IFunctionIncludeConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.functionGroupName)
+    throw new Error('functionGroupName is required');
+  if (!config.includeName) throw new Error('includeName is required');
+  const groupLower = encodeSapObjectName(
+    config.functionGroupName,
+  ).toLowerCase();
+  const encodedInclude = encodeSapObjectName(config.includeName.toUpperCase());
+  const url = `/sap/bc/adt/functions/groups/${groupLower}/includes/${encodedInclude}/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `function include ${config.includeName}`);
+  }
+}
+
+export async function getFunctionIncludeVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/functionModule/AdtFunctionModule.ts
+++ b/src/core/functionModule/AdtFunctionModule.ts
@@ -44,6 +44,10 @@ import { unlockFunctionModule } from './unlock';
 import { update } from './update';
 import { validateFunctionModuleName } from './validation';
 
+import {
+  getFunctionModuleVersionSource,
+  getFunctionModuleVersions,
+} from './versions';
 export class AdtFunctionModule
   implements IAdtObject<IFunctionModuleConfig, IFunctionModuleState>
 {
@@ -667,5 +671,13 @@ export class AdtFunctionModule
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IFunctionModuleConfig>) {
+    return getFunctionModuleVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getFunctionModuleVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/functionModule/versions.ts
+++ b/src/core/functionModule/versions.ts
@@ -1,0 +1,49 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IFunctionModuleConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getFunctionModuleVersions(
+  connection: IAbapConnection,
+  config: Partial<IFunctionModuleConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.functionGroupName)
+    throw new Error('functionGroupName is required');
+  if (!config.functionModuleName)
+    throw new Error('functionModuleName is required');
+  const encodedGroup = encodeSapObjectName(config.functionGroupName);
+  const encodedName = encodeSapObjectName(config.functionModuleName);
+  const url = `/sap/bc/adt/functions/groups/${encodedGroup}/fmodules/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `function module ${config.functionModuleName}`);
+  }
+}
+
+export async function getFunctionModuleVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -44,6 +44,7 @@ import { unlockInterface } from './unlock';
 import { upload } from './update';
 import { validateInterfaceName } from './validation';
 
+import { getInterfaceVersionSource, getInterfaceVersions } from './versions';
 export class AdtInterface
   implements IAdtObject<IInterfaceConfig, IInterfaceState>
 {
@@ -618,5 +619,13 @@ export class AdtInterface
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IInterfaceConfig>) {
+    return getInterfaceVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getInterfaceVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/interface/versions.ts
+++ b/src/core/interface/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IInterfaceConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getInterfaceVersions(
+  connection: IAbapConnection,
+  config: Partial<IInterfaceConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.interfaceName) throw new Error('interfaceName is required');
+  const encodedName = encodeSapObjectName(config.interfaceName);
+  const url = `/sap/bc/adt/oo/interfaces/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `interface ${config.interfaceName}`);
+  }
+}
+
+export async function getInterfaceVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/metadataExtension/AdtMetadataExtension.ts
+++ b/src/core/metadataExtension/AdtMetadataExtension.ts
@@ -46,6 +46,10 @@ import { unlockMetadataExtension } from './unlock';
 import { updateMetadataExtension } from './update';
 import { validateMetadataExtension } from './validation';
 
+import {
+  getMetadataExtensionVersionSource,
+  getMetadataExtensionVersions,
+} from './versions';
 export class AdtMetadataExtension
   implements IAdtObject<IMetadataExtensionConfig, IMetadataExtensionState>
 {
@@ -604,5 +608,13 @@ export class AdtMetadataExtension
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IMetadataExtensionConfig>) {
+    return getMetadataExtensionVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getMetadataExtensionVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/metadataExtension/versions.ts
+++ b/src/core/metadataExtension/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IMetadataExtensionConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getMetadataExtensionVersions(
+  connection: IAbapConnection,
+  config: Partial<IMetadataExtensionConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.name) throw new Error('name is required');
+  const encodedName = encodeSapObjectName(config.name.toLowerCase());
+  const url = `/sap/bc/adt/ddic/ddlx/sources/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `metadata extension ${config.name}`);
+  }
+}
+
+export async function getMetadataExtensionVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/package/AdtPackage.ts
+++ b/src/core/package/AdtPackage.ts
@@ -27,10 +27,12 @@ import type {
   IAdtObject,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IReadOptions } from '../shared/types';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { checkPackage } from './check';
 import { createPackage } from './create';
 import { checkPackageDeletion, deletePackage } from './delete';
@@ -40,7 +42,6 @@ import type { IPackageConfig, IPackageState } from './types';
 import { unlockPackage } from './unlock';
 import { updatePackage } from './update';
 import { validatePackageBasic } from './validation';
-
 export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
@@ -603,5 +604,15 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
       unlockResult: result,
       errors: [],
     };
+  }
+
+  async getVersions(
+    _config: Partial<IPackageConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('package');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('package');
   }
 }

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -44,6 +44,7 @@ import { unlockProgram } from './unlock';
 import { uploadProgramSource } from './update';
 import { validateProgramName } from './validation';
 
+import { getProgramVersionSource, getProgramVersions } from './versions';
 export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
@@ -642,5 +643,13 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IProgramConfig>) {
+    return getProgramVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getProgramVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/program/versions.ts
+++ b/src/core/program/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IProgramConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getProgramVersions(
+  connection: IAbapConnection,
+  config: Partial<IProgramConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.programName) throw new Error('programName is required');
+  const encodedName = encodeSapObjectName(config.programName);
+  const url = `/sap/bc/adt/programs/programs/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `program ${config.programName}`);
+  }
+}
+
+export async function getProgramVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/scalarFunction/AdtScalarFunction.ts
+++ b/src/core/scalarFunction/AdtScalarFunction.ts
@@ -29,6 +29,10 @@ import { validateScalarFunctionName } from './validation';
 
 const VALIDATION_UNSUPPORTED_STATUSES = new Set([404, 405, 501]);
 
+import {
+  getScalarFunctionVersionSource,
+  getScalarFunctionVersions,
+} from './versions';
 export class AdtScalarFunction
   implements IAdtObject<IScalarFunctionConfig, IScalarFunctionState>
 {
@@ -375,5 +379,13 @@ export class AdtScalarFunction
     } finally {
       this.connection.setSessionType('stateless');
     }
+  }
+
+  getVersions(config: Partial<IScalarFunctionConfig>) {
+    return getScalarFunctionVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getScalarFunctionVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/scalarFunction/versions.ts
+++ b/src/core/scalarFunction/versions.ts
@@ -1,0 +1,48 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IScalarFunctionConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getScalarFunctionVersions(
+  connection: IAbapConnection,
+  config: Partial<IScalarFunctionConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.scalarFunctionName)
+    throw new Error('scalarFunctionName is required');
+  const encodedName = encodeSapObjectName(
+    config.scalarFunctionName.toLowerCase(),
+  );
+  const url = `/sap/bc/adt/ddic/dsfd/sources/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `scalar function ${config.scalarFunctionName}`);
+  }
+}
+
+export async function getScalarFunctionVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
+++ b/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
@@ -33,6 +33,10 @@ import { validateScalarFunctionImplementationName } from './validation';
 
 const VALIDATION_UNSUPPORTED_STATUSES = new Set([404, 405, 501]);
 
+import {
+  getScalarFunctionImplementationVersionSource,
+  getScalarFunctionImplementationVersions,
+} from './versions';
 export class AdtScalarFunctionImplementation
   implements
     IAdtObject<
@@ -398,5 +402,16 @@ export class AdtScalarFunctionImplementation
     } finally {
       this.connection.setSessionType('stateless');
     }
+  }
+
+  getVersions(config: Partial<IScalarFunctionImplementationConfig>) {
+    return getScalarFunctionImplementationVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getScalarFunctionImplementationVersionSource(
+      this.connection,
+      contentUri,
+    );
   }
 }

--- a/src/core/scalarFunctionImplementation/versions.ts
+++ b/src/core/scalarFunctionImplementation/versions.ts
@@ -1,0 +1,51 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IScalarFunctionImplementationConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getScalarFunctionImplementationVersions(
+  connection: IAbapConnection,
+  config: Partial<IScalarFunctionImplementationConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.implementationName)
+    throw new Error('implementationName is required');
+  const encodedName = encodeSapObjectName(
+    config.implementationName.toLowerCase(),
+  );
+  const url = `/sap/bc/adt/ddic/dsfi/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(
+      e,
+      `scalar function implementation ${config.implementationName}`,
+    );
+  }
+}
+
+export async function getScalarFunctionImplementationVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/service/AdtService.ts
+++ b/src/core/service/AdtService.ts
@@ -3,6 +3,7 @@ import type {
   IAdtOperationOptions,
   IAdtResponse,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import { XMLParser } from 'fast-xml-parser';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -18,6 +19,7 @@ import {
 import { buildQueryString } from '../../utils/internalUtils';
 import { getSystemInformation } from '../../utils/systemInfo';
 import { getTimeout } from '../../utils/timeouts';
+import { throwUnsupportedVersions } from '../shared/versions';
 import type {
   IActivateServiceBindingParams,
   IAdtServiceBinding,
@@ -38,7 +40,6 @@ import type {
   IValidateServiceBindingParams,
 } from './types';
 import { resolveBindingVariant } from './types';
-
 export class AdtServiceBinding implements IAdtServiceBinding {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
@@ -1070,6 +1071,16 @@ export class AdtServiceBinding implements IAdtServiceBinding {
         Accept: 'application/xml, application/json, text/plain',
       },
     });
+  }
+
+  async getVersions(
+    _config: Partial<IServiceBindingConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('service binding');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('service binding');
   }
 }
 

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -46,6 +46,10 @@ import { unlockServiceDefinition } from './unlock';
 import { updateServiceDefinition } from './update';
 import { validateServiceDefinitionName } from './validation';
 
+import {
+  getServiceDefinitionVersionSource,
+  getServiceDefinitionVersions,
+} from './versions';
 export class AdtServiceDefinition
   implements IAdtObject<IServiceDefinitionConfig, IServiceDefinitionState>
 {
@@ -607,5 +611,13 @@ export class AdtServiceDefinition
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IServiceDefinitionConfig>) {
+    return getServiceDefinitionVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getServiceDefinitionVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/serviceDefinition/versions.ts
+++ b/src/core/serviceDefinition/versions.ts
@@ -1,0 +1,48 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IServiceDefinitionConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getServiceDefinitionVersions(
+  connection: IAbapConnection,
+  config: Partial<IServiceDefinitionConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.serviceDefinitionName)
+    throw new Error('serviceDefinitionName is required');
+  const encodedName = encodeSapObjectName(
+    config.serviceDefinitionName.toLowerCase(),
+  );
+  const url = `/sap/bc/adt/ddic/srvd/sources/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `service definition ${config.serviceDefinitionName}`);
+  }
+}
+
+export async function getServiceDefinitionVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/shared/versions.ts
+++ b/src/core/shared/versions.ts
@@ -1,0 +1,70 @@
+import {
+  AdtObjectErrorCodes,
+  AdtOperationError,
+  type IObjectVersion,
+} from '@mcp-abap-adt/interfaces';
+import { XMLParser } from 'fast-xml-parser';
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  parseAttributeValue: false,
+  parseTagValue: false,
+});
+
+/** Parse an ADT versions Atom feed into a list of versions. Pure — no endpoints. */
+export function parseVersionsFeed(xml: string): IObjectVersion[] {
+  const root = parser.parse(xml) as Record<string, any>;
+  const feed = root['atom:feed'] ?? root.feed;
+  if (!feed) return [];
+  const title = feed['atom:title'] ?? feed.title;
+  const rawEntries = feed['atom:entry'] ?? feed.entry;
+  const entries = Array.isArray(rawEntries)
+    ? rawEntries
+    : rawEntries
+      ? [rawEntries]
+      : [];
+  return entries.map((e: Record<string, any>) => {
+    const content = e['atom:content'] ?? e.content ?? {};
+    const author = e['atom:author'] ?? e.author;
+    return {
+      versionId: String(e['atom:id'] ?? e.id ?? ''),
+      author: author
+        ? String(author['atom:name'] ?? author.name ?? '') || undefined
+        : undefined,
+      updatedAt:
+        (e['atom:updated'] ?? e.updated)
+          ? String(e['atom:updated'] ?? e.updated)
+          : undefined,
+      title: title ? String(title) : undefined,
+      contentUri: String(content['@_src'] ?? ''),
+    };
+  });
+}
+
+/** Throw a typed "no version history" error. Used by non-source types and by
+ *  source types when SAP reports the versions resource is absent (404/406). */
+export function throwUnsupportedVersions(detail?: string): never {
+  const e = new AdtOperationError(
+    `Version history is not available${detail ? ` for ${detail}` : ''}`,
+  );
+  e.code = AdtObjectErrorCodes.UNSUPPORTED_OPERATION;
+  throw e;
+}
+
+/** Translate ANY version-request failure into an interface-level error so no
+ *  raw IAdtResponse/axios object ever leaks outward. 404/406 → unsupported;
+ *  everything else → AdtOperationError carrying status + originalError.
+ *  Call this from the catch of every version list/content GET. */
+export function throwVersionsError(error: unknown, detail: string): never {
+  const status = (error as any)?.response?.status ?? (error as any)?.status;
+  if (status === 404 || status === 406) {
+    throwUnsupportedVersions(detail);
+  }
+  const e = new AdtOperationError(
+    `Failed to read version history for ${detail}`,
+  );
+  if (typeof status === 'number') e.status = status;
+  e.originalError = error;
+  throw e;
+}

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -43,6 +43,7 @@ import { unlockStructure } from './unlock';
 import { upload } from './update';
 import { validateStructureName } from './validation';
 
+import { getStructureVersionSource, getStructureVersions } from './versions';
 export class AdtStructure
   implements IAdtObject<IStructureConfig, IStructureState>
 {
@@ -598,5 +599,13 @@ export class AdtStructure
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<IStructureConfig>) {
+    return getStructureVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getStructureVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/structure/versions.ts
+++ b/src/core/structure/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { IStructureConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getStructureVersions(
+  connection: IAbapConnection,
+  config: Partial<IStructureConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.structureName) throw new Error('structureName is required');
+  const encodedName = encodeSapObjectName(config.structureName);
+  const url = `/sap/bc/adt/ddic/structures/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `structure ${config.structureName}`);
+  }
+}
+
+export async function getStructureVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -38,6 +38,7 @@ import type { ITableConfig, ITableState } from './types';
 import { unlockTable } from './unlock';
 import { updateTable } from './update';
 import { validateTableName } from './validation';
+import { getTableVersionSource, getTableVersions } from './versions';
 
 export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
   private readonly connection: IAbapConnection;
@@ -560,5 +561,13 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<ITableConfig>) {
+    return getTableVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getTableVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/table/versions.ts
+++ b/src/core/table/versions.ts
@@ -1,0 +1,43 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { ITableConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+export async function getTableVersions(
+  connection: IAbapConnection,
+  config: Partial<ITableConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.tableName) throw new Error('tableName is required');
+  const url = `/sap/bc/adt/ddic/tables/${encodeSapObjectName(config.tableName)}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `table ${config.tableName}`);
+  }
+}
+
+export async function getTableVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/tabletype/AdtDdicTableType.ts
+++ b/src/core/tabletype/AdtDdicTableType.ts
@@ -39,6 +39,7 @@ import { unlockTableType } from './unlock';
 import { updateTableType } from './update';
 import { validateTableTypeName } from './validation';
 
+import { getTableTypeVersionSource, getTableTypeVersions } from './versions';
 export class AdtDdicTableType
   implements IAdtObject<ITableTypeConfig, ITableTypeState>
 {
@@ -607,5 +608,13 @@ export class AdtDdicTableType
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<ITableTypeConfig>) {
+    return getTableTypeVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getTableTypeVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/tabletype/versions.ts
+++ b/src/core/tabletype/versions.ts
@@ -1,0 +1,45 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { ITableTypeConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getTableTypeVersions(
+  connection: IAbapConnection,
+  config: Partial<ITableTypeConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.tableTypeName) throw new Error('tableTypeName is required');
+  const encodedName = encodeSapObjectName(config.tableTypeName);
+  const url = `/sap/bc/adt/ddic/tabletypes/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `table type ${config.tableTypeName}`);
+  }
+}
+
+export async function getTableTypeVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -43,6 +43,10 @@ import { unlockTransformation } from './unlock';
 import { updateTransformation } from './update';
 import { validateTransformationName } from './validation';
 
+import {
+  getTransformationVersionSource,
+  getTransformationVersions,
+} from './versions';
 export class AdtTransformation
   implements IAdtObject<ITransformationConfig, ITransformationState>
 {
@@ -607,5 +611,13 @@ export class AdtTransformation
       unlockResult: result,
       errors: [],
     };
+  }
+
+  getVersions(config: Partial<ITransformationConfig>) {
+    return getTransformationVersions(this.connection, config);
+  }
+
+  getVersionSource(contentUri: string) {
+    return getTransformationVersionSource(this.connection, contentUri);
   }
 }

--- a/src/core/transformation/versions.ts
+++ b/src/core/transformation/versions.ts
@@ -1,0 +1,48 @@
+import type { IAbapConnection, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+import { parseVersionsFeed, throwVersionsError } from '../shared/versions';
+import type { ITransformationConfig } from './types';
+
+const ACCEPT_VERSION_FEED = 'application/atom+xml;type=feed';
+
+// candidate URI — probe-verify on trial
+export async function getTransformationVersions(
+  connection: IAbapConnection,
+  config: Partial<ITransformationConfig>,
+): Promise<IObjectVersion[]> {
+  if (!config.transformationName)
+    throw new Error('transformationName is required');
+  const encodedName = encodeSapObjectName(
+    config.transformationName.toLowerCase(),
+  );
+  const url = `/sap/bc/adt/xslt/transformations/${encodedName}/source/main/versions`;
+  try {
+    const res = await connection.makeAdtRequest({
+      url,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: ACCEPT_VERSION_FEED },
+    });
+    return parseVersionsFeed(String(res.data));
+  } catch (e) {
+    throwVersionsError(e, `transformation ${config.transformationName}`);
+  }
+}
+
+export async function getTransformationVersionSource(
+  connection: IAbapConnection,
+  contentUri: string,
+): Promise<string> {
+  try {
+    const res = await connection.makeAdtRequest({
+      url: contentUri,
+      method: 'GET',
+      timeout: getTimeout('default'),
+      headers: { Accept: 'text/plain' },
+    });
+    return String(res.data);
+  } catch (e) {
+    throwVersionsError(e, 'version content');
+  }
+}

--- a/src/core/transport/AdtRequest.ts
+++ b/src/core/transport/AdtRequest.ts
@@ -25,14 +25,15 @@ import type {
   IAdtObject,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { createTransport } from './create';
 import { listTransports } from './list';
 import { getTransport } from './read';
 import type { ITransportConfig, ITransportState } from './types';
-
 export class AdtRequest
   implements IAdtObject<ITransportConfig, ITransportState>
 {
@@ -254,5 +255,15 @@ export class AdtRequest
     _lockHandle: string,
   ): Promise<ITransportState> {
     throw new Error('Unlock operation is not supported for transport requests');
+  }
+
+  async getVersions(
+    _config: Partial<ITransportConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('transport request');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('transport request');
   }
 }

--- a/src/core/unitTest/AdtUnitTest.ts
+++ b/src/core/unitTest/AdtUnitTest.ts
@@ -26,6 +26,7 @@ import type {
   IAdtObject,
   IAdtOperationOptions,
   ILogger,
+  IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
 import {
   headerValueToString,
@@ -33,6 +34,7 @@ import {
 } from '../../utils/internalUtils';
 import { AdtClass, AdtLocalTestClass } from '../class';
 import { getClassUnitTestResult, getClassUnitTestStatus } from '../class/run';
+import { throwUnsupportedVersions } from '../shared/versions';
 import { startClassUnitTestRun } from './run';
 import type {
   IClassUnitTestDefinition,
@@ -40,7 +42,6 @@ import type {
   IUnitTestConfig,
   IUnitTestState,
 } from './types';
-
 export class AdtUnitTest
   implements IAdtObject<IUnitTestConfig, IUnitTestState>
 {
@@ -406,5 +407,15 @@ export class AdtUnitTest
     _lockHandle: string,
   ): Promise<IUnitTestState> {
     throw new Error('Unlock operation is not supported for unit tests');
+  }
+
+  async getVersions(
+    _config: Partial<IUnitTestConfig>,
+  ): Promise<IObjectVersion[]> {
+    throwUnsupportedVersions('unit test');
+  }
+
+  async getVersionSource(_contentUri: string): Promise<string> {
+    throwUnsupportedVersions('unit test');
   }
 }


### PR DESCRIPTION
Implements **object version history** across every `IAdtObject` handler, per `docs/superpowers/specs/2026-06-28-object-version-history-design.md` + plan.

## What
- Every object handler implements `getVersions(config)` (list SAP version history → `IObjectVersion[]`) and `getVersionSource(contentUri)` (fetch a version's source).
- **Each handler owns its own version endpoint** (single point of responsibility): source types GET `<sourceUri>/versions` (classes → `/includes/{type}/versions`) as an Atom feed; the shared, zero-endpoint helpers are only `parseVersionsFeed`, `throwUnsupportedVersions`, `throwVersionsError`.
- **Full encapsulation:** 404/406 → `AdtOperationError(UNSUPPORTED_OPERATION)`; any other failure → `AdtOperationError(status, originalError)`. No raw `IAdtResponse`/axios ever leaks outward.
- Non-source types (package, transport, …) throw `UNSUPPORTED_OPERATION` (no HTTP).

## Verification
- Trial-verified end-to-end (`getVersions` + `getVersionSource`): **table, class, interface, serviceDefinition** (integration test, self-skips without `.env`).
- `ddl`/`accessControl`: object source 200 but `/versions` 404 on the cloud trial — kept as candidate (a cloud 404 is not universal; safely degrades to `UNSUPPORTED_OPERATION`).
- Other source types (program, functionModule, structure, behaviorDefinition, …): candidate URLs, probe-pending on systems that support them; safe degrade.
- `npm run build` clean; unit suite **266/53**; `test:check:integration` clean.

## Breaking
- **7.0.0 (major).** Requires `@mcp-abap-adt/interfaces@^9.0.0` (the contract that adds the two required `IAdtObject` methods + `IObjectVersion` + `UNSUPPORTED_OPERATION`). interfaces 9.0.0 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)