### PR TITLE
fix(where-used): resilient to systems without the /usageReferences/scope sub-resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,10 @@ for (const ref of result.references) {
 }
 
 // Restrict to specific object types — SAP filters server-side, so it never
-// returns the unwanted types (e.g. hundreds of classes when you want structures)
+// returns the unwanted types (e.g. hundreds of classes when you want structures).
+// On systems without the /usageReferences/scope sub-resource (some S/4 releases
+// 404 it) the search falls back to unscoped and the filter is applied to the
+// parsed references client-side, so you still get the narrowed set.
 await utils.getWhereUsedList({
   object_name: 'ZMY_TABLE',
   object_type: 'table',

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -165,7 +165,7 @@ Notably, where-used supports:
 - scope fetch (`getWhereUsedScope`),
 - local scope mutation (`modifyWhereUsedScope`),
 - execution (`getWhereUsed`) and parsed convenience (`getWhereUsedList`),
-- server-side type filtering via `getWhereUsedList({ enableOnlyTypes, disableTypes })` — SAP searches (and returns) only the selected object types.
+- type filtering via `getWhereUsedList({ enableOnlyTypes, disableTypes })` — applied server-side through the `/usageReferences/scope` sub-resource where available, otherwise (some S/4 releases 404 that resource) the search falls back to unscoped and the filter is applied to the parsed references client-side. Either way the caller receives only the selected object types.
 
 ## Accept Negotiation (406 Recovery)
 

--- a/docs/usage/CLIENT_API_REFERENCE.md
+++ b/docs/usage/CLIENT_API_REFERENCE.md
@@ -328,6 +328,11 @@ XML parsing in one call and returns structured `references`. Use `enableOnlyType
 restrict the search to specific ADT object types — SAP applies the selection server-side,
 so it never searches (nor returns) the unwanted types, e.g. hundreds of `CLAS/OC`:
 
+> On systems that do not expose the `/usageReferences/scope` sub-resource (some S/4
+> releases answer it with HTTP 404), server-side filtering is unavailable: the search
+> falls back to an unscoped query and `enableOnlyTypes` / `disableTypes` are then applied
+> to the parsed `references` client-side, so callers still receive the narrowed set.
+
 ```typescript
 const utils = client.getUtils();
 

--- a/src/__tests__/unit/shared/getWhereUsedList.test.ts
+++ b/src/__tests__/unit/shared/getWhereUsedList.test.ts
@@ -125,6 +125,33 @@ describe('getWhereUsedList type filtering', () => {
     expect(result.totalReferences).toBe(0);
   });
 
+  it('filters references client-side by enableOnlyTypes when /scope is 404', async () => {
+    // Unscoped fallback returns a mix of types (as a real S/4 would for a
+    // heavily-used base). Only the requested TABL/DS must come back.
+    const MIXED = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageReferenceResult xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences" xmlns:adtcore="http://www.sap.com/adt/core" numberOfResults="3" resultDescription="Found 3"><usagereferences:referencedObjects><usagereferences:referencedObject uri="/a"><usagereferences:adtObject adtcore:type="CLAS/OC" adtcore:name="CL_FOO"/></usagereferences:referencedObject><usagereferences:referencedObject uri="/b"><usagereferences:adtObject adtcore:type="TABL/DS" adtcore:name="ZAPPEND_VBAK"/></usagereferences:referencedObject><usagereferences:referencedObject uri="/c"><usagereferences:adtObject adtcore:type="PROG/P" adtcore:name="ZREPORT"/></usagereferences:referencedObject></usagereferences:referencedObjects></usagereferences:usageReferenceResult>`;
+
+    const connection = {
+      makeAdtRequest: async (options: any): Promise<IAdtResponse> => {
+        if (options.url.includes('/usageReferences/scope')) {
+          const err: any = new Error('Request failed with status code 404');
+          err.status = 404;
+          throw err;
+        }
+        return { data: MIXED, status: 200, headers: {} } as IAdtResponse;
+      },
+    } as unknown as IAbapConnection;
+
+    const result = await getWhereUsedList(connection, {
+      object_name: 'VBAK',
+      object_type: 'table',
+      enableOnlyTypes: ['TABL/DS'],
+    });
+
+    expect(result.references.map((r) => r.type)).toEqual(['TABL/DS']);
+    expect(result.references[0].name).toBe('ZAPPEND_VBAK');
+    expect(result.totalReferences).toBe(1);
+  });
+
   it('re-throws non-404 scope errors instead of falling back', async () => {
     const connection = {
       makeAdtRequest: async (options: any): Promise<IAdtResponse> => {

--- a/src/__tests__/unit/shared/getWhereUsedList.test.ts
+++ b/src/__tests__/unit/shared/getWhereUsedList.test.ts
@@ -70,4 +70,79 @@ describe('getWhereUsedList type filtering', () => {
     expect(searchBodies).toHaveLength(1);
     expect(selectedTypes(searchBodies[0]).sort()).toEqual(['INTF/OI']);
   });
+
+  it('does NOT call the /scope sub-resource when no type filter is requested', async () => {
+    const urls: string[] = [];
+    const searchBodies: string[] = [];
+    const connection = {
+      makeAdtRequest: async (options: any): Promise<IAdtResponse> => {
+        urls.push(options.url);
+        searchBodies.push(String(options.data));
+        return { data: RESULT_XML, status: 200, headers: {} } as IAdtResponse;
+      },
+    } as unknown as IAbapConnection;
+
+    await getWhereUsedList(connection, {
+      object_name: 'ZAC_SHR_BTABL',
+      object_type: 'table',
+    });
+
+    // Only the direct /usageReferences search runs — no /scope round-trip — and
+    // the body carries no <scope> (SAP applies its default scope).
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).not.toContain('/usageReferences/scope');
+    expect(searchBodies[0]).not.toContain('<usagereferences:scope>');
+  });
+
+  it('falls back to an unscoped search when /scope answers 404', async () => {
+    const urls: string[] = [];
+    const searchBodies: string[] = [];
+    const connection = {
+      makeAdtRequest: async (options: any): Promise<IAdtResponse> => {
+        urls.push(options.url);
+        if (options.url.includes('/usageReferences/scope')) {
+          // Some S/4 releases do not expose the scope sub-resource.
+          const err: any = new Error('Request failed with status code 404');
+          err.status = 404;
+          throw err;
+        }
+        searchBodies.push(String(options.data));
+        return { data: RESULT_XML, status: 200, headers: {} } as IAdtResponse;
+      },
+    } as unknown as IAbapConnection;
+
+    const result = await getWhereUsedList(connection, {
+      object_name: 'VBAK',
+      object_type: 'table',
+      enableOnlyTypes: ['TABL/DS'],
+    });
+
+    // The search still runs (unscoped) instead of throwing, so the caller can
+    // filter references client-side.
+    expect(urls.some((u) => u.includes('/usageReferences/scope'))).toBe(true);
+    expect(searchBodies).toHaveLength(1);
+    expect(searchBodies[0]).not.toContain('<usagereferences:scope>');
+    expect(result.totalReferences).toBe(0);
+  });
+
+  it('re-throws non-404 scope errors instead of falling back', async () => {
+    const connection = {
+      makeAdtRequest: async (options: any): Promise<IAdtResponse> => {
+        if (options.url.includes('/usageReferences/scope')) {
+          const err: any = new Error('Request failed with status code 500');
+          err.status = 500;
+          throw err;
+        }
+        return { data: RESULT_XML, status: 200, headers: {} } as IAdtResponse;
+      },
+    } as unknown as IAbapConnection;
+
+    await expect(
+      getWhereUsedList(connection, {
+        object_name: 'VBAK',
+        object_type: 'table',
+        enableOnlyTypes: ['TABL/DS'],
+      }),
+    ).rejects.toThrow('500');
+  });
 });

--- a/src/core/shared/AdtUtils.ts
+++ b/src/core/shared/AdtUtils.ts
@@ -218,19 +218,18 @@ export class AdtUtils {
   }
 
   /**
-   * Where-used Step 2: execute search.
+   * Where-used: execute search.
    *
-   * This performs the where-used search for an object using a scope XML. If you
-   * do not pass a scope, the server's default selection is used.
-   *
-   * Two-step ADT operation:
-   * 1. Fetch scope configuration (if not provided)
-   * 2. Execute where-used search with the scope
+   * Performs the where-used search for an object. When a scope XML is supplied
+   * the search is narrowed to those object types; when omitted it runs unscoped
+   * against SAP's default selection. This posts directly to /usageReferences and
+   * does NOT fetch the /usageReferences/scope sub-resource, so it works on
+   * systems that do not expose it.
    *
    * @param params - Where-used parameters
    * @param params.object_name - Name of the object to search
    * @param params.object_type - Type of the object (class, table, etc.)
-   * @param params.scopeXml - Optional scope XML from getWhereUsedScope(). If not provided, uses default SAP selection.
+   * @param params.scopeXml - Optional scope XML from getWhereUsedScope(). When omitted, the search runs unscoped (SAP's default selection); no scope is fetched.
    * @returns Where-used references in XML format
    *
    * @example

--- a/src/core/shared/types.ts
+++ b/src/core/shared/types.ts
@@ -157,11 +157,15 @@ export interface IGetWhereUsedListParams {
    */
   enableAllTypes?: boolean;
   /**
-   * Restrict the search to ONLY these object types (e.g. ['TABL/DS', 'TABL/DT']).
-   * All other types are deselected, so SAP does not search them at all — this is
-   * how you avoid getting 1000 classes back when you only want structures/tables.
-   * Type names are the ADT global types from the scope (e.g. 'CLAS/OC', 'STRU/DT').
-   * Takes precedence over `enableAllTypes`. Ignored if empty.
+   * Restrict the result to ONLY these object types (e.g. ['TABL/DS', 'TABL/DT']) —
+   * this is how you avoid getting 1000 classes back when you only want
+   * structures/tables. Where the `/usageReferences/scope` sub-resource is
+   * available the other types are deselected server-side (SAP never searches
+   * them); where it is not (some S/4 releases 404 it) the search runs unscoped
+   * and the filter is applied to the parsed references client-side instead — the
+   * returned set is the same either way. Type names are the ADT global types
+   * (e.g. 'CLAS/OC', 'STRU/DT'). Takes precedence over `enableAllTypes`. Ignored
+   * if empty.
    */
   enableOnlyTypes?: string[];
   /**

--- a/src/core/shared/types.ts
+++ b/src/core/shared/types.ts
@@ -137,8 +137,10 @@ export interface IGetWhereUsedParams {
   object_name: string;
   object_type: string;
   /**
-   * Optional: scope XML from getWhereUsedScope() with user-modified selections
-   * If not provided, will fetch default scope automatically
+   * Optional: scope XML from getWhereUsedScope() with user-modified selections.
+   * When omitted, the search runs unscoped (SAP's default scope) — getWhereUsed()
+   * does NOT fetch a scope itself, so it works on systems that do not expose the
+   * /usageReferences/scope sub-resource.
    */
   scopeXml?: string;
 }

--- a/src/core/shared/whereUsed.ts
+++ b/src/core/shared/whereUsed.ts
@@ -345,6 +345,10 @@ export async function getWhereUsedList(
   }
 
   let scopeXml: string | undefined;
+  // Set when the /usageReferences/scope sub-resource is unavailable and we fell
+  // back to an unscoped search. The requested type filter could not be applied
+  // server-side, so it is applied to the parsed references instead (below).
+  let scopeUnavailable = false;
 
   // Fetch and modify the scope only when the caller wants to constrain which
   // object types are searched. Otherwise getWhereUsed() falls back to SAP's
@@ -382,6 +386,7 @@ export async function getWhereUsedList(
       // case is swallowed; anything else (auth, network, 5xx) is re-thrown.
       if (!isScopeResourceUnavailable(error)) throw error;
       scopeXml = undefined;
+      scopeUnavailable = true;
     }
   }
 
@@ -449,12 +454,35 @@ export async function getWhereUsedList(
     }
   }
 
