### PR TITLE
feat(versions): expose transportRequest/transportDescription (7.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.2.0] - 2026-06-30
+
+### Added
+- **Version history now surfaces the transport request.** `getVersions` (`parseVersionsFeed`) reads each version entry's transport-request `<atom:link>` and populates the new optional `IObjectVersion.transportRequest` (e.g. `'DS4K901917'`) and `transportDescription` (its short text). An entry may carry two such links (sapgui + adt) with the same request — the first wins; versions without a transport leave both undefined. Requires `@mcp-abap-adt/interfaces@^9.1.0`.
+
 ## [7.1.0] - 2026-06-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^9.0.0",
+        "@mcp-abap-adt/interfaces": "^9.1.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.13.6",
         "fast-xml-parser": "^5.4.1"
@@ -1560,9 +1560,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.0.0.tgz",
-      "integrity": "sha512-jXRdXIMFnXfkK8mTARUEc7HMiQezesnGo9PxKMtF/mc98PdsPCYMxGEJXXrnyRLqErelfElJx3E6b1JhWs7rpA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.1.0.tgz",
+      "integrity": "sha512-AgrSEk7RK38s8R8PSRwOBynGEs7Rg4rYBkZ/F9i5gveWmV2bZ4BAc/+d7mAytyR/hkrngssjsXc1GJslbyN+mA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -113,7 +113,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^9.0.0",
+    "@mcp-abap-adt/interfaces": "^9.1.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.13.6",
     "fast-xml-parser": "^5.4.1"

--- a/src/__tests__/unit/versionsParse.test.ts
+++ b/src/__tests__/unit/versionsParse.test.ts
@@ -9,6 +9,9 @@ const FEED = `<?xml version="1.0" encoding="utf-8"?><atom:feed xmlns:atom="http:
 
 const EMPTY = `<?xml version="1.0"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom"><atom:title>Version List of X</atom:title></atom:feed>`;
 
