### PR TITLE
fix(where-used): parse result regardless of the namespace prefix (usagereferences vs usageReferences)

### DIFF
--- a/src/__tests__/unit/shared/getWhereUsedList.test.ts
+++ b/src/__tests__/unit/shared/getWhereUsedList.test.ts
@@ -152,6 +152,50 @@ describe('getWhereUsedList type filtering', () => {
     expect(result.totalReferences).toBe(1);
   });
 
+  // The namespace PREFIX bound to http://www.sap.com/adt/ris/usageReferences is
+  // system-dependent: some releases emit `usagereferences:` (lower-case), others
+  // `usageReferences:` (camel-case, observed live on an S/4 system). The parser
+  // must read references regardless of which alias the server chose.
+  const resultWith = (prefix: string) =>
+    `<?xml version="1.0" encoding="utf-8"?>` +
+    `<${prefix}:usageReferenceResult xmlns:${prefix}="http://www.sap.com/adt/ris/usageReferences" numberOfResults="2" resultDescription="References for: VBAK">` +
+    `<${prefix}:referencedObjects>` +
+    `<${prefix}:referencedObject uri="/a" parentUri="/p" isResult="false" usageInformation="gradeDirect">` +
+    `<${prefix}:adtObject adtcore:responsible="DEV" adtcore:name="ZAPPEND_VBAK" adtcore:type="TABL/DS" adtcore:description="d" xmlns:adtcore="http://www.sap.com/adt/core">` +
+    `<adtcore:packageRef adtcore:name="ZPKG"/></${prefix}:adtObject></${prefix}:referencedObject>` +
+    `<${prefix}:referencedObject uri="/b">` +
+    `<${prefix}:adtObject adtcore:name="CL_FOO" adtcore:type="CLAS/OC" xmlns:adtcore="http://www.sap.com/adt/core"/>` +
+    `</${prefix}:referencedObject></${prefix}:referencedObjects></${prefix}:usageReferenceResult>`;
+
+  for (const prefix of ['usagereferences', 'usageReferences']) {
+    it(`parses the result regardless of the "${prefix}:" namespace prefix`, async () => {
+      const connection = {
+        makeAdtRequest: async (): Promise<IAdtResponse> =>
+          ({
+            data: resultWith(prefix),
+            status: 200,
+            headers: {},
+          }) as IAdtResponse,
+      } as unknown as IAbapConnection;
+
+      const result = await getWhereUsedList(connection, {
+        object_name: 'VBAK',
+        object_type: 'table',
+      });
+
+      expect(result.totalReferences).toBe(2);
+      expect(result.references).toHaveLength(2);
+      const append = result.references.find((r) => r.type === 'TABL/DS');
+      expect(append?.name).toBe('ZAPPEND_VBAK');
+      expect(append?.packageName).toBe('ZPKG');
+      expect(append?.responsible).toBe('DEV');
+      expect(result.references.map((r) => r.type).sort()).toEqual([
+        'CLAS/OC',
+        'TABL/DS',
+      ]);
+    });
+  }
+
   it('re-throws non-404 scope errors instead of falling back', async () => {
     const connection = {
       makeAdtRequest: async (options: any): Promise<IAdtResponse> => {

--- a/src/__tests__/unit/shared/getWhereUsedList.test.ts
+++ b/src/__tests__/unit/shared/getWhereUsedList.test.ts
@@ -14,10 +14,10 @@ const SCOPE_XML = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageS
 
 const RESULT_XML = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageReferenceResult xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences" numberOfResults="0" resultDescription="Found 0"><usagereferences:referencedObjects/></usagereferences:usageReferenceResult>`;
 
-/** Type names selected in a search request body. */
+/** Type names selected in a search request body (prefix-agnostic). */
 function selectedTypes(xml: string): string[] {
   const selected: string[] = [];
-  for (const m of xml.matchAll(/<usagereferences:type\b[^>]*\/>/g)) {
+  for (const m of xml.matchAll(/<[A-Za-z][\w-]*:type\b[^>]*\/>/g)) {
     if (/isSelected="true"/.test(m[0])) {
       const name = m[0].match(/name="([^"]+)"/);
       if (name) selected.push(name[1]);
@@ -25,6 +25,13 @@ function selectedTypes(xml: string): string[] {
   }
   return selected;
 }
+
+/** Same scope payload as SCOPE_XML but bound under a camel-case prefix —
+ * mirrors the system-dependent `usageReferences:` alias seen live on S/4. */
+const SCOPE_XML_CAMEL = SCOPE_XML.replace(
+  /usagereferences/g,
+  'usageReferences',
+);
 
 function makeFakeConnection(): {
   connection: IAbapConnection;
@@ -69,6 +76,39 @@ describe('getWhereUsedList type filtering', () => {
 
     expect(searchBodies).toHaveLength(1);
     expect(selectedTypes(searchBodies[0]).sort()).toEqual(['INTF/OI']);
+  });
+
+  it('applies the type filter when the scope uses a camel-case prefix', async () => {
+    const searchBodies: string[] = [];
+    const connection = {
+      makeAdtRequest: async (options: any): Promise<IAdtResponse> => {
+        if (options.url.includes('/usageReferences/scope')) {
+          return {
+            data: SCOPE_XML_CAMEL,
+            status: 200,
+            headers: {},
+          } as IAdtResponse;
+        }
+        searchBodies.push(String(options.data));
+        return { data: RESULT_XML, status: 200, headers: {} } as IAdtResponse;
+      },
+    } as unknown as IAbapConnection;
+
+    await getWhereUsedList(connection, {
+      object_name: 'ZAC_SHR_BTABL',
+      object_type: 'table',
+      enableOnlyTypes: ['TABL/DS'],
+    });
+
+    expect(searchBodies).toHaveLength(1);
+    // The isSelected flip worked despite the camel-case prefix...
+    expect(selectedTypes(searchBodies[0]).sort()).toEqual(['TABL/DS']);
+    // ...and the re-wrapped <scope> stays namespace-bound (prefix + xmlns kept).
+    expect(searchBodies[0]).toContain('<usageReferences:scope');
+    expect(searchBodies[0]).toContain(
+      'xmlns:usageReferences="http://www.sap.com/adt/ris/usageReferences"',
+    );
+    expect(searchBodies[0]).not.toContain('usageScopeResult');
   });
 
   it('does NOT call the /scope sub-resource when no type filter is requested', async () => {

--- a/src/core/shared/whereUsed.ts
+++ b/src/core/shared/whereUsed.ts
@@ -75,12 +75,14 @@ export function modifyWhereUsedScope(
     disable?: string[];
   },
 ): string {
-  // Each available type is a self-closing <usagereferences:type .../> tag.
-  // We rewrite ONLY the isSelected attribute per tag and never touch the
-  // opaque <usagereferences:payload> blob or attribute ordering — SAP emits
-  // attributes as `isDefault isSelected name`, so logic must read `name`
-  // wherever it appears, not assume it precedes isSelected.
-  const typeTagRegex = /<usagereferences:type\b[^>]*?\/>/g;
+  // Each available type is a self-closing <ns:type .../> tag. The namespace
+  // PREFIX is system-dependent (usagereferences: vs usageReferences:), so match
+  // any prefix — hard-coding one made the rewrite a silent no-op on the other.
+  // We rewrite ONLY the isSelected attribute per tag and never touch the opaque
+  // <ns:payload> blob or attribute ordering — SAP emits attributes as
+  // `isDefault isSelected name`, so logic must read `name` wherever it appears,
+  // not assume it precedes isSelected.
+  const typeTagRegex = /<[A-Za-z][\w-]*:type\b[^>]*?\/>/g;
 
   return scopeXml.replace(typeTagRegex, (tag) => {
     const nameMatch = tag.match(/\bname="([^"]*)"/);
@@ -102,8 +104,9 @@ export function modifyWhereUsedScope(
 }
 
 /**
- * Set the isSelected attribute on a single <usagereferences:type> tag,
- * inserting it if absent. Leaves all other attributes and their order intact.
+ * Set the isSelected attribute on a single <ns:type> tag, inserting it if
+ * absent. Leaves all other attributes and their order intact. The namespace
+ * prefix is matched (and preserved) rather than hard-coded.
  */
 function setIsSelected(typeTag: string, selected: boolean): string {
   const value = selected ? 'true' : 'false';
@@ -114,8 +117,8 @@ function setIsSelected(typeTag: string, selected: boolean): string {
     );
   }
   return typeTag.replace(
-    /<usagereferences:type\b/,
-    `<usagereferences:type isSelected="${value}"`,
+    /<([A-Za-z][\w-]*:type)\b/,
+    `<$1 isSelected="${value}"`,
   );
 }
 
@@ -280,18 +283,15 @@ export async function getWhereUsed(
   const searchUrl = `/sap/bc/adt/repository/informationsystem/usageReferences?uri=${encodeURIComponent(objectUri)}`;
 
   // When a scope is provided, extract the inner content of usageScopeResult and
-  // re-wrap it as <usagereferences:scope>. Otherwise omit the scope element.
+  // re-wrap it as <ns:scope>. The namespace prefix is system-dependent
+  // (usagereferences: vs usageReferences:), so capture and reuse it, and KEEP the
+  // open tag's attributes ($2, i.e. the xmlns declaration) on <scope> so the
+  // re-wrapped element stays namespace-bound regardless of which prefix SAP used.
   const scopeContent = params.scopeXml
     ? params.scopeXml
         .replace(/<\?xml[^>]*\?>/, '')
-        .replace(
-          /<usagereferences:usageScopeResult[^>]*>/,
-          '<usagereferences:scope>',
-        )
-        .replace(
-          /<\/usagereferences:usageScopeResult>/,
-          '</usagereferences:scope>',
-        )
+        .replace(/<([A-Za-z][\w-]*):usageScopeResult\b([^>]*)>/, '<$1:scope$2>')
+        .replace(/<\/([A-Za-z][\w-]*):usageScopeResult>/, '</$1:scope>')
     : '';
 
   const searchRequestBody = `<?xml version="1.0" encoding="UTF-8"?><usagereferences:usageReferenceRequest xmlns:usagereferences="http://www.sap.com/adt/ris/usageReferences"><usagereferences:affectedObjects/>${scopeContent}</usagereferences:usageReferenceRequest>`;

--- a/src/core/shared/whereUsed.ts
+++ b/src/core/shared/whereUsed.ts
@@ -23,10 +23,18 @@ import type {
   IWhereUsedReference,
 } from './types';
 
+// removeNSPrefix strips the namespace prefix from every element and attribute
+// name. The where-used result is namespaced under http://www.sap.com/adt/ris/
+// usageReferences, but the *prefix* SAP binds to it is system-dependent — some
+// releases emit `usagereferences:` (lower-case), others `usageReferences:`
+// (camel-case). Stripping the prefix lets us read the result regardless of which
+// alias the server chose, instead of hard-coding one and silently parsing 0
+// references on the other. (adtcore:* attributes are normalised the same way.)
 const xmlParser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
   parseAttributeValue: false,
+  removeNSPrefix: true,
 });
 
 /**
@@ -400,9 +408,12 @@ export async function getWhereUsedList(
 
   const xml: string = response.data;
 
-  // Parse XML response
+  // Parse XML response. Element/attribute names are namespace-prefix-free
+  // (see xmlParser config — removeNSPrefix), so `usageReferenceResult`,
+  // `referencedObject`, `adtObject`, `@_type`, `@_name`, … regardless of whether
+  // the server used the `usagereferences:` or `usageReferences:` prefix.
   const parsed = xmlParser.parse(xml);
-  const root = parsed['usagereferences:usageReferenceResult'];
+  const root = parsed.usageReferenceResult;
 
   if (!root) {
     return {
@@ -420,11 +431,10 @@ export async function getWhereUsedList(
 
   // Parse referenced objects
   const references: IWhereUsedReference[] = [];
-  const referencedObjectsNode = root['usagereferences:referencedObjects'];
+  const referencedObjectsNode = root.referencedObjects;
 
   if (referencedObjectsNode) {
-    const refObjects =
-      referencedObjectsNode['usagereferences:referencedObject'];
+    const refObjects = referencedObjectsNode.referencedObject;
     const refArray = Array.isArray(refObjects)
       ? refObjects
       : refObjects
@@ -432,22 +442,22 @@ export async function getWhereUsedList(
         : [];
 
     for (const refObj of refArray) {
-      const adtObject = refObj['usagereferences:adtObject'];
+      const adtObject = refObj.adtObject;
       if (!adtObject) continue;
 
       // Skip packages (DEVC/K) - they are container nodes, not actual references
-      const objType = adtObject['@_adtcore:type'] || '';
+      const objType = adtObject['@_type'] || '';
       if (objType === 'DEVC/K') continue;
 
-      const packageRef = adtObject['adtcore:packageRef'];
+      const packageRef = adtObject.packageRef;
 
       references.push({
         uri: refObj['@_uri'] || '',
-        name: adtObject['@_adtcore:name'] || '',
+        name: adtObject['@_name'] || '',
         type: objType,
         parentUri: refObj['@_parentUri'],
-        packageName: packageRef?.['@_adtcore:name'],
-        responsible: adtObject['@_adtcore:responsible'],
+        packageName: packageRef?.['@_name'],
+        responsible: adtObject['@_responsible'],
         isResult: refObj['@_isResult'] === 'true',
         usageInformation: refObj['@_usageInformation'],
         objectIdentifier: refObj.objectIdentifier,


### PR DESCRIPTION
## Problem

`getWhereUsedList` parsed the result through hard-coded `usagereferences:`-prefixed keys (`usagereferences:usageReferenceResult`, `:referencedObjects`, `:referencedObject`, `:adtObject`, `@_adtcore:type`, `@_adtcore:name`, …).

But the namespace **prefix** SAP binds to `http://www.sap.com/adt/ris/usageReferences` is **system-dependent**:
- some releases emit `usagereferences:` (lower-case) — what the parser assumed;
- others emit `usageReferences:` (camel-case) — **observed live on an S/4 system**.

On the camel-case systems every lookup missed, so a perfectly good **200** response carrying thousands of references parsed to **zero — silently**. Concretely, on a live S/4 the where-used for `VBAK` returns a **6 MB** body with `numberOfResults="5970"`, and the library returned `references: []`. Downstream this is why `GetStructuresList` reported **0 append structures** for `VBAK` there.

This is a separate root cause from #58 (the `/scope` 404 fallback): #58 got the request to a 200; this fixes reading the 200.

## Fix

- `removeNSPrefix: true` on the `XMLParser` — strips the namespace prefix from every element and attribute name, normalising `usagereferences:` / `usageReferences:` **and** `adtcore:` uniformly.
- Read prefix-free keys: `usageReferenceResult`, `referencedObjects`, `referencedObject`, `adtObject`, `packageRef`, `@_type`, `@_name`, `@_responsible`.

## Verification

- Parsed the **real 6 MB S/4 response**: **0 → 5970** total references (9159 parsed rows, incl. 188 `TABL/*` — the append structures), TABL/DS names like `AD01VBAK`, `/ILE/TILVBAK`, `APSM_FM_POSTING_DATE_VBAK`.
- Unit tests: parametrised over both `usagereferences:` and `usageReferences:` prefixes (assert identical parse); existing where-used tests unchanged. `lint + build + test` green.

> Code + tests only — version bump / CHANGELOG left out (to be set at release time).