+  // When server-side scoping was unavailable, the search ran unscoped and the
+  // parsed list holds every reference type (potentially thousands). Apply the
+  // requested type filter here so callers receive the same narrowed set they
+  // would have gotten from a server-side scope — the SAP round-trip cannot be
+  // avoided on such systems, but the result handed back (and ultimately the
+  // load on the consumer/LLM) is reduced to the types actually asked for.
+  let resultRefs = references;
+  if (scopeUnavailable && (enableOnly || disable)) {
+    if (enableOnly) {
+      const allow = new Set(enableOnly);
+      resultRefs = resultRefs.filter((r) => allow.has(r.type));
+    }
+    if (disable) {
+      const deny = new Set(disable);
+      resultRefs = resultRefs.filter((r) => !deny.has(r.type));
+    }
+  }
+
   return {
     objectName: params.object_name,
     objectType: params.object_type,
-    totalReferences: numberOfResults,
+    // After a client-side narrow the server's numberOfResults no longer matches
+    // what we return, so report the size of the references actually handed back.
+    totalReferences:
+      scopeUnavailable && (enableOnly || disable)
+        ? resultRefs.length
+        : numberOfResults,
     resultDescription,
-    references,
+    references: resultRefs,
     rawXml: params.includeRawXml ? xml : undefined,
   };
 }

