### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released only for the latest `7.x` minor line. Older majors
+are not maintained — upgrade to the latest `7.x`.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 7.x     | :white_check_mark: |
+| < 7.0   | :x:                |
+
+## Reporting a vulnerability
+
+**Please report security vulnerabilities privately — do not open a public issue
+or PR.**
+
+- **Preferred:** GitHub private vulnerability reporting — open the repository's
+  **Security** tab → **Report a vulnerability**
+  (https://github.com/fr0ster/mcp-abap-adt-clients/security/advisories/new).
+- **Alternative:** email <oleksij.kyslytsja@gmail.com>.
+
+Please include:
+
+- the affected version(s),
+- a description of the issue and its impact,
+- steps to reproduce or a proof of concept.
+
+You will receive an acknowledgement of the report. We will investigate,
+coordinate a fix, and disclose responsibly once a patched release is available.
+Credit will be given to reporters who wish to be acknowledged.
+
+## Dependencies
+
+Runtime dependencies are monitored with Dependabot; `npm audit` is expected to
+report **0 vulnerabilities** on the default branch. Dependency security bumps are
+shipped as patch releases.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,15 @@
 
 ## Supported versions
 
-Security fixes are released only for the latest `7.x` minor line. Older majors
-are not maintained — upgrade to the latest `7.x`.
+Security fixes are released only on the **latest `7.x` minor** (as a new patch).
+Older `7.x` minors and older majors are not maintained — upgrade to the latest
+`7.x`.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 7.x     | :white_check_mark: |
-| < 7.0   | :x:                |
+| Version                        | Supported          |
+| ------------------------------ | ------------------ |
+| Latest `7.x` minor (`7.2.x`)   | :white_check_mark: |
+| Older `7.x` minors (`< 7.2`)   | :x:                |
+| `< 7.0`                        | :x:                |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
Adds a security policy:
- **Supported versions:** latest `7.x` only.
- **Reporting:** private — GitHub's "Report a vulnerability" (private vulnerability reporting is enabled on the repo) or email.
- **Dependencies:** monitored via Dependabot; `npm audit` expected 0 on the default branch (as of 7.2.1).

GitHub will surface this as the "Security policy" in the repo's Security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)