+// Real program (REPS) feed: one version carries a transport (two links), two do not.
+const FEED_WITH_TRANSPORT = `<?xml version="1.0" encoding="UTF-8"?><atom:feed xmlns:atom="http://www.w3.org/2005/Atom" xmlns:adtcore="http://www.sap.com/adt/core"><atom:title>Version List of ZDMS_UPLOAD_FILES (REPS)</atom:title><atom:entry><atom:author><atom:name>EXT_KKOROTCH</atom:name></atom:author><atom:content type="text/plain" src="/sap/bc/adt/programs/programs/zdms_upload_files/source/main/versions/20260528180205/00002/content"/><atom:id>00002</atom:id><atom:link adtcore:name="DS4K901917" href="/sap/bc/adt/vit/wb/object_type/%20%20%20%20rq/object_name/DS4K901917" rel="http://www.sap.com/adt/relations/transport/request" type="application/vnd.sap.sapgui" title="EDI-94 Reports adjustments for RISE migration"/><atom:link adtcore:name="DS4K901917" href="/sap/bc/adt/cts/transportrequests/DS4K901917" rel="http://www.sap.com/adt/relations/transport/request" type="application/vnd.sap.adt.transportrequests.v1+xml" title="EDI-94 Reports adjustments for RISE migration"/><atom:title>EDI-94 Reports adjustments for RISE migration</atom:title><atom:updated>2026-05-28T18:02:05Z</atom:updated></atom:entry><atom:entry><atom:author><atom:name>EXT_KKOROTCH</atom:name></atom:author><atom:content type="text/plain" src="/sap/bc/adt/programs/programs/zdms_upload_files/source/main/versions/20260528180205/00000/content"/><atom:id>00000</atom:id><atom:updated>2026-05-22T14:41:24Z</atom:updated></atom:entry><atom:entry><atom:author><atom:name>EXT_KKOROTCH</atom:name></atom:author><atom:content type="text/plain" src="/sap/bc/adt/programs/programs/zdms_upload_files/source/main/versions/20260528180205/00001/content"/><atom:id>00001</atom:id><atom:updated>2026-05-21T15:25:24Z</atom:updated></atom:entry></atom:feed>`;
+
 describe('parseVersionsFeed', () => {
   it('parses a single-entry feed', () => {
     const v = parseVersionsFeed(FEED);
@@ -25,6 +28,25 @@ describe('parseVersionsFeed', () => {
 
   it('returns [] for a feed with no entries', () => {
     expect(parseVersionsFeed(EMPTY)).toEqual([]);
+  });
+
+  it('extracts transportRequest/transportDescription from the per-entry link (only where present)', () => {
+    const v = parseVersionsFeed(FEED_WITH_TRANSPORT);
+    expect(v).toHaveLength(3);
+
+    // 00002 carries a transport (two links, sapgui + adt, same name → first wins)
+    const e2 = v.find((x) => x.versionId === '00002')!;
+    expect(e2.transportRequest).toBe('DS4K901917');
+    expect(e2.transportDescription).toBe(
+      'EDI-94 Reports adjustments for RISE migration',
+    );
+
+    // 00000 / 00001 have no transport link → both fields undefined
+    for (const id of ['00000', '00001']) {
+      const e = v.find((x) => x.versionId === id)!;
+      expect(e.transportRequest).toBeUndefined();
+      expect(e.transportDescription).toBeUndefined();
+    }
   });
 });
 

--- a/src/core/shared/versions.ts
+++ b/src/core/shared/versions.ts
@@ -27,6 +27,7 @@ export function parseVersionsFeed(xml: string): IObjectVersion[] {
   return entries.map((e: Record<string, any>) => {
     const content = e['atom:content'] ?? e.content ?? {};
     const author = e['atom:author'] ?? e.author;
+    const transport = extractTransport(e);
     return {
       versionId: String(e['atom:id'] ?? e.id ?? ''),
       author: author
@@ -38,8 +39,31 @@ export function parseVersionsFeed(xml: string): IObjectVersion[] {
           : undefined,
       title: title ? String(title) : undefined,
       contentUri: String(content['@_src'] ?? ''),
+      transportRequest: transport.request,
+      transportDescription: transport.description,
     };
   });
+}
+
+const TRANSPORT_REL = 'http://www.sap.com/adt/relations/transport/request';
+
+/** Pull the transport request (id + description) from a version entry's
+ *  transport-request <atom:link>. An entry may carry two such links (sapgui +
+ *  adt) with the same name — the first wins. Entries without a transport leave
+ *  both undefined. */
+function extractTransport(entry: Record<string, any>): {
+  request?: string;
+  description?: string;
+} {
+  const raw = entry['atom:link'] ?? entry.link;
+  const links = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  const link = links.find(
+    (l: Record<string, any>) => l?.['@_rel'] === TRANSPORT_REL,
+  );
+  if (!link) return {};
+  const request = String(link['@_adtcore:name'] ?? '') || undefined;
+  const description = String(link['@_title'] ?? '') || undefined;
+  return { request, description };
 }
 
 /** Throw a typed "no version history" error. Used by non-source types and by


### PR DESCRIPTION
`getVersions` now surfaces the transport request each version was recorded under.

## What
- `parseVersionsFeed` reads each version entry's transport-request `<atom:link rel="…/transport/request" adtcore:name="…" title="…">` and populates the new optional `IObjectVersion.transportRequest` (e.g. `DS4K901917`) + `transportDescription` (short text).
- An entry may carry two such links (sapgui + adt v1+xml) with the same request id → first wins. Versions without a transport leave both undefined.
- Requires `@mcp-abap-adt/interfaces@^9.1.0` (published).

## Tests
- New unit case on a real program (REPS) feed: the transported version yields `transportRequest='DS4K901917'` + its description; the two non-transported versions yield undefined. Full unit suite **275/54**; `npm run build` clean.

Additive (optional fields populated) → **7.2.0 minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)