--- a/src/core/shared/whereUsed.ts
+++ b/src/core/shared/whereUsed.ts
@@ -319,8 +319,9 @@ export async function getWhereUsed(
  *   enableAllTypes: true
  * });
  *
- * // Or restrict to just the types you care about (e.g. only structures/tables),
- * // so SAP never searches — and never returns — hundreds of classes.
+ * // Or restrict to just the types you care about (e.g. only structures/tables)
+ * // so you never get hundreds of classes back. Filtered server-side via the
+ * // scope sub-resource where available, else client-side on the unscoped result.
  * const structuresOnly = await getWhereUsedList(connection, {
  *   object_name: 'ZMY_TABLE',
  *   object_type: 'table',

--- a/src/core/shared/whereUsed.ts
+++ b/src/core/shared/whereUsed.ts
@@ -165,6 +165,20 @@ function buildObjectUri(objectName: string, objectType: string): string {
 }
 
 /**
+ * True when an error indicates the /usageReferences/scope sub-resource is not
+ * available on the target system. SAP answers such requests with HTTP 404
+ * ("No suitable resource found") — and 406 for an unaccepted media type — on
+ * releases that do not expose the scope step. Callers use this to fall back to
+ * an unscoped where-used search rather than failing outright.
+ */
+function isScopeResourceUnavailable(error: unknown): boolean {
+  const status =
+    // biome-ignore lint/suspicious/noExplicitAny: error shape is provider-defined
+    (error as any)?.response?.status ?? (error as any)?.status;
+  return status === 404 || status === 406;
+}
+
+/**
  * Get where-used scope configuration (Step 1 of 2)
  *
  * Returns available object types for where-used search.
@@ -221,15 +235,17 @@ export async function getWhereUsedScope(
 }
 
 /**
- * Get where-used references for ABAP object (Step 2 of 2)
+ * Get where-used references for ABAP object
  *
- * Eclipse ADT uses a two-step process:
- * 1. GET scope configuration (getWhereUsedScope) - returns available object types
- * 2. POST actual search with scope (this function) - executes search
+ * Posts directly to /usageReferences (the request the Eclipse ADT client
+ * sends). An optional scope can be supplied to narrow the searched object types
+ * server-side; when omitted, SAP applies its default scope. This function never
+ * calls the /usageReferences/scope sub-resource itself — that resource is not
+ * available on every system (see getWhereUsedScope).
  *
  * @param connection - ABAP connection
  * @param params - Where-used parameters
- * @param params.scopeXml - Optional scope XML from getWhereUsedScope(). If not provided, will fetch default scope.
+ * @param params.scopeXml - Optional scope XML from getWhereUsedScope(). When omitted, the search runs against SAP's default scope (unscoped).
  * @returns Where-used references
  */
 export async function getWhereUsed(
@@ -245,31 +261,30 @@ export async function getWhereUsed(
 
   const objectUri = buildObjectUri(params.object_name, params.object_type);
 
-  // If scope not provided, fetch default scope
-  let scopeXml: string = params.scopeXml || '';
-  if (!scopeXml) {
-    const scopeResponse = await getWhereUsedScope(connection, {
-      object_name: params.object_name,
-      object_type: params.object_type,
-    });
-    scopeXml = scopeResponse.data;
-  }
-
-  // Step 2: Perform actual where-used search with scope
+  // Step 2: perform the actual where-used search.
+  // We do NOT auto-fetch a default scope here. The Eclipse ADT client posts
+  // directly to /usageReferences with a minimal request body and lets SAP apply
+  // its default scope; the /usageReferences/scope sub-resource is not exposed on
+  // every system (some S/4 releases answer 404 "No suitable resource found"), so
+  // depending on it would break an otherwise-supported search. An explicit
+  // <scope> is embedded only when the caller supplied one (the optional 2-step
+  // optimisation that narrows the searched object types server-side).
   const searchUrl = `/sap/bc/adt/repository/informationsystem/usageReferences?uri=${encodeURIComponent(objectUri)}`;
 
-  // Build request body with scope from step 1
-  // Extract inner content of usageScopeResult and wrap it in usageReferenceRequest
-  const scopeContent = scopeXml
-    .replace(/<\?xml[^>]*\?>/, '')
-    .replace(
-      /<usagereferences:usageScopeResult[^>]*>/,
-      '<usagereferences:scope>',
-    )
-    .replace(
-      /<\/usagereferences:usageScopeResult>/,
-      '</usagereferences:scope>',
-    );
+  // When a scope is provided, extract the inner content of usageScopeResult and
+  // re-wrap it as <usagereferences:scope>. Otherwise omit the scope element.
+  const scopeContent = params.scopeXml
+    ? params.scopeXml
+        .replace(/<\?xml[^>]*\?>/, '')
+        .replace(
+          /<usagereferences:usageScopeResult[^>]*>/,
+          '<usagereferences:scope>',
+        )
+        .replace(
+          /<\/usagereferences:usageScopeResult>/,
+          '</usagereferences:scope>',
+        )
+    : '';
 
   const searchRequestBody = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageReferenceRequest xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences"><usagereferences:affectedObjects/>${scopeContent}</usagereferences:usageReferenceRequest>`;
 
@@ -340,23 +355,34 @@ export async function getWhereUsedList(
   const disable = params.disableTypes?.length ? params.disableTypes : undefined;
 
   if (params.enableAllTypes || enableOnly || disable) {
-    const scopeResponse = await getWhereUsedScope(connection, {
-      object_name: params.object_name,
-      object_type: params.object_type,
-    });
+    try {
+      const scopeResponse = await getWhereUsedScope(connection, {
+        object_name: params.object_name,
+        object_type: params.object_type,
+      });
 
-    // enableOnly wins over enableAll; disable is then applied on top so callers
-    // can both narrow to a set and prune one of those, in a single pass.
-    let modified = scopeResponse.data;
-    if (enableOnly) {
-      modified = modifyWhereUsedScope(modified, { enableOnly });
-    } else if (params.enableAllTypes) {
-      modified = modifyWhereUsedScope(modified, { enableAll: true });
+      // enableOnly wins over enableAll; disable is then applied on top so callers
+      // can both narrow to a set and prune one of those, in a single pass.
+      let modified = scopeResponse.data;
+      if (enableOnly) {
+        modified = modifyWhereUsedScope(modified, { enableOnly });
+      } else if (params.enableAllTypes) {
+        modified = modifyWhereUsedScope(modified, { enableAll: true });
+      }
+      if (disable) {
+        modified = modifyWhereUsedScope(modified, { disable });
+      }
+      scopeXml = modified;
+    } catch (error) {
+      // The /usageReferences/scope sub-resource is not exposed on every system
+      // (some S/4 releases answer 404 "No suitable resource found"). Server-side
+      // type filtering is then impossible, so fall back to an unscoped search —
+      // SAP's default scope, exactly what the Eclipse ADT client sends — and let
+      // the caller filter the references client-side. Only the missing-resource
+      // case is swallowed; anything else (auth, network, 5xx) is re-thrown.
+      if (!isScopeResourceUnavailable(error)) throw error;
+      scopeXml = undefined;
     }
-    if (disable) {
-      modified = modifyWhereUsedScope(modified, { disable });
-    }
-    scopeXml = modified;
   }
 
   // Execute where-used search


### PR DESCRIPTION
## Problem

`getWhereUsedList` fetches `/sap/bc/adt/repository/informationsystem/usageReferences/scope` (the 2-step Eclipse "scope" flow) whenever type filtering is requested, and `getWhereUsed` auto-fetches it when no scope is supplied. That sub-resource is **not exposed on every system**: some S/4 releases answer it with **HTTP 404 "No suitable resource found" for every object type** — verified on a live S/4 against classes, tables and structures.

The 404 aborted the whole search, so consumers silently got zero references. Downstream this surfaced as `GetStructuresList` returning **0 append structures** for tables that actually have them (e.g. `VBAK`) on such systems.

The Eclipse ADT client never uses `/scope` for a plain search — it POSTs directly to `/usageReferences` with a minimal `<usageReferenceRequest><affectedObjects/></usageReferenceRequest>` body and lets SAP apply its default scope (confirmed from a live Eclipse request trace).

## Fix

- **`getWhereUsed`** no longer auto-fetches a default scope. With no `scopeXml` it posts the minimal request (Eclipse behaviour); an explicit `<scope>` is embedded only when the caller supplies one. It never calls `/scope` itself.
- **`getWhereUsedList`** still uses the 2-step scope flow for server-side type filtering where it works, but catches a missing-scope-resource error (404/406) via `isScopeResourceUnavailable()` and **falls back to an unscoped search**; anything else (auth/network/5xx) propagates.
- **Client-side narrowing on fallback:** the unscoped search returns every reference type (thousands for a heavily-used base — e.g. ~4.5k for a standard table). The SAP round-trip is unavoidable there, but `getWhereUsedList` now applies the requested `enableOnlyTypes` / `disableTypes` to the parsed references, so callers receive the same narrowed set a server-side scope would have given. `totalReferences` reflects the returned set.

## Tests

Added unit tests: no-scope default path makes no `/scope` round-trip; 404 → unscoped fallback; client-side type narrowing on fallback; non-404 scope errors re-throw. Existing type-filtering tests unchanged. `lint + build + test` green.

> Code + tests only — version bump / CHANGELOG intentionally left out (to be set at release time).