### PR TITLE
feat(locks): session-scoped lock registry with unlockAll() safety net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.0] - 2026-07-16
+
+### Added
+- **Session-scoped lock registry with `unlockAll()` safety net.** `AdtClient` now owns one `LockRegistry` shared by every handler it creates, so all enqueue locks held in the session are tracked in one place. New API on `AdtClient`: `unlockAll()` releases every dangling lock in a single call and returns the ones it could not release (`LockFailure[]`); `pendingLocks` lists the keys currently held (e.g. `Domain/ZFOO`, `DataElement/ZBAR`); and `[Symbol.asyncDispose]` enables `await using client = …` cleanup.
+  - This is a **last-resort** safety net for abandoned locks (a forgot-to-unlock, or a managed flow that threw before its unlock). It deliberately does **not** make the lock→unlock critical section non-interruptible — preventing a client timeout from interrupting that section remains the caller's responsibility. On process crash/kill the ultimate backstop is SAP releasing the session's enqueue locks on session-drop.
+  - Every lock-holding handler is wired to track on lock and untrack on clean unlock — across public `lock()`/`unlock()`, the managed `create()`/`update()` chains, and error-cleanup unlock. Nested handlers (`functionModule`/`functionInclude`) use composite `Type/group/name` keys; `enhancement` captures its type in the unlock; class-includes (`LocalTestClass`/`Types`/`Definitions`/`Macros`) inherit the wired `AdtClass` lock/unlock. No-op-lock handlers (`service`/`transport`/`unitTest`/`messageClassMessage`) are excluded — their `lock()` is unsupported.
+  - `unlockAll()` runs the whole batch under a single `stateful`→`stateless` transition, so a per-unlock switch to stateless cannot clear the session mid-batch (as `RfcAbapConnection` does) and invalidate the remaining lock handles. `[Symbol.asyncDispose]` is best-effort: it never throws (so it cannot mask the error that ended the `using` scope), logs a warning for any residual failure, and leaves those locks observable via `pendingLocks`.
+
 ## [7.3.1] - 2026-07-04
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.3.1",
+  "version": "7.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "7.3.1",
+      "version": "7.4.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.3.1",
+  "version": "7.4.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/integration/core/domain/DomainLockRegistry.test.ts
+++ b/src/__tests__/integration/core/domain/DomainLockRegistry.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Integration test for the session-scoped lock registry (final unlock safety net).
+ *
+ * Proves end-to-end against a real SAP system that:
+ *  - AdtDomain.lock() records the held lock in the client's session-scoped registry
+ *  - AdtClient.unlockAll() releases a lock the caller never unlocked, and SAP
+ *    accepts the UNLOCK (no failures)
+ *
+ * This is the "last resort" cleanup, not the primary defense — preventing a
+ * timeout from interrupting the lock→unlock critical section stays with the caller.
+ *
+ * Enable debug logs:
+ *  DEBUG_ADT_TESTS=true   - Integration test execution logs
+ *  DEBUG_ADT_LIBS=true    - Domain library logs
+ *  DEBUG_CONNECTORS=true  - Connection logs (@mcp-abap-adt/connection)
+ *
+ * Run: npm test -- --testPathPatterns=domain/DomainLockRegistry
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import * as dotenv from 'dotenv';
+import type { AdtClient } from '../../../../clients/AdtClient';
+import type { IDomainConfig } from '../../../../core/domain';
+import { getDomain } from '../../../../core/domain/read';
+import { isCloudEnvironment } from '../../../../utils/systemInfo';
+import {
+  createTestAdtClient,
+  getConfig,
+  resolveSystemContext,
+} from '../../../helpers/sessionConfig';
+import { TestConfigResolver } from '../../../helpers/TestConfigResolver';
+import {
+  createConnectionLogger,
+  createLibraryLogger,
+  createTestsLogger,
+} from '../../../helpers/testLogger';
+import {
+  logTestEnd,
+  logTestError,
+  logTestSkip,
+  logTestStart,
+  logTestSuccess,
+} from '../../../helpers/testProgressLogger';
+
+const { getTimeout } = require('../../../helpers/test-helper');
+
+const envPath =
+  process.env.MCP_ENV_PATH || path.resolve(__dirname, '../../../../.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath, quiet: true });
+}
+
+const connectionLogger: ILogger = createConnectionLogger();
+const libraryLogger: ILogger = createLibraryLogger();
+const testsLogger: ILogger = createTestsLogger();
+
+const TEST_NAME = 'Domain - lock registry final unlock';
+
+describe('Domain lock registry (using AdtClient)', () => {
+  let connection: IAbapConnection;
+  let client: AdtClient;
+  let hasConfig = false;
+  let isCloudSystem = false;
+  let config: IDomainConfig | undefined;
+
+  beforeAll(async () => {
+    try {
+      const sapConfig = getConfig();
+      connection = createAbapConnection(sapConfig, connectionLogger);
+      await (connection as any).connect();
+      isCloudSystem = await isCloudEnvironment(connection);
+      const systemContext = await resolveSystemContext(
+        connection,
+        isCloudSystem,
+      );
+      const { client: resolvedClient } = await createTestAdtClient(
+        connection,
+        libraryLogger,
+        systemContext,
+      );
+      client = resolvedClient;
+
+      // Resolve domain params from test-config.yaml (no hardcoding).
+      const resolver = new TestConfigResolver({
+        handlerName: 'create_domain',
+        testCaseName: 'adt_domain',
+        isCloud: isCloudSystem,
+        logger: testsLogger,
+      });
+      const params = resolver.getParams();
+      const packageName = resolver.getPackageName();
+      if (params?.domain_name && packageName) {
+        config = {
+          domainName: params.domain_name,
+          packageName,
+          transportRequest: resolver.getTransportRequest(),
+          description: params.description,
+          datatype: params.datatype || 'CHAR',
+          length: params.length || 5,
+          decimals: params.decimals,
+          lowercase: params.lowercase,
+          sign_exists: params.sign_exists,
+        };
+      }
+      hasConfig = true;
+    } catch (_error) {
+      hasConfig = false;
+    }
+  });
+
+  it(
+    'unlockAll() releases a lock the caller never unlocked',
+    async () => {
+      logTestStart(testsLogger, TEST_NAME, {
+        name: 'lock_registry_final_unlock',
+        params: { domain_name: config?.domainName },
+      });
+
+      if (!hasConfig || !client || !config) {
+        logTestSkip(testsLogger, TEST_NAME, 'No SAP configuration');
+        return;
+      }
+
+      try {
+        // Ensure the domain exists (idempotent: create it only if missing).
+        try {
+          await getDomain(connection, config.domainName);
+        } catch (error: any) {
+          if (error?.response?.status === 404) {
+            await client.getDomain().create(config);
+          } else {
+            throw error;
+          }
+        }
+
+        // Lock through the client — the handler records it in the session-scoped
+        // registry. Deliberately do NOT unlock here.
+        const domain = client.getDomain();
+        const lockHandle = await domain.lock(config);
+        expect(typeof lockHandle).toBe('string');
+        expect(lockHandle.length).toBeGreaterThan(0);
+
+        // Last-resort cleanup releases the abandoned lock; SAP must accept it.
+        const failures = await client.unlockAll();
+        expect(failures).toEqual([]);
+
+        logTestSuccess(testsLogger, TEST_NAME);
+      } catch (error) {
+        logTestError(testsLogger, TEST_NAME, error);
+        throw error;
+      } finally {
+        logTestEnd(testsLogger, TEST_NAME);
+      }
+    },
+    getTimeout('test'),
+  );
+});

--- a/src/__tests__/integration/core/domain/SessionLockRegistry.test.ts
+++ b/src/__tests__/integration/core/domain/SessionLockRegistry.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Integration test for the session-scoped lock registry across object types.
+ *
+ * Proves end-to-end that ONE AdtClient session aggregates locks from different
+ * handler types (Domain + DataElement), and that `unlockAll()` releases every
+ * dangling lock in a single call — the "one session, all locks" design.
+ *
+ * All object parameters come from test-config.yaml via TestConfigResolver.
+ *
+ * Enable debug logs:
+ *  DEBUG_ADT_TESTS=true   - Integration test execution logs
+ *  DEBUG_ADT_LIBS=true    - Library logs
+ *  DEBUG_CONNECTORS=true  - Connection logs
+ *
+ * Run: npm test -- --testPathPatterns=domain/SessionLockRegistry
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import * as dotenv from 'dotenv';
+import type { AdtClient } from '../../../../clients/AdtClient';
+import type { IDataElementConfig } from '../../../../core/dataElement';
+import { getDataElement } from '../../../../core/dataElement/read';
+import type { IDomainConfig } from '../../../../core/domain';
+import { getDomain } from '../../../../core/domain/read';
+import { isCloudEnvironment } from '../../../../utils/systemInfo';
+import {
+  createTestAdtClient,
+  getConfig,
+  resolveSystemContext,
+} from '../../../helpers/sessionConfig';
+import { TestConfigResolver } from '../../../helpers/TestConfigResolver';
+import {
+  createConnectionLogger,
+  createLibraryLogger,
+  createTestsLogger,
+} from '../../../helpers/testLogger';
+import {
+  logTestEnd,
+  logTestError,
+  logTestSkip,
+  logTestStart,
+  logTestSuccess,
+} from '../../../helpers/testProgressLogger';
+
+const envPath =
+  process.env.MCP_ENV_PATH || path.resolve(__dirname, '../../../../.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath, quiet: true });
+}
+
+const connectionLogger: ILogger = createConnectionLogger();
+const libraryLogger: ILogger = createLibraryLogger();
+const testsLogger: ILogger = createTestsLogger();
+
+const TEST_NAME = 'Session lock registry - unlockAll across object types';
+
+describe('Session lock registry (using AdtClient)', () => {
+  let connection: IAbapConnection;
+  let client: AdtClient;
+  let hasConfig = false;
+  let isCloudSystem = false;
+  let domainConfig: IDomainConfig | undefined;
+  let dataElementConfig: IDataElementConfig | undefined;
+
+  beforeAll(async () => {
+    try {
+      const sapConfig = getConfig();
+      connection = createAbapConnection(sapConfig, connectionLogger);
+      await (connection as any).connect();
+      isCloudSystem = await isCloudEnvironment(connection);
+      const systemContext = await resolveSystemContext(
+        connection,
+        isCloudSystem,
+      );
+      const { client: resolvedClient } = await createTestAdtClient(
+        connection,
+        libraryLogger,
+        systemContext,
+      );
+      client = resolvedClient;
+
+      const domainResolver = new TestConfigResolver({
+        handlerName: 'create_domain',
+        testCaseName: 'adt_domain',
+        isCloud: isCloudSystem,
+        logger: testsLogger,
+      });
+      const dp = domainResolver.getParams();
+      const domainPackage = domainResolver.getPackageName();
+      if (dp?.domain_name && domainPackage) {
+        domainConfig = {
+          domainName: dp.domain_name,
+          packageName: domainPackage,
+          transportRequest: domainResolver.getTransportRequest(),
+          description: dp.description,
+          datatype: dp.datatype || 'CHAR',
+          length: dp.length || 5,
+          decimals: dp.decimals,
+        };
+      }
+
+      const deResolver = new TestConfigResolver({
+        handlerName: 'create_data_element',
+        testCaseName: 'adt_data_element',
+        isCloud: isCloudSystem,
+        logger: testsLogger,
+      });
+      const ep = deResolver.getParams();
+      const dePackage = deResolver.getPackageName();
+      if (ep?.data_element_name && dePackage) {
+        dataElementConfig = {
+          dataElementName: ep.data_element_name,
+          packageName: dePackage,
+          transportRequest: deResolver.getTransportRequest(),
+          description: ep.description,
+          typeKind: ep.type_kind || 'predefinedAbapType',
+          dataType: ep.data_type || 'CHAR',
+          length: ep.length,
+          decimals: ep.decimals,
+          shortLabel: ep.short_label,
+          mediumLabel: ep.medium_label,
+          longLabel: ep.long_label,
+          headingLabel: ep.heading_label,
+        } as IDataElementConfig;
+      }
+
+      hasConfig = true;
+    } catch (_error) {
+      hasConfig = false;
+    }
+  });
+
+  it('aggregates locks from multiple handler types and unlockAll releases them all', async () => {
+    logTestStart(testsLogger, TEST_NAME, {
+      name: 'session_unlock_all',
+      params: {
+        domain_name: domainConfig?.domainName,
+        data_element_name: dataElementConfig?.dataElementName,
+      },
+    });
+
+    if (!hasConfig || !client || !domainConfig || !dataElementConfig) {
+      logTestSkip(testsLogger, TEST_NAME, 'No SAP configuration');
+      return;
+    }
+
+    try {
+      // Ensure both objects exist (idempotent: create only if missing).
+      try {
+        await getDomain(connection, domainConfig.domainName);
+      } catch (error: any) {
+        if (error?.response?.status === 404) {
+          await client.getDomain().create(domainConfig);
+        } else {
+          throw error;
+        }
+      }
+      try {
+        await getDataElement(connection, dataElementConfig.dataElementName);
+      } catch (error: any) {
+        if (error?.response?.status === 404) {
+          await client.getDataElement().create(dataElementConfig);
+        } else {
+          throw error;
+        }
+      }
+
+      // Lock both through the SAME client session — deliberately no unlock.
+      await client.getDomain().lock(domainConfig);
+      await client.getDataElement().lock(dataElementConfig);
+
+      // The session-scoped registry aggregates both, regardless of type.
+      expect(client.pendingLocks.length).toBe(2);
+
+      // One call releases every dangling lock; SAP must accept them all.
+      const failures = await client.unlockAll();
+      expect(failures).toEqual([]);
+      expect(client.pendingLocks).toEqual([]);
+
+      logTestSuccess(testsLogger, TEST_NAME);
+    } catch (error) {
+      // Best-effort cleanup so a mid-test failure never leaves locks behind.
+      await client.unlockAll().catch(() => {});
+      logTestError(testsLogger, TEST_NAME, error);
+      throw error;
+    } finally {
+      logTestEnd(testsLogger, TEST_NAME);
+    }
+  }, 900000);
+});

--- a/src/__tests__/unit/clients/AdtClientLockRegistry.test.ts
+++ b/src/__tests__/unit/clients/AdtClientLockRegistry.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for AdtClient's session-scoped lock registry and its best-effort
+ * `Symbol.asyncDispose`.
+ *
+ * A fake IAbapConnection injects the lock handle and forces the unlock to fail
+ * deterministically (a busy-context unlock cannot be reproduced live on demand).
+ * The object name comes from test-config.yaml via TestConfigResolver.
+ */
+
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { AdtClient } from '../../../clients/AdtClient';
+import { TestConfigResolver } from '../../helpers/TestConfigResolver';
+import { createTestsLogger } from '../../helpers/testLogger';
+import {
+  logTestEnd,
+  logTestStart,
+  logTestSuccess,
+} from '../../helpers/testProgressLogger';
+
+const testsLogger: ILogger = createTestsLogger();
+
+const LOCK_XML =
+  '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>HANDLE123</LOCK_HANDLE></DATA></asx:values></asx:abap>';
+
+/** Fake connection: LOCK → handle, UNLOCK → throws, everything else → 200. */
+function failingUnlockConnection(): IAbapConnection {
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    if (String(req.url).includes('_action=LOCK')) {
+      return { status: 200, data: LOCK_XML };
+    }
+    if (String(req.url).includes('_action=UNLOCK')) {
+      throw new Error('context busy');
+    }
+    return { status: 200, data: '' };
+  });
+  const setSessionType = jest.fn();
+  return { makeAdtRequest, setSessionType } as unknown as IAbapConnection;
+}
+
+describe('AdtClient lock registry dispose', () => {
+  const resolver = new TestConfigResolver({
+    handlerName: 'create_domain',
+    testCaseName: 'adt_domain',
+    logger: testsLogger,
+  });
+  const domainName: string = resolver.getParams().domain_name;
+  const lockKey = `Domain/${String(domainName).toUpperCase()}`;
+
+  it('await using dispose is best-effort: it does not throw and leaves the failed lock observable in pendingLocks', async () => {
+    logTestStart(testsLogger, 'AdtClient dispose - best-effort', {
+      name: 'dispose_best_effort',
+      params: { domain_name: domainName },
+    });
+
+    const warn = jest.fn();
+    const logger: ILogger = {
+      debug: () => {},
+      info: () => {},
+      warn,
+      error: () => {},
+    };
+    const client = new AdtClient(failingUnlockConnection(), logger);
+
+    await client.getDomain().lock({ domainName });
+    expect(client.pendingLocks).toEqual([lockKey]);
+
+    // Dispose must not throw even though the unlock fails...
+    await expect(client[Symbol.asyncDispose]()).resolves.toBeUndefined();
+
+    // ...and the unreleased lock stays observable (retained, not lost),
+    // with a warning emitted so the failure is not silent.
+    expect(client.pendingLocks).toEqual([lockKey]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain(lockKey);
+
+    logTestSuccess(testsLogger, 'AdtClient dispose - best-effort');
+    logTestEnd(testsLogger, 'AdtClient dispose - best-effort');
+  });
+});

--- a/src/__tests__/unit/core/domainLockRegistry.test.ts
+++ b/src/__tests__/unit/core/domainLockRegistry.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for AdtDomain ↔ LockRegistry wiring.
+ *
+ * A fake IAbapConnection is used only to inject the lock handle and to force
+ * failure paths deterministically (a busy-context unlock cannot be reproduced
+ * on a live system on demand). All object parameters (domain name, package)
+ * come from test-config.yaml via TestConfigResolver — never hardcoded.
+ */
+
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { AdtDomain } from '../../../core/domain/AdtDomain';
+import { LockRegistry } from '../../../core/shared/LockRegistry';
+import { TestConfigResolver } from '../../helpers/TestConfigResolver';
+import { createTestsLogger } from '../../helpers/testLogger';
+import {
+  logTestEnd,
+  logTestStart,
+  logTestSuccess,
+} from '../../helpers/testProgressLogger';
+
+const testsLogger: ILogger = createTestsLogger();
+
+const LOCK_XML =
+  '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>HANDLE123</LOCK_HANDLE></DATA></asx:values></asx:abap>';
+
+/** Fake connection: answers LOCK with a handle, everything else with 200/empty. */
+function fakeConnection(): { conn: IAbapConnection; calls: any[] } {
+  const calls: any[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    if (String(req.url).includes('_action=LOCK')) {
+      return { status: 200, data: LOCK_XML };
+    }
+    return { status: 200, data: '' };
+  });
+  const setSessionType = jest.fn();
+  return {
+    conn: { makeAdtRequest, setSessionType } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+describe('AdtDomain lock registry wiring', () => {
+  const resolver = new TestConfigResolver({
+    handlerName: 'create_domain',
+    testCaseName: 'adt_domain',
+    logger: testsLogger,
+  });
+  const params = resolver.getParams();
+  const domainName: string = params.domain_name;
+  const packageName = resolver.getPackageName();
+  const lockKey = `Domain/${String(domainName).toUpperCase()}`;
+
+  it('lock() records the held lock in the injected registry', async () => {
+    logTestStart(testsLogger, 'Domain lock registry - lock() tracks', {
+      name: 'lock_tracks',
+      params: { domain_name: domainName },
+    });
+    const { conn } = fakeConnection();
+    const registry = new LockRegistry();
+    const domain = new AdtDomain(conn, undefined, undefined, registry);
+
+    await domain.lock({ domainName });
+
+    expect(registry.pending).toEqual([lockKey]);
+    logTestSuccess(testsLogger, 'Domain lock registry - lock() tracks');
+    logTestEnd(testsLogger, 'Domain lock registry - lock() tracks');
+  });
+
+  it('unlock() removes the lock from the registry', async () => {
+    logTestStart(testsLogger, 'Domain lock registry - unlock() untracks', {
+      name: 'unlock_untracks',
+      params: { domain_name: domainName },
+    });
+    const { conn } = fakeConnection();
+    const registry = new LockRegistry();
+    const domain = new AdtDomain(conn, undefined, undefined, registry);
+
+    const handle = await domain.lock({ domainName });
+    await domain.unlock({ domainName }, handle);
+
+    expect(registry.pending).toEqual([]);
+    logTestSuccess(testsLogger, 'Domain lock registry - unlock() untracks');
+    logTestEnd(testsLogger, 'Domain lock registry - unlock() untracks');
+  });
+
+  it('registry.unlockAll() releases a lock the caller never unlocked', async () => {
+    logTestStart(testsLogger, 'Domain lock registry - unlockAll() releases', {
+      name: 'unlockall_releases',
+      params: { domain_name: domainName },
+    });
+    const { conn, calls } = fakeConnection();
+    const registry = new LockRegistry();
+    const domain = new AdtDomain(conn, undefined, undefined, registry);
+
+    await domain.lock({ domainName });
+    const failures = await registry.unlockAll();
+
+    expect(failures).toEqual([]);
+    expect(registry.pending).toEqual([]);
+    const unlockCall = calls.find((c) =>
+      String(c.url).includes('_action=UNLOCK'),
+    );
+    expect(unlockCall).toBeDefined();
+    expect(String(unlockCall.url)).toContain('lockHandle=HANDLE123');
+    logTestSuccess(testsLogger, 'Domain lock registry - unlockAll() releases');
+    logTestEnd(testsLogger, 'Domain lock registry - unlockAll() releases');
+  });
+
+  it('managed update() retains the lock when the flow fails and cleanup unlock also fails', async () => {
+    logTestStart(testsLogger, 'Domain lock registry - managed retention', {
+      name: 'managed_retention',
+      params: { domain_name: domainName, package_name: packageName },
+    });
+    // LOCK succeeds; the update read-modify-write fails; and the error-path
+    // cleanup unlock ALSO fails (server context still busy). The registry must
+    // keep the lock so unlockAll() is the last resort.
+    const makeAdtRequest = jest.fn(async (req: any) => {
+      if (String(req.url).includes('_action=LOCK')) {
+        return { status: 200, data: LOCK_XML };
+      }
+      if (String(req.url).includes('_action=UNLOCK')) {
+        throw new Error('context busy');
+      }
+      throw new Error('update failed');
+    });
+    const setSessionType = jest.fn();
+    const conn = {
+      makeAdtRequest,
+      setSessionType,
+    } as unknown as IAbapConnection;
+    const registry = new LockRegistry();
+    const domain = new AdtDomain(conn, undefined, undefined, registry);
+
+    await expect(domain.update({ domainName, packageName })).rejects.toThrow();
+
+    expect(registry.pending).toEqual([lockKey]);
+    logTestSuccess(testsLogger, 'Domain lock registry - managed retention');
+    logTestEnd(testsLogger, 'Domain lock registry - managed retention');
+  });
+});

--- a/src/__tests__/unit/shared/LockRegistry.test.ts
+++ b/src/__tests__/unit/shared/LockRegistry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for the session-scoped LockRegistry (final unlock safety net).
+ *
+ * The registry is object-type agnostic, so the tests drive it with keys built
+ * from real object names resolved from test-config.yaml via TestConfigResolver —
+ * no hardcoded object names.
+ */
+
+import type { ILogger } from '@mcp-abap-adt/interfaces';
+import { LockRegistry } from '../../../core/shared/LockRegistry';
+import { TestConfigResolver } from '../../helpers/TestConfigResolver';
+import { createTestsLogger } from '../../helpers/testLogger';
+import {
+  logTestEnd,
+  logTestStart,
+  logTestSuccess,
+} from '../../helpers/testProgressLogger';
+
+const testsLogger: ILogger = createTestsLogger();
+
+describe('LockRegistry', () => {
+  const domainResolver = new TestConfigResolver({
+    handlerName: 'create_domain',
+    testCaseName: 'adt_domain',
+    logger: testsLogger,
+  });
+  const dataElementResolver = new TestConfigResolver({
+    handlerName: 'create_data_element',
+    testCaseName: 'adt_data_element',
+    logger: testsLogger,
+  });
+  const keyA = `Domain/${String(domainResolver.getParams().domain_name).toUpperCase()}`;
+  const keyB = `DataElement/${String(dataElementResolver.getParams().data_element_name).toUpperCase()}`;
+
+  it('unlockAll invokes the unlock thunk for every tracked object and clears them', async () => {
+    logTestStart(testsLogger, 'LockRegistry - unlockAll clears all', {
+      name: 'unlockall_clears',
+      params: { keyA, keyB },
+    });
+    const registry = new LockRegistry();
+    const unlocked: string[] = [];
+
+    registry.track(keyA, async () => {
+      unlocked.push(keyA);
+    });
+    registry.track(keyB, async () => {
+      unlocked.push(keyB);
+    });
+
+    const failures = await registry.unlockAll();
+
+    expect(unlocked.sort()).toEqual([keyA, keyB].sort());
+    expect(failures).toEqual([]);
+    expect(registry.pending).toEqual([]);
+    logTestSuccess(testsLogger, 'LockRegistry - unlockAll clears all');
+    logTestEnd(testsLogger, 'LockRegistry - unlockAll clears all');
+  });
+
+  it('does not unlock an object that was already untracked (clean unlock)', async () => {
+    logTestStart(testsLogger, 'LockRegistry - untrack skips unlock', {
+      name: 'untrack_skips',
+      params: { keyA },
+    });
+    const registry = new LockRegistry();
+    const unlocked: string[] = [];
+
+    registry.track(keyA, async () => {
+      unlocked.push(keyA);
+    });
+    // Handler released it normally and told the registry.
+    registry.untrack(keyA);
+
+    const failures = await registry.unlockAll();
+
+    expect(unlocked).toEqual([]);
+    expect(failures).toEqual([]);
+    expect(registry.pending).toEqual([]);
+    logTestSuccess(testsLogger, 'LockRegistry - untrack skips unlock');
+    logTestEnd(testsLogger, 'LockRegistry - untrack skips unlock');
+  });
+
+  it('keeps locks whose unlock throws and reports them, still releasing the others', async () => {
+    logTestStart(testsLogger, 'LockRegistry - retains failed unlock', {
+      name: 'retains_failed',
+      params: { keyA, keyB },
+    });
+    const registry = new LockRegistry();
+    const unlocked: string[] = [];
+    const boom = new Error('context busy');
+
+    registry.track(keyA, async () => {
+      throw boom;
+    });
+    registry.track(keyB, async () => {
+      unlocked.push(keyB);
+    });
+
+    const failures = await registry.unlockAll();
+
+    expect(unlocked).toEqual([keyB]);
+    expect(failures).toEqual([{ key: keyA, error: boom }]);
+    // The failed lock is retained so a later retry / session-drop can handle it.
+    expect(registry.pending).toEqual([keyA]);
+    logTestSuccess(testsLogger, 'LockRegistry - retains failed unlock');
+    logTestEnd(testsLogger, 'LockRegistry - retains failed unlock');
+  });
+});

--- a/src/__tests__/unit/shared/LockRegistry.test.ts
+++ b/src/__tests__/unit/shared/LockRegistry.test.ts
@@ -104,4 +104,51 @@ describe('LockRegistry', () => {
     logTestSuccess(testsLogger, 'LockRegistry - retains failed unlock');
     logTestEnd(testsLogger, 'LockRegistry - retains failed unlock');
   });
+
+  it('keeps the session stateful for the whole batch (one stateful, one stateless — no mid-batch toggle)', async () => {
+    logTestStart(testsLogger, 'LockRegistry - batch session', {
+      name: 'batch_session',
+      params: { keyA, keyB },
+    });
+    // Some connections (RFC) clear the stateful cookie when switched to
+    // stateless; toggling per-unlock would invalidate the remaining handles.
+    const events: string[] = [];
+    const session = {
+      setSessionType: (t: 'stateful' | 'stateless') => events.push(t),
+    };
+    const registry = new LockRegistry(session);
+
+    registry.track(keyA, async () => {
+      events.push('unlockA');
+    });
+    registry.track(keyB, async () => {
+      events.push('unlockB');
+    });
+
+    await registry.unlockAll();
+
+    // Exactly one stateful at the start, both unlocks, then one stateless.
+    expect(events).toEqual(['stateful', 'unlockA', 'unlockB', 'stateless']);
+    logTestSuccess(testsLogger, 'LockRegistry - batch session');
+    logTestEnd(testsLogger, 'LockRegistry - batch session');
+  });
+
+  it('does not touch the session when there is nothing to unlock', async () => {
+    logTestStart(testsLogger, 'LockRegistry - empty batch', {
+      name: 'empty_batch',
+      params: {},
+    });
+    const events: string[] = [];
+    const session = {
+      setSessionType: (t: 'stateful' | 'stateless') => events.push(t),
+    };
+    const registry = new LockRegistry(session);
+
+    const failures = await registry.unlockAll();
+
+    expect(failures).toEqual([]);
+    expect(events).toEqual([]);
+    logTestSuccess(testsLogger, 'LockRegistry - empty batch');
+    logTestEnd(testsLogger, 'LockRegistry - empty batch');
+  });
 });

--- a/src/clients/AdtClient.ts
+++ b/src/clients/AdtClient.ts
@@ -136,6 +136,7 @@ import {
   type IServiceDefinitionState,
 } from '../core/serviceDefinition';
 import { AdtUtils } from '../core/shared/AdtUtils';
+import { type LockFailure, LockRegistry } from '../core/shared/LockRegistry';
 import {
   AdtStructure,
   type IStructureConfig,
@@ -185,6 +186,11 @@ export class AdtClient {
   protected logger: ILogger;
   protected systemContext: IAdtSystemContext;
   protected contentTypes?: import('../core/shared/contentTypes').IAdtContentTypes;
+  /**
+   * Session-scoped registry of locks held by handlers created from this client.
+   * All handlers share one stateful session, so all their locks belong here.
+   */
+  protected readonly lockRegistry = new LockRegistry();
 
   constructor(
     connection: IAbapConnection,
@@ -237,6 +243,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -250,6 +257,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -258,7 +266,13 @@ export class AdtClient {
    * @returns IAdtObject instance for Interface operations
    */
   getInterface(): IAdtObject<IInterfaceConfig, IInterfaceState> {
-    return new AdtInterface(this.connection, this.logger, this.systemContext);
+    return new AdtInterface(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      undefined,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -266,7 +280,38 @@ export class AdtClient {
    * @returns IAdtObject instance for Domain operations
    */
   getDomain(): IAdtObject<IDomainConfig, IDomainState> {
-    return new AdtDomain(this.connection, this.logger, this.systemContext);
+    return new AdtDomain(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      this.lockRegistry,
+    );
+  }
+
+  /**
+   * Last-resort cleanup: release every lock still held by handlers created from
+   * this client. Returns the locks that could not be released.
+   *
+   * This is a safety net for abandoned locks (a forgot-to-unlock, or a managed
+   * flow that threw before its unlock). Preventing a timeout from interrupting a
+   * lock→unlock critical section remains the caller's responsibility.
+   */
+  async unlockAll(): Promise<LockFailure[]> {
+    return this.lockRegistry.unlockAll();
+  }
+
+  /**
+   * Keys of locks currently held by handlers created from this client
+   * (e.g. `Domain/ZFOO`, `DataElement/ZBAR`). Lets a consumer inspect whether a
+   * session was left with dangling locks before deciding to `unlockAll()`.
+   */
+  get pendingLocks(): string[] {
+    return this.lockRegistry.pending;
+  }
+
+  /** Release all held locks when used with `await using`. */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.unlockAll();
   }
 
   /**
@@ -274,7 +319,12 @@ export class AdtClient {
    * @returns IAdtObject instance for DataElement operations
    */
   getDataElement(): IAdtObject<IDataElementConfig, IDataElementState> {
-    return new AdtDataElement(this.connection, this.logger, this.systemContext);
+    return new AdtDataElement(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -289,6 +339,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -297,7 +348,12 @@ export class AdtClient {
    * @returns IAdtObject instance for Structure operations
    */
   getStructure(): IAdtObject<IStructureConfig, IStructureState> {
-    return new AdtStructure(this.connection, this.logger, this.systemContext);
+    return new AdtStructure(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -305,7 +361,12 @@ export class AdtClient {
    * @returns IAdtObject instance for Table operations
    */
   getTable(): IAdtObject<ITableConfig, ITableState> {
-    return new AdtTable(this.connection, this.logger, this.systemContext);
+    return new AdtTable(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -317,6 +378,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -328,7 +390,12 @@ export class AdtClient {
    * @returns IAdtObject instance for DDL source operations
    */
   getDdl(): IAdtObject<IDdlConfig, IDdlState> {
-    return new AdtDdl(this.connection, this.logger, this.systemContext);
+    return new AdtDdl(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -341,6 +408,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -354,6 +422,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -370,6 +439,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -378,7 +448,12 @@ export class AdtClient {
    * @returns IAdtObject instance for Package operations
    */
   getPackage(): IAdtObject<IPackageConfig, IPackageState> {
-    return new AdtPackage(this.connection, this.logger, this.systemContext);
+    return new AdtPackage(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -390,6 +465,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -414,6 +490,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -427,6 +504,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -442,6 +520,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -453,6 +532,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -467,6 +547,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -481,6 +562,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -515,6 +597,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -526,7 +609,11 @@ export class AdtClient {
     IBehaviorImplementationConfig,
     IBehaviorImplementationState
   > {
-    return new AdtBehaviorImplementation(this.connection, this.logger);
+    return new AdtBehaviorImplementation(
+      this.connection,
+      this.logger,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -541,6 +628,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -555,7 +643,12 @@ export class AdtClient {
    * @returns IAdtObject instance for Enhancement operations
    */
   getEnhancement(): IAdtObject<IEnhancementConfig, IEnhancementState> {
-    return new AdtEnhancement(this.connection, this.logger, this.systemContext);
+    return new AdtEnhancement(
+      this.connection,
+      this.logger,
+      this.systemContext,
+      this.lockRegistry,
+    );
   }
 
   /**
@@ -567,6 +660,7 @@ export class AdtClient {
       this.connection,
       this.logger,
       this.systemContext,
+      this.lockRegistry,
     );
   }
 
@@ -620,6 +714,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -633,6 +728,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -646,6 +742,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 
@@ -659,6 +756,7 @@ export class AdtClient {
       this.logger,
       this.systemContext,
       this.contentTypes,
+      this.lockRegistry,
     );
   }
 }

--- a/src/clients/AdtClient.ts
+++ b/src/clients/AdtClient.ts
@@ -190,7 +190,7 @@ export class AdtClient {
    * Session-scoped registry of locks held by handlers created from this client.
    * All handlers share one stateful session, so all their locks belong here.
    */
-  protected readonly lockRegistry = new LockRegistry();
+  protected readonly lockRegistry: LockRegistry;
 
   constructor(
     connection: IAbapConnection,
@@ -198,6 +198,8 @@ export class AdtClient {
     options?: IAdtClientOptions,
   ) {
     this.connection = connection;
+    // Pass the connection so unlockAll() can keep the whole batch stateful.
+    this.lockRegistry = new LockRegistry(connection);
     this.logger = logger ?? {
       debug: () => {},
       info: () => {},

--- a/src/clients/AdtClient.ts
+++ b/src/clients/AdtClient.ts
@@ -309,9 +309,27 @@ export class AdtClient {
     return this.lockRegistry.pending;
   }
 
-  /** Release all held locks when used with `await using`. */
+  /**
+   * Release all held locks when used with `await using`.
+   *
+   * Best-effort: like {@link unlockAll}, this never throws — a lock whose unlock
+   * fails is retained rather than surfaced as an error, so a disposer failure
+   * cannot mask the error that ended the `using` scope. Any residual failures
+   * are logged as a warning and remain observable via {@link pendingLocks}.
+   * Callers that must react to unlock failures should call `unlockAll()`
+   * explicitly and inspect the returned `LockFailure[]`.
+   */
   async [Symbol.asyncDispose](): Promise<void> {
-    await this.unlockAll();
+    const failures = await this.unlockAll();
+    if (failures.length > 0) {
+      this.logger.warn(
+        `[AdtClient] dispose left ${failures.length} lock(s) unreleased: ${failures
+          .map((f) => f.key)
+          .join(
+            ', ',
+          )}. They remain in pendingLocks; retry unlockAll() or rely on session-drop.`,
+      );
+    }
   }
 
   /**

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -73,14 +73,8 @@ export class AdtAccessControl
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockAccessControl(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockAccessControl(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateAccessControl } from './activation';
 import { checkAccessControl } from './check';
@@ -53,16 +58,30 @@ export class AdtAccessControl
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'AccessControl';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockAccessControl(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -309,6 +328,7 @@ export class AdtAccessControl
         this.connection,
         config.accessControlName,
       );
+      this.lockTracker.track(config.accessControlName, lockHandle);
       this.logger?.info?.('Access control locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -369,6 +389,7 @@ export class AdtAccessControl
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.accessControlName);
         lockHandle = undefined;
         this.logger?.info?.('Access control unlocked');
       }
@@ -441,6 +462,7 @@ export class AdtAccessControl
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.accessControlName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -579,6 +601,7 @@ export class AdtAccessControl
       this.connection,
       config.accessControlName,
     );
+    this.lockTracker.track(config.accessControlName, lockHandle);
     return lockHandle;
   }
 
@@ -600,6 +623,7 @@ export class AdtAccessControl
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.accessControlName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/appendStructure/AdtAppendStructure.ts
+++ b/src/core/appendStructure/AdtAppendStructure.ts
@@ -59,14 +59,8 @@ export class AdtAppendStructure
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockAppendStructure(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockAppendStructure(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/appendStructure/AdtAppendStructure.ts
+++ b/src/core/appendStructure/AdtAppendStructure.ts
@@ -11,6 +11,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateAppendStructure } from './activation';
 import { checkAppendStructure } from './check';
@@ -39,16 +44,30 @@ export class AdtAppendStructure
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'AppendStructure';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockAppendStructure(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   async validate(
@@ -194,6 +213,7 @@ export class AdtAppendStructure
         this.connection,
         config.appendStructureName,
       );
+      this.lockTracker.track(config.appendStructureName, lockHandle);
 
       const codeToCheck = options?.sourceCode || config.sourceCode;
       if (codeToCheck) {
@@ -237,6 +257,7 @@ export class AdtAppendStructure
         } finally {
           this.connection.setSessionType('stateless');
         }
+        this.lockTracker.untrack(config.appendStructureName);
         lockHandle = undefined;
       }
 
@@ -280,6 +301,7 @@ export class AdtAppendStructure
             config.appendStructureName,
             lockHandle,
           );
+          this.lockTracker.untrack(config.appendStructureName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -361,7 +383,12 @@ export class AdtAppendStructure
     if (!config.appendStructureName)
       throw new Error('Append structure name is required');
     this.connection.setSessionType('stateful');
-    return lockAppendStructure(this.connection, config.appendStructureName);
+    const lockHandle = await lockAppendStructure(
+      this.connection,
+      config.appendStructureName,
+    );
+    this.lockTracker.track(config.appendStructureName, lockHandle);
+    return lockHandle;
   }
 
   async unlock(
@@ -377,6 +404,7 @@ export class AdtAppendStructure
         config.appendStructureName,
         lockHandle,
       );
+      this.lockTracker.untrack(config.appendStructureName);
       return { unlockResult, errors: [] };
     } finally {
       this.connection.setSessionType('stateless');

--- a/src/core/authorizationField/AdtAuthorizationField.ts
+++ b/src/core/authorizationField/AdtAuthorizationField.ts
@@ -70,14 +70,8 @@ export class AdtAuthorizationField
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockAuthorizationField(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockAuthorizationField(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/authorizationField/AdtAuthorizationField.ts
+++ b/src/core/authorizationField/AdtAuthorizationField.ts
@@ -25,6 +25,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import { throwUnsupportedVersions } from '../shared/versions';
 import { activateAuthorizationField } from './activation';
 import { checkAuthorizationField } from './check';
@@ -50,16 +55,30 @@ export class AdtAuthorizationField
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'AuthorizationField';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockAuthorizationField(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -310,6 +329,7 @@ export class AdtAuthorizationField
         this.logger,
       );
       state.lockHandle = lockHandle;
+      this.lockTracker.track(fullConfig.authorizationFieldName, lockHandle);
       fullConfig.onLock?.(lockHandle);
       this.logger?.info?.('Authorization field locked, handle:', lockHandle);
 
@@ -364,6 +384,7 @@ export class AdtAuthorizationField
         lockHandle,
       );
       this.connection.setSessionType('stateless');
+      this.lockTracker.untrack(fullConfig.authorizationFieldName);
       lockHandle = undefined;
       this.logger?.info?.('Authorization field unlocked');
 
@@ -431,6 +452,7 @@ export class AdtAuthorizationField
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(fullConfig.authorizationFieldName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -573,6 +595,7 @@ export class AdtAuthorizationField
       config.authorizationFieldName,
       this.logger,
     );
+    this.lockTracker.track(config.authorizationFieldName, lockHandle);
     return lockHandle;
   }
 
@@ -594,6 +617,7 @@ export class AdtAuthorizationField
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.authorizationFieldName);
     return { errors: [] };
   }
 

--- a/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
+++ b/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activate } from './activation';
 import { check as checkBehaviorDefinition } from './check';
@@ -56,16 +61,30 @@ export class AdtBehaviorDefinition
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'BehaviorDefinition';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlock(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -365,6 +384,7 @@ export class AdtBehaviorDefinition
       this.connection.setSessionType('stateful');
       lockHandle = await lock(this.connection, config.name);
       state.lockHandle = lockHandle;
+      this.lockTracker.track(config.name, lockHandle);
       this.logger?.info?.('Behavior definition locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -424,6 +444,7 @@ export class AdtBehaviorDefinition
         );
         state.unlockResult = unlockResponse;
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.name);
         lockHandle = undefined;
         this.logger?.info?.('Behavior definition unlocked');
       }
@@ -489,6 +510,7 @@ export class AdtBehaviorDefinition
           this.connection.setSessionType('stateful');
           await unlock(this.connection, config.name, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.name);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -638,6 +660,7 @@ export class AdtBehaviorDefinition
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lock(this.connection, config.name);
+    this.lockTracker.track(config.name, lockHandle);
     return lockHandle;
   }
 
@@ -655,6 +678,7 @@ export class AdtBehaviorDefinition
     this.connection.setSessionType('stateful');
     const result = await unlock(this.connection, config.name, lockHandle);
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.name);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
+++ b/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
@@ -76,14 +76,7 @@ export class AdtBehaviorDefinition
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlock(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) => unlock(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
+++ b/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
@@ -34,6 +34,7 @@ import { safeErrorMessage } from '../../utils/internalUtils';
 import { getSystemInformation } from '../../utils/systemInfo';
 import { AdtClass } from '../class';
 import { updateClass } from '../class/update';
+import type { LockRegistry } from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import {
   getBehaviorImplementationMetadata,
@@ -60,10 +61,22 @@ export class AdtBehaviorImplementation
   private readonly class: AdtClass;
   public readonly objectType: string = 'BehaviorImplementation';
 
-  constructor(connection: IAbapConnection, logger?: ILogger) {
+  constructor(
+    connection: IAbapConnection,
+    logger?: ILogger,
+    lockRegistry?: LockRegistry,
+  ) {
     this.connection = connection;
     this.logger = logger;
-    this.class = new AdtClass(connection, logger);
+    // Behavior implementation locks are class locks delegated to this internal
+    // AdtClass — pass the session registry so those locks are tracked too.
+    this.class = new AdtClass(
+      connection,
+      logger,
+      undefined,
+      undefined,
+      lockRegistry,
+    );
   }
 
   /**

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -31,6 +31,11 @@ import {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage, safeStringify } from '../../utils/internalUtils';
 import type { IAdtContentTypes } from '../shared/contentTypes';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateClass } from './activation';
 import { checkClass, checkClassLocalTestClass } from './check';
@@ -57,6 +62,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
   protected readonly contentTypes?: IAdtContentTypes;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Class';
 
   constructor(
@@ -64,11 +70,24 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
     contentTypes?: IAdtContentTypes,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
     this.contentTypes = contentTypes;
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (className, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockClass(this.connection, className, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -349,6 +368,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
       this.connection.setSessionType('stateful');
       lockHandle = await lockClass(this.connection, config.className);
       state.lockHandle = lockHandle;
+      this.lockTracker.track(config.className, lockHandle);
       this.logger?.info?.('Class locked, handle:', lockHandle);
 
       // 2. Check inactive with code/xml for update (from options or config)
@@ -406,6 +426,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.className);
         lockHandle = undefined;
         this.logger?.info?.('Class unlocked');
       }
@@ -459,6 +480,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
           this.connection.setSessionType('stateful');
           await unlockClass(this.connection, config.className, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.className);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -703,7 +725,9 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
     // is only valid inside stateful requests, so a stateless write between lock
     // and unlock fails with 423.
     this.connection.setSessionType('stateful');
-    return await lockClass(this.connection, config.className);
+    const lockHandle = await lockClass(this.connection, config.className);
+    this.lockTracker.track(config.className, lockHandle);
+    return lockHandle;
   }
 
   /**
@@ -723,6 +747,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.className);
     return {
       unlockResult: result,
       errors: [],
@@ -808,6 +833,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
       this.logger?.info?.('Step 1: Locking parent class');
       this.connection.setSessionType('stateful');
       lockHandle = await lockClass(this.connection, config.className);
+      this.lockTracker.track(config.className, lockHandle);
       this.logger?.info?.('Parent class locked, handle:', lockHandle);
 
       // 2. Update test classes (uses parent class lock handle)
@@ -826,6 +852,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
       this.connection.setSessionType('stateful');
       await unlockClass(this.connection, config.className, lockHandle);
       this.connection.setSessionType('stateless');
+      this.lockTracker.untrack(config.className);
       lockHandle = undefined;
 
       return response;
@@ -837,6 +864,7 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
           this.connection.setSessionType('stateful');
           await unlockClass(this.connection, config.className, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.className);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock parent class after error:',

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -79,14 +79,8 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (className, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockClass(this.connection, className, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (className, lockHandle) =>
+        unlockClass(this.connection, className, lockHandle),
     );
   }
 

--- a/src/core/dataElement/AdtDataElement.ts
+++ b/src/core/dataElement/AdtDataElement.ts
@@ -66,14 +66,8 @@ export class AdtDataElement
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockDataElement(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockDataElement(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/dataElement/AdtDataElement.ts
+++ b/src/core/dataElement/AdtDataElement.ts
@@ -28,6 +28,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { throwUnsupportedVersions } from '../shared/versions';
 import { activateDataElement } from './activation';
@@ -46,16 +51,30 @@ export class AdtDataElement
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'DataElement';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockDataElement(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -322,6 +341,7 @@ export class AdtDataElement
         config.dataElementName,
       );
       state.lockHandle = lockHandle;
+      this.lockTracker.track(config.dataElementName, lockHandle);
       this.logger?.info?.('Data element locked, handle:', lockHandle);
 
       // 2. Check inactive with XML for update (if provided)
@@ -398,6 +418,7 @@ export class AdtDataElement
         );
         state.unlockResult = unlockResponse;
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.dataElementName);
         lockHandle = undefined;
         this.logger?.info?.('Data element unlocked');
       }
@@ -467,6 +488,7 @@ export class AdtDataElement
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.dataElementName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -651,6 +673,7 @@ export class AdtDataElement
       this.connection,
       config.dataElementName,
     );
+    this.lockTracker.track(config.dataElementName, lockHandle);
     return lockHandle;
   }
 
@@ -672,6 +695,7 @@ export class AdtDataElement
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.dataElementName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/ddl/AdtDdl.ts
+++ b/src/core/ddl/AdtDdl.ts
@@ -67,14 +67,7 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (ddlName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockDDLS(this.connection, ddlName, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (ddlName, lockHandle) => unlockDDLS(this.connection, ddlName, lockHandle),
     );
   }
 

--- a/src/core/ddl/AdtDdl.ts
+++ b/src/core/ddl/AdtDdl.ts
@@ -30,6 +30,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateDDLS } from './activation';
 import { checkDdl } from './check';
@@ -47,16 +52,30 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'View';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (ddlName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockDDLS(this.connection, ddlName, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -309,6 +328,7 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
       this.logger?.info?.('Step 1: Locking view');
       this.connection.setSessionType('stateful');
       lockHandle = await lockDDLS(this.connection, config.ddlName);
+      this.lockTracker.track(config.ddlName, lockHandle);
       this.logger?.info?.('View locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -361,6 +381,7 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
         this.connection.setSessionType('stateful');
         await unlockDDLS(this.connection, config.ddlName, lockHandle);
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.ddlName);
         lockHandle = undefined;
         this.logger?.info?.('View unlocked');
       }
@@ -436,6 +457,7 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
           this.connection.setSessionType('stateful');
           await unlockDDLS(this.connection, config.ddlName, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.ddlName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -562,6 +584,7 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lockDDLS(this.connection, config.ddlName);
+    this.lockTracker.track(config.ddlName, lockHandle);
     return lockHandle;
   }
 
@@ -583,6 +606,7 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.ddlName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -28,6 +28,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { throwUnsupportedVersions } from '../shared/versions';
 import { activateDomain } from './activation';
@@ -44,16 +49,30 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Domain';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (domainName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockDomain(this.connection, domainName, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -292,6 +311,7 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
       this.connection.setSessionType('stateful');
       lockHandle = await lockDomain(this.connection, config.domainName);
       state.lockHandle = lockHandle;
+      this.lockTracker.track(config.domainName, lockHandle);
       this.logger?.info?.('locked');
 
       // 2. Check inactive with XML for update (if provided)
@@ -362,6 +382,7 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
         );
         state.unlockResult = unlockResponse;
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.domainName);
         lockHandle = undefined;
         this.logger?.info?.('unlocked');
       }
@@ -425,7 +446,10 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
           this.connection.setSessionType('stateful');
           await unlockDomain(this.connection, config.domainName, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.domainName);
         } catch (unlockError) {
+          // Cleanup unlock failed — the lock stays tracked so unlockAll() (or
+          // session-drop) remains the last resort.
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
             safeErrorMessage(unlockError),
@@ -602,6 +626,7 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lockDomain(this.connection, config.domainName);
+    this.lockTracker.track(config.domainName, lockHandle);
     return lockHandle;
   }
 
@@ -623,6 +648,7 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.domainName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -64,14 +64,8 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (domainName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockDomain(this.connection, domainName, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (domainName, lockHandle) =>
+        unlockDomain(this.connection, domainName, lockHandle),
     );
   }
 

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -34,6 +34,7 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import type { LockRegistry } from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateEnhancement } from './activation';
 import { check as checkEnhancement } from './check';
@@ -46,6 +47,7 @@ import {
   getEnhancementTransport,
 } from './read';
 import {
+  type EnhancementType,
   type IEnhancementConfig,
   type IEnhancementState,
   supportsSourceCode,
@@ -64,16 +66,50 @@ export class AdtEnhancement
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockRegistry?: LockRegistry;
   public readonly objectType: string = 'Enhancement';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockRegistry = lockRegistry;
+  }
+
+  /** Registry key for a held enhancement lock (e.g. `Enhancement/ZFOO`). */
+  private lockKey(name: string): string {
+    return `${this.objectType}/${name.toUpperCase()}`;
+  }
+
+  /**
+   * Record a held lock. Enhancement unlock needs the enhancement type, so the
+   * unlock thunk captures it alongside the name and handle.
+   */
+  private trackLock(
+    type: EnhancementType | undefined,
+    name: string | undefined,
+    lockHandle: string,
+  ): void {
+    if (!type || !name) return;
+    this.lockRegistry?.track(this.lockKey(name), async () => {
+      this.connection.setSessionType('stateful');
+      try {
+        await unlockEnhancement(this.connection, type, name, lockHandle);
+      } finally {
+        this.connection.setSessionType('stateless');
+      }
+    });
+  }
+
+  /** Drop a lock from the registry after a clean unlock. */
+  private untrackLock(name: string | undefined): void {
+    if (!name) return;
+    this.lockRegistry?.untrack(this.lockKey(name));
   }
 
   /**
@@ -441,6 +477,11 @@ export class AdtEnhancement
         config.enhancementName,
       );
       state.lockHandle = lockHandle;
+      this.trackLock(
+        config.enhancementType,
+        config.enhancementName,
+        lockHandle,
+      );
       this.logger?.info?.('Enhancement locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -509,6 +550,7 @@ export class AdtEnhancement
         );
         state.unlockResult = unlockResponse;
         this.connection.setSessionType('stateless');
+        this.untrackLock(config.enhancementName);
         lockHandle = undefined;
         this.logger?.info?.('Enhancement unlocked');
       }
@@ -582,6 +624,7 @@ export class AdtEnhancement
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.untrackLock(config.enhancementName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -770,6 +813,7 @@ export class AdtEnhancement
       config.enhancementType,
       config.enhancementName,
     );
+    this.trackLock(config.enhancementType, config.enhancementName, lockHandle);
     return lockHandle;
   }
 
@@ -792,6 +836,7 @@ export class AdtEnhancement
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.untrackLock(config.enhancementName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -96,14 +96,10 @@ export class AdtEnhancement
     lockHandle: string,
   ): void {
     if (!type || !name) return;
-    this.lockRegistry?.track(this.lockKey(name), async () => {
-      this.connection.setSessionType('stateful');
-      try {
-        await unlockEnhancement(this.connection, type, name, lockHandle);
-      } finally {
-        this.connection.setSessionType('stateless');
-      }
-    });
+    // Raw unlock — LockRegistry.unlockAll() manages the session for the batch.
+    this.lockRegistry?.track(this.lockKey(name), () =>
+      unlockEnhancement(this.connection, type, name, lockHandle),
+    );
   }
 
   /** Drop a lock from the registry after a clean unlock. */

--- a/src/core/featureToggle/AdtFeatureToggle.ts
+++ b/src/core/featureToggle/AdtFeatureToggle.ts
@@ -28,6 +28,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import { throwUnsupportedVersions } from '../shared/versions';
 import { activateFeatureToggle } from './activation';
 import { checkFeatureToggle } from './check';
@@ -55,16 +60,34 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'FeatureToggle';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (featureToggleName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockFeatureToggle(
+            this.connection,
+            featureToggleName,
+            lockHandle,
+          );
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -161,6 +184,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
           this.logger,
         );
         state.lockHandle = lockHandle;
+        this.lockTracker.track(config.featureToggleName, lockHandle);
         config.onLock?.(lockHandle);
         this.logger?.info?.('Feature toggle locked, handle:', lockHandle);
 
@@ -182,6 +206,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.featureToggleName);
         lockHandle = undefined;
         this.logger?.info?.('Feature toggle unlocked');
 
@@ -211,6 +236,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
             config.featureToggleName,
             lockHandle,
           );
+          this.lockTracker.untrack(config.featureToggleName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -385,6 +411,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
         this.logger,
       );
       state.lockHandle = lockHandle;
+      this.lockTracker.track(fullConfig.featureToggleName, lockHandle);
       fullConfig.onLock?.(lockHandle);
       this.logger?.info?.('Feature toggle locked, handle:', lockHandle);
 
@@ -455,6 +482,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
         lockHandle,
       );
       this.connection.setSessionType('stateless');
+      this.lockTracker.untrack(fullConfig.featureToggleName);
       lockHandle = undefined;
       this.logger?.info?.('Feature toggle unlocked');
 
@@ -513,6 +541,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(fullConfig.featureToggleName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -663,6 +692,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
       config.featureToggleName,
       this.logger,
     );
+    this.lockTracker.track(config.featureToggleName, lockHandle);
     return lockHandle;
   }
 
@@ -684,6 +714,7 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.featureToggleName);
     return { errors: [] };
   }
 

--- a/src/core/featureToggle/AdtFeatureToggle.ts
+++ b/src/core/featureToggle/AdtFeatureToggle.ts
@@ -75,18 +75,8 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (featureToggleName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockFeatureToggle(
-            this.connection,
-            featureToggleName,
-            lockHandle,
-          );
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (featureToggleName, lockHandle) =>
+        unlockFeatureToggle(this.connection, featureToggleName, lockHandle),
     );
   }
 

--- a/src/core/functionGroup/AdtFunctionGroup.ts
+++ b/src/core/functionGroup/AdtFunctionGroup.ts
@@ -72,18 +72,8 @@ export class AdtFunctionGroup
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (functionGroupName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockFunctionGroup(
-            this.connection,
-            functionGroupName,
-            lockHandle,
-          );
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (functionGroupName, lockHandle) =>
+        unlockFunctionGroup(this.connection, functionGroupName, lockHandle),
     );
   }
 

--- a/src/core/functionGroup/AdtFunctionGroup.ts
+++ b/src/core/functionGroup/AdtFunctionGroup.ts
@@ -32,6 +32,11 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IAdtContentTypes } from '../shared/contentTypes';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { throwUnsupportedVersions } from '../shared/versions';
 import { activateFunctionGroup } from './activation';
@@ -50,6 +55,7 @@ export class AdtFunctionGroup
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
   protected readonly contentTypes?: IAdtContentTypes;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'FunctionGroup';
 
   constructor(
@@ -57,11 +63,28 @@ export class AdtFunctionGroup
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
     contentTypes?: IAdtContentTypes,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
     this.contentTypes = contentTypes;
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (functionGroupName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockFunctionGroup(
+            this.connection,
+            functionGroupName,
+            lockHandle,
+          );
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -479,6 +502,7 @@ export class AdtFunctionGroup
         config.functionGroupName,
         sessionId,
       );
+      this.lockTracker.track(config.functionGroupName, lockHandle);
       this.logger?.info?.('Function group locked, handle:', lockHandle);
 
       // 2. Update metadata (description)
@@ -523,6 +547,7 @@ export class AdtFunctionGroup
           sessionId,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.functionGroupName);
         lockHandle = undefined;
         this.logger?.info?.('Function group unlocked');
       }
@@ -599,6 +624,7 @@ export class AdtFunctionGroup
             sessionId,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.functionGroupName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -725,6 +751,7 @@ export class AdtFunctionGroup
       this.connection,
       config.functionGroupName,
     );
+    this.lockTracker.track(config.functionGroupName, lockHandle);
     return lockHandle;
   }
 
@@ -746,6 +773,7 @@ export class AdtFunctionGroup
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.functionGroupName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -25,6 +25,7 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IAdtContentTypes } from '../shared/contentTypes';
+import type { LockRegistry } from '../shared/LockRegistry';
 import { activateFunctionInclude } from './activation';
 import { checkFunctionInclude } from './check';
 import { create as createFunctionInclude } from './create';
@@ -57,6 +58,7 @@ export class AdtFunctionInclude
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
   protected readonly contentTypes?: IAdtContentTypes;
+  private readonly lockRegistry?: LockRegistry;
   public readonly objectType: string = 'FunctionInclude';
 
   constructor(
@@ -64,11 +66,49 @@ export class AdtFunctionInclude
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
     contentTypes?: IAdtContentTypes,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
     this.contentTypes = contentTypes;
+    this.lockRegistry = lockRegistry;
+  }
+
+  /** Registry key for a held lock (nested: group + include). */
+  private lockKey(group: string, includeName: string): string {
+    return `${this.objectType}/${group.toUpperCase()}/${includeName.toUpperCase()}`;
+  }
+
+  /** Record a held lock; the unlock thunk needs the parent function group. */
+  private trackLock(
+    group: string | undefined,
+    includeName: string | undefined,
+    lockHandle: string,
+  ): void {
+    if (!group || !includeName) return;
+    this.lockRegistry?.track(this.lockKey(group, includeName), async () => {
+      this.connection.setSessionType('stateful');
+      try {
+        await unlockFunctionInclude(
+          this.connection,
+          group,
+          includeName,
+          lockHandle,
+        );
+      } finally {
+        this.connection.setSessionType('stateless');
+      }
+    });
+  }
+
+  /** Drop a lock from the registry after a clean unlock. */
+  private untrackLock(
+    group: string | undefined,
+    includeName: string | undefined,
+  ): void {
+    if (!group || !includeName) return;
+    this.lockRegistry?.untrack(this.lockKey(group, includeName));
   }
 
   /**
@@ -190,6 +230,11 @@ export class AdtFunctionInclude
           config.includeName,
           this.logger,
         );
+        this.trackLock(
+          config.functionGroupName,
+          config.includeName,
+          lockHandle,
+        );
         state.lockHandle = lockHandle;
         config.onLock?.(lockHandle);
 
@@ -213,6 +258,7 @@ export class AdtFunctionInclude
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.untrackLock(config.functionGroupName, config.includeName);
         lockHandle = undefined;
 
         this.logger?.info?.('Step 5: Activating function include');
@@ -240,6 +286,7 @@ export class AdtFunctionInclude
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.untrackLock(config.functionGroupName, config.includeName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -475,6 +522,11 @@ export class AdtFunctionInclude
         this.logger,
       );
       state.lockHandle = lockHandle;
+      this.trackLock(
+        fullConfig.functionGroupName,
+        fullConfig.includeName,
+        lockHandle,
+      );
       fullConfig.onLock?.(lockHandle);
       this.logger?.info?.('Function include locked, handle:', lockHandle);
 
@@ -548,6 +600,7 @@ export class AdtFunctionInclude
         lockHandle,
       );
       this.connection.setSessionType('stateless');
+      this.untrackLock(fullConfig.functionGroupName, fullConfig.includeName);
       lockHandle = undefined;
 
       // 5. Final check
@@ -613,6 +666,10 @@ export class AdtFunctionInclude
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.untrackLock(
+            fullConfig.functionGroupName,
+            fullConfig.includeName,
+          );
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -764,6 +821,7 @@ export class AdtFunctionInclude
       config.includeName,
       this.logger,
     );
+    this.trackLock(config.functionGroupName, config.includeName, lockHandle);
     return lockHandle;
   }
 
@@ -786,6 +844,7 @@ export class AdtFunctionInclude
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.untrackLock(config.functionGroupName, config.includeName);
     return { errors: [] };
   }
 

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -87,19 +87,10 @@ export class AdtFunctionInclude
     lockHandle: string,
   ): void {
     if (!group || !includeName) return;
-    this.lockRegistry?.track(this.lockKey(group, includeName), async () => {
-      this.connection.setSessionType('stateful');
-      try {
-        await unlockFunctionInclude(
-          this.connection,
-          group,
-          includeName,
-          lockHandle,
-        );
-      } finally {
-        this.connection.setSessionType('stateless');
-      }
-    });
+    // Raw unlock — LockRegistry.unlockAll() manages the session for the batch.
+    this.lockRegistry?.track(this.lockKey(group, includeName), () =>
+      unlockFunctionInclude(this.connection, group, includeName, lockHandle),
+    );
   }
 
   /** Drop a lock from the registry after a clean unlock. */

--- a/src/core/functionModule/AdtFunctionModule.ts
+++ b/src/core/functionModule/AdtFunctionModule.ts
@@ -28,6 +28,7 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IAdtContentTypes } from '../shared/contentTypes';
+import type { LockRegistry } from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateFunctionModule } from './activation';
 import { checkFunctionModule } from './check';
@@ -55,6 +56,7 @@ export class AdtFunctionModule
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
   protected readonly contentTypes?: IAdtContentTypes;
+  private readonly lockRegistry?: LockRegistry;
   public readonly objectType: string = 'FunctionModule';
 
   constructor(
@@ -62,11 +64,49 @@ export class AdtFunctionModule
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
     contentTypes?: IAdtContentTypes,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
     this.contentTypes = contentTypes;
+    this.lockRegistry = lockRegistry;
+  }
+
+  /** Registry key for a held lock (nested: group + module). */
+  private lockKey(group: string, moduleName: string): string {
+    return `${this.objectType}/${group.toUpperCase()}/${moduleName.toUpperCase()}`;
+  }
+
+  /** Record a held lock; the unlock thunk needs the parent function group. */
+  private trackLock(
+    group: string | undefined,
+    moduleName: string | undefined,
+    lockHandle: string,
+  ): void {
+    if (!group || !moduleName) return;
+    this.lockRegistry?.track(this.lockKey(group, moduleName), async () => {
+      this.connection.setSessionType('stateful');
+      try {
+        await unlockFunctionModule(
+          this.connection,
+          group,
+          moduleName,
+          lockHandle,
+        );
+      } finally {
+        this.connection.setSessionType('stateless');
+      }
+    });
+  }
+
+  /** Drop a lock from the registry after a clean unlock. */
+  private untrackLock(
+    group: string | undefined,
+    moduleName: string | undefined,
+  ): void {
+    if (!group || !moduleName) return;
+    this.lockRegistry?.untrack(this.lockKey(group, moduleName));
   }
 
   /**
@@ -348,6 +388,11 @@ export class AdtFunctionModule
         config.functionGroupName,
         config.functionModuleName,
       );
+      this.trackLock(
+        config.functionGroupName,
+        config.functionModuleName,
+        lockHandle,
+      );
       this.logger?.info?.('Function module locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -415,6 +460,7 @@ export class AdtFunctionModule
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.untrackLock(config.functionGroupName, config.functionModuleName);
         lockHandle = undefined;
         this.logger?.info?.('Function module unlocked');
       }
@@ -498,6 +544,7 @@ export class AdtFunctionModule
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.untrackLock(config.functionGroupName, config.functionModuleName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -643,6 +690,11 @@ export class AdtFunctionModule
       config.functionGroupName,
       config.functionModuleName,
     );
+    this.trackLock(
+      config.functionGroupName,
+      config.functionModuleName,
+      lockHandle,
+    );
     return lockHandle;
   }
 
@@ -667,6 +719,7 @@ export class AdtFunctionModule
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.untrackLock(config.functionGroupName, config.functionModuleName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/functionModule/AdtFunctionModule.ts
+++ b/src/core/functionModule/AdtFunctionModule.ts
@@ -85,19 +85,10 @@ export class AdtFunctionModule
     lockHandle: string,
   ): void {
     if (!group || !moduleName) return;
-    this.lockRegistry?.track(this.lockKey(group, moduleName), async () => {
-      this.connection.setSessionType('stateful');
-      try {
-        await unlockFunctionModule(
-          this.connection,
-          group,
-          moduleName,
-          lockHandle,
-        );
-      } finally {
-        this.connection.setSessionType('stateless');
-      }
-    });
+    // Raw unlock — LockRegistry.unlockAll() manages the session for the batch.
+    this.lockRegistry?.track(this.lockKey(group, moduleName), () =>
+      unlockFunctionModule(this.connection, group, moduleName, lockHandle),
+    );
   }
 
   /** Drop a lock from the registry after a clean unlock. */

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -28,6 +28,11 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import type { IAdtContentTypes } from '../shared/contentTypes';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateInterface } from './activation';
 import { checkInterface } from './check';
@@ -52,6 +57,7 @@ export class AdtInterface
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
   protected readonly contentTypes?: IAdtContentTypes;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Interface';
 
   constructor(
@@ -59,11 +65,24 @@ export class AdtInterface
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
     contentTypes?: IAdtContentTypes,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
     this.contentTypes = contentTypes;
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (interfaceName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockInterface(this.connection, interfaceName, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -280,6 +299,7 @@ export class AdtInterface
       );
       lockHandle = lockResult.lockHandle;
       state.lockHandle = lockHandle;
+      this.lockTracker.track(config.interfaceName, lockHandle);
       this.logger?.info?.('Interface locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -340,6 +360,7 @@ export class AdtInterface
         );
         state.unlockResult = unlockResponse;
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.interfaceName);
         lockHandle = undefined;
         this.logger?.info?.('Interface unlocked');
       }
@@ -411,6 +432,7 @@ export class AdtInterface
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.interfaceName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -594,6 +616,7 @@ export class AdtInterface
 
     this.connection.setSessionType('stateful');
     const result = await lockInterface(this.connection, config.interfaceName);
+    this.lockTracker.track(config.interfaceName, result.lockHandle);
     return result.lockHandle;
   }
 
@@ -615,6 +638,7 @@ export class AdtInterface
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.interfaceName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -74,14 +74,8 @@ export class AdtInterface
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (interfaceName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockInterface(this.connection, interfaceName, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (interfaceName, lockHandle) =>
+        unlockInterface(this.connection, interfaceName, lockHandle),
     );
   }
 

--- a/src/core/messageClass/AdtMessageClass.ts
+++ b/src/core/messageClass/AdtMessageClass.ts
@@ -63,14 +63,8 @@ export class AdtMessageClass
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockMessageClass(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockMessageClass(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/messageClass/AdtMessageClass.ts
+++ b/src/core/messageClass/AdtMessageClass.ts
@@ -25,6 +25,11 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import { throwUnsupportedOperation } from '../shared/unsupported';
 import { createMessageClass } from './create';
 import { checkDeletion, deleteMessageClass } from './delete';
@@ -43,16 +48,30 @@ export class AdtMessageClass
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'MessageClass';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockMessageClass(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -171,6 +190,7 @@ export class AdtMessageClass
       this.logger?.info?.('lock');
       this.connection.setSessionType('stateful');
       lockHandle = await lockMessageClass(this.connection, config.name);
+      this.lockTracker.track(config.name, lockHandle);
       this.logger?.info?.('locked');
 
       this.logger?.info?.('update');
@@ -190,6 +210,7 @@ export class AdtMessageClass
         lockHandle,
       );
       this.connection.setSessionType('stateless');
+      this.lockTracker.untrack(config.name);
       lockHandle = undefined;
       this.logger?.info?.('unlocked');
 
@@ -200,6 +221,7 @@ export class AdtMessageClass
         try {
           this.logger?.warn?.('Unlocking message class during error cleanup');
           await unlockMessageClass(this.connection, config.name, lockHandle);
+          this.lockTracker.untrack(config.name);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -286,7 +308,9 @@ export class AdtMessageClass
       throw new Error('Message class name is required');
     }
     this.connection.setSessionType('stateful');
-    return lockMessageClass(this.connection, config.name);
+    const lockHandle = await lockMessageClass(this.connection, config.name);
+    this.lockTracker.track(config.name, lockHandle);
+    return lockHandle;
   }
 
   /**
@@ -305,6 +329,7 @@ export class AdtMessageClass
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.name);
     return { unlockResult, errors: [] };
   }
 

--- a/src/core/metadataExtension/AdtMetadataExtension.ts
+++ b/src/core/metadataExtension/AdtMetadataExtension.ts
@@ -76,14 +76,8 @@ export class AdtMetadataExtension
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockMetadataExtension(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockMetadataExtension(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/metadataExtension/AdtMetadataExtension.ts
+++ b/src/core/metadataExtension/AdtMetadataExtension.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateMetadataExtension } from './activate';
 import { checkMetadataExtension } from './check';
@@ -56,16 +61,30 @@ export class AdtMetadataExtension
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'MetadataExtension';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockMetadataExtension(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -316,6 +335,7 @@ export class AdtMetadataExtension
       this.logger?.info?.('Step 1: Locking metadata extension');
       this.connection.setSessionType('stateful');
       lockHandle = await lockMetadataExtension(this.connection, config.name);
+      this.lockTracker.track(config.name, lockHandle);
       this.logger?.info?.('Metadata extension locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -367,6 +387,7 @@ export class AdtMetadataExtension
         this.connection.setSessionType('stateful');
         await unlockMetadataExtension(this.connection, config.name, lockHandle);
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.name);
         lockHandle = undefined;
         this.logger?.info?.('Metadata extension unlocked');
       }
@@ -437,6 +458,7 @@ export class AdtMetadataExtension
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.name);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -583,6 +605,7 @@ export class AdtMetadataExtension
       this.connection,
       config.name,
     );
+    this.lockTracker.track(config.name, lockHandle);
     return lockHandle;
   }
 
@@ -604,6 +627,7 @@ export class AdtMetadataExtension
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.name);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/package/AdtPackage.ts
+++ b/src/core/package/AdtPackage.ts
@@ -66,14 +66,8 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (packageName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockPackage(this.connection, packageName, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (packageName, lockHandle) =>
+        unlockPackage(this.connection, packageName, lockHandle),
     );
   }
 

--- a/src/core/package/AdtPackage.ts
+++ b/src/core/package/AdtPackage.ts
@@ -31,6 +31,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { throwUnsupportedVersions } from '../shared/versions';
 import { checkPackage } from './check';
@@ -46,16 +51,30 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Package';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (packageName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockPackage(this.connection, packageName, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -381,6 +400,7 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
       const lockResult = await lockPackage(this.connection, config.packageName);
       lockHandle = lockResult.lockHandle;
       lockCorrNr = lockResult.corrNr;
+      this.lockTracker.track(config.packageName, lockHandle);
       this.logger?.info?.(
         `Package locked, handle: ${lockHandle}, corrNr: ${lockCorrNr}`,
       );
@@ -448,6 +468,7 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
         this.connection.setSessionType('stateful');
         await unlockPackage(this.connection, config.packageName, lockHandle);
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.packageName);
         lockHandle = undefined;
         this.logger?.info?.('Package unlocked');
       }
@@ -471,6 +492,7 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
           this.connection.setSessionType('stateful');
           await unlockPackage(this.connection, config.packageName, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.packageName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -579,6 +601,7 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
 
     this.connection.setSessionType('stateful');
     const lockResult = await lockPackage(this.connection, config.packageName);
+    this.lockTracker.track(config.packageName, lockResult.lockHandle);
     return lockResult.lockHandle;
   }
 
@@ -600,6 +623,7 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.packageName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -28,6 +28,11 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage, safeStringify } from '../../utils/internalUtils';
 import type { IAdtContentTypes } from '../shared/contentTypes';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateProgram } from './activation';
 import { checkProgram } from './check';
@@ -50,6 +55,7 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
   protected readonly contentTypes?: IAdtContentTypes;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Program';
 
   constructor(
@@ -57,11 +63,24 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
     contentTypes?: IAdtContentTypes,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
     this.contentTypes = contentTypes;
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (programName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockProgram(this.connection, programName, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -300,6 +319,7 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
       this.connection.setSessionType('stateful');
       lockHandle = await lockProgram(this.connection, config.programName);
       state.lockHandle = lockHandle;
+      this.lockTracker.track(config.programName, lockHandle);
       this.logger?.info?.('Program locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -360,6 +380,7 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
         );
         state.unlockResult = unlockResponse;
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.programName);
         lockHandle = undefined;
         this.logger?.info?.('Program unlocked');
       }
@@ -417,6 +438,7 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
           this.connection.setSessionType('stateful');
           await unlockProgram(this.connection, config.programName, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.programName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -618,6 +640,7 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
 
     this.connection.setSessionType('stateful');
     const lockHandle = await lockProgram(this.connection, config.programName);
+    this.lockTracker.track(config.programName, lockHandle);
     return lockHandle;
   }
 
@@ -639,6 +662,7 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.programName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -72,14 +72,8 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (programName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockProgram(this.connection, programName, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (programName, lockHandle) =>
+        unlockProgram(this.connection, programName, lockHandle),
     );
   }
 

--- a/src/core/scalarFunction/AdtScalarFunction.ts
+++ b/src/core/scalarFunction/AdtScalarFunction.ts
@@ -59,14 +59,8 @@ export class AdtScalarFunction
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockScalarFunction(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockScalarFunction(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/scalarFunction/AdtScalarFunction.ts
+++ b/src/core/scalarFunction/AdtScalarFunction.ts
@@ -11,6 +11,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateScalarFunction } from './activation';
 import { checkScalarFunction } from './check';
@@ -39,16 +44,30 @@ export class AdtScalarFunction
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'ScalarFunction';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockScalarFunction(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   async validate(
@@ -192,6 +211,7 @@ export class AdtScalarFunction
         this.connection,
         config.scalarFunctionName,
       );
+      this.lockTracker.track(config.scalarFunctionName, lockHandle);
 
       const codeToCheck = options?.sourceCode || config.sourceCode;
       if (codeToCheck) {
@@ -235,6 +255,7 @@ export class AdtScalarFunction
         } finally {
           this.connection.setSessionType('stateless');
         }
+        this.lockTracker.untrack(config.scalarFunctionName);
         lockHandle = undefined;
       }
 
@@ -278,6 +299,7 @@ export class AdtScalarFunction
             config.scalarFunctionName,
             lockHandle,
           );
+          this.lockTracker.untrack(config.scalarFunctionName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -359,7 +381,12 @@ export class AdtScalarFunction
     if (!config.scalarFunctionName)
       throw new Error('Scalar function name is required');
     this.connection.setSessionType('stateful');
-    return lockScalarFunction(this.connection, config.scalarFunctionName);
+    const lockHandle = await lockScalarFunction(
+      this.connection,
+      config.scalarFunctionName,
+    );
+    this.lockTracker.track(config.scalarFunctionName, lockHandle);
+    return lockHandle;
   }
 
   async unlock(
@@ -375,6 +402,7 @@ export class AdtScalarFunction
         config.scalarFunctionName,
         lockHandle,
       );
+      this.lockTracker.untrack(config.scalarFunctionName);
       return { unlockResult, errors: [] };
     } finally {
       this.connection.setSessionType('stateless');

--- a/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
+++ b/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
@@ -11,6 +11,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateScalarFunctionImplementation } from './activation';
 import { checkScalarFunctionImplementation } from './check';
@@ -47,16 +52,34 @@ export class AdtScalarFunctionImplementation
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'ScalarFunctionImplementation';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockScalarFunctionImplementation(
+            this.connection,
+            name,
+            lockHandle,
+          );
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   async validate(
@@ -211,6 +234,7 @@ export class AdtScalarFunctionImplementation
         this.connection,
         config.implementationName,
       );
+      this.lockTracker.track(config.implementationName, lockHandle);
       const updateResult = await updateScalarFunctionImplementation(
         this.connection,
         {
@@ -225,6 +249,7 @@ export class AdtScalarFunctionImplementation
         config.implementationName,
         lockHandle,
       );
+      this.lockTracker.untrack(config.implementationName);
       lockHandle = undefined;
       return { updateResult, errors: [] };
     } catch (error) {
@@ -235,6 +260,7 @@ export class AdtScalarFunctionImplementation
             config.implementationName,
             lockHandle,
           );
+          this.lockTracker.untrack(config.implementationName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -284,6 +310,7 @@ export class AdtScalarFunctionImplementation
         this.connection,
         config.implementationName,
       );
+      this.lockTracker.track(config.implementationName, lockHandle);
       const updateResult = await updateScalarFunctionImplementationMetadata(
         this.connection,
         {
@@ -298,6 +325,7 @@ export class AdtScalarFunctionImplementation
         config.implementationName,
         lockHandle,
       );
+      this.lockTracker.untrack(config.implementationName);
       lockHandle = undefined;
       return { updateResult, errors: [] };
     } catch (error) {
@@ -308,6 +336,7 @@ export class AdtScalarFunctionImplementation
             config.implementationName,
             lockHandle,
           );
+          this.lockTracker.untrack(config.implementationName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -379,10 +408,12 @@ export class AdtScalarFunctionImplementation
     if (!config.implementationName)
       throw new Error('Implementation name is required');
     this.connection.setSessionType('stateful');
-    return lockScalarFunctionImplementation(
+    const lockHandle = await lockScalarFunctionImplementation(
       this.connection,
       config.implementationName,
     );
+    this.lockTracker.track(config.implementationName, lockHandle);
+    return lockHandle;
   }
 
   async unlock(
@@ -398,6 +429,7 @@ export class AdtScalarFunctionImplementation
         config.implementationName,
         lockHandle,
       );
+      this.lockTracker.untrack(config.implementationName);
       return { unlockResult, errors: [] };
     } finally {
       this.connection.setSessionType('stateless');

--- a/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
+++ b/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
@@ -67,18 +67,8 @@ export class AdtScalarFunctionImplementation
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockScalarFunctionImplementation(
-            this.connection,
-            name,
-            lockHandle,
-          );
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockScalarFunctionImplementation(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -76,14 +76,8 @@ export class AdtServiceDefinition
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockServiceDefinition(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) =>
+        unlockServiceDefinition(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateServiceDefinition } from './activation';
 import { checkServiceDefinition } from './check';
@@ -56,16 +61,30 @@ export class AdtServiceDefinition
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'ServiceDefinition';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockServiceDefinition(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -315,6 +334,7 @@ export class AdtServiceDefinition
         this.connection,
         config.serviceDefinitionName,
       );
+      this.lockTracker.track(config.serviceDefinitionName, lockHandle);
       this.logger?.info?.('Service definition locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -374,6 +394,7 @@ export class AdtServiceDefinition
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.serviceDefinitionName);
         lockHandle = undefined;
         this.logger?.info?.('Service definition unlocked');
       }
@@ -450,6 +471,7 @@ export class AdtServiceDefinition
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.serviceDefinitionName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -586,6 +608,7 @@ export class AdtServiceDefinition
       this.connection,
       config.serviceDefinitionName,
     );
+    this.lockTracker.track(config.serviceDefinitionName, lockHandle);
     return lockHandle;
   }
 
@@ -607,6 +630,7 @@ export class AdtServiceDefinition
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.serviceDefinitionName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/shared/LockRegistry.ts
+++ b/src/core/shared/LockRegistry.ts
@@ -11,8 +11,14 @@
  * interrupting the lock→unlock critical section is the caller's responsibility.
  */
 
-/** Releases a single held lock. Provided by the handler that acquired it. */
-export type UnlockThunk = () => Promise<void>;
+/**
+ * Releases a single held lock. Provided by the handler that acquired it.
+ *
+ * The thunk MUST NOT toggle the connection session type — `unlockAll()` keeps
+ * the session stateful for the whole batch and restores stateless once at the
+ * end (see {@link LockRegistry.unlockAll}).
+ */
+export type UnlockThunk = () => Promise<unknown>;
 
 /** A lock that `unlockAll()` failed to release, kept for reporting / retry. */
 export interface LockFailure {
@@ -20,8 +26,21 @@ export interface LockFailure {
   error: unknown;
 }
 
+/** Minimal session control the registry needs to run an unlock batch. */
+export interface ISessionController {
+  setSessionType(type: 'stateful' | 'stateless'): void;
+}
+
 export class LockRegistry {
   private readonly locks = new Map<string, UnlockThunk>();
+
+  /**
+   * @param session Controls the shared connection's session type. `unlockAll()`
+   *   uses it to keep the session stateful for the whole batch — some
+   *   connections (RFC) clear the stateful cookie when switched to stateless,
+   *   which would invalidate the remaining lock handles mid-batch.
+   */
+  constructor(private readonly session?: ISessionController) {}
 
   /** Record a held lock under a stable object key (e.g. `DOMA/ZFOO`). */
   track(key: string, unlock: UnlockThunk): void {
@@ -41,16 +60,27 @@ export class LockRegistry {
   /**
    * Release every lock still held. Successfully released locks are dropped;
    * locks whose unlock throws are kept and returned as failures.
+   *
+   * The whole batch runs under a single stateful→stateless transition so that a
+   * per-unlock switch to stateless can't clear the session mid-batch and break
+   * the remaining lock handles.
    */
   async unlockAll(): Promise<LockFailure[]> {
     const failures: LockFailure[] = [];
-    for (const [key, unlock] of [...this.locks]) {
-      try {
-        await unlock();
-        this.locks.delete(key);
-      } catch (error) {
-        failures.push({ key, error });
+    if (this.locks.size === 0) return failures;
+
+    this.session?.setSessionType('stateful');
+    try {
+      for (const [key, unlock] of [...this.locks]) {
+        try {
+          await unlock();
+          this.locks.delete(key);
+        } catch (error) {
+          failures.push({ key, error });
+        }
       }
+    } finally {
+      this.session?.setSessionType('stateless');
     }
     return failures;
   }
@@ -73,12 +103,14 @@ export interface LockTracker {
  *
  * @param registry   Session registry to record into (undefined → no-op tracker).
  * @param objectType Stable type prefix for the key (e.g. `Domain`).
- * @param unlock     Releases a held lock; invoked by `unlockAll()` for abandoned locks.
+ * @param unlock     Raw release of a held lock, invoked by `unlockAll()` for
+ *                   abandoned locks. MUST NOT toggle the session type —
+ *                   `unlockAll()` manages the session for the whole batch.
  */
 export function createLockTracker(
   registry: LockRegistry | undefined,
   objectType: string,
-  unlock: (objectName: string, lockHandle: string) => Promise<void>,
+  unlock: (objectName: string, lockHandle: string) => Promise<unknown>,
 ): LockTracker {
   const keyOf = (objectName: string): string =>
     `${objectType}/${objectName.toUpperCase()}`;

--- a/src/core/shared/LockRegistry.ts
+++ b/src/core/shared/LockRegistry.ts
@@ -1,0 +1,93 @@
+/**
+ * Session-scoped registry of held object locks.
+ *
+ * One registry per stateful session (owned by AdtClient). Handlers record a lock
+ * when they acquire it and remove it on a clean unlock. `unlockAll()` is the
+ * last-resort cleanup: it releases any lock still held (e.g. the consumer forgot
+ * to unlock, or a managed flow threw before its unlock), so a session is never
+ * abandoned with dangling enqueue locks.
+ *
+ * This is a safety net, NOT the primary defense. Preventing a timeout from
+ * interrupting the lock→unlock critical section is the caller's responsibility.
+ */
+
+/** Releases a single held lock. Provided by the handler that acquired it. */
+export type UnlockThunk = () => Promise<void>;
+
+/** A lock that `unlockAll()` failed to release, kept for reporting / retry. */
+export interface LockFailure {
+  key: string;
+  error: unknown;
+}
+
+export class LockRegistry {
+  private readonly locks = new Map<string, UnlockThunk>();
+
+  /** Record a held lock under a stable object key (e.g. `DOMA/ZFOO`). */
+  track(key: string, unlock: UnlockThunk): void {
+    this.locks.set(key, unlock);
+  }
+
+  /** Drop a lock after it has been released cleanly. */
+  untrack(key: string): void {
+    this.locks.delete(key);
+  }
+
+  /** Keys of locks still held. */
+  get pending(): string[] {
+    return [...this.locks.keys()];
+  }
+
+  /**
+   * Release every lock still held. Successfully released locks are dropped;
+   * locks whose unlock throws are kept and returned as failures.
+   */
+  async unlockAll(): Promise<LockFailure[]> {
+    const failures: LockFailure[] = [];
+    for (const [key, unlock] of [...this.locks]) {
+      try {
+        await unlock();
+        this.locks.delete(key);
+      } catch (error) {
+        failures.push({ key, error });
+      }
+    }
+    return failures;
+  }
+}
+
+/**
+ * Per-handler view over a {@link LockRegistry}: records/removes locks under a
+ * stable, type-prefixed key. A no-op when no registry is present, so handlers
+ * work unchanged whether or not a registry was injected.
+ */
+export interface LockTracker {
+  /** Record a held lock for `objectName`. */
+  track(objectName: string, lockHandle: string): void;
+  /** Drop the lock for `objectName` after a clean unlock. */
+  untrack(objectName: string): void;
+}
+
+/**
+ * Build a {@link LockTracker} for one object type.
+ *
+ * @param registry   Session registry to record into (undefined → no-op tracker).
+ * @param objectType Stable type prefix for the key (e.g. `Domain`).
+ * @param unlock     Releases a held lock; invoked by `unlockAll()` for abandoned locks.
+ */
+export function createLockTracker(
+  registry: LockRegistry | undefined,
+  objectType: string,
+  unlock: (objectName: string, lockHandle: string) => Promise<void>,
+): LockTracker {
+  const keyOf = (objectName: string): string =>
+    `${objectType}/${objectName.toUpperCase()}`;
+  return {
+    track(objectName, lockHandle) {
+      registry?.track(keyOf(objectName), () => unlock(objectName, lockHandle));
+    },
+    untrack(objectName) {
+      registry?.untrack(keyOf(objectName));
+    },
+  };
+}

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateStructure } from './activation';
 import { checkStructure } from './check';
@@ -50,16 +55,30 @@ export class AdtStructure
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Structure';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockStructure(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -308,6 +327,7 @@ export class AdtStructure
       this.logger?.info?.('Step 1: Locking structure');
       this.connection.setSessionType('stateful');
       lockHandle = await lockStructure(this.connection, config.structureName);
+      this.lockTracker.track(config.structureName, lockHandle);
       this.logger?.info?.('Structure locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -366,6 +386,7 @@ export class AdtStructure
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.structureName);
         lockHandle = undefined;
         this.logger?.info?.('Structure unlocked');
       }
@@ -444,6 +465,7 @@ export class AdtStructure
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.structureName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -574,6 +596,7 @@ export class AdtStructure
       this.connection,
       config.structureName,
     );
+    this.lockTracker.track(config.structureName, lockHandle);
     return lockHandle;
   }
 
@@ -595,6 +618,7 @@ export class AdtStructure
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.structureName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -70,14 +70,7 @@ export class AdtStructure
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockStructure(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) => unlockStructure(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -64,14 +64,7 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockTable(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) => unlockTable(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateTable } from './activation';
 import { runTableCheckRun } from './check';
@@ -44,16 +49,30 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Table';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockTable(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -289,6 +308,7 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
         this.connection,
         config.tableName,
       );
+      this.lockTracker.track(config.tableName, lockHandle);
       this.logger?.info?.('Table locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -343,6 +363,7 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
         this.connection.setSessionType('stateful');
         await unlockTable(this.connection, config.tableName, lockHandle);
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.tableName);
         lockHandle = undefined;
         this.logger?.info?.('Table unlocked');
       }
@@ -416,6 +437,7 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
           this.connection.setSessionType('stateful');
           await unlockTable(this.connection, config.tableName, lockHandle);
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.tableName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -536,6 +558,7 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
       this.connection,
       config.tableName,
     );
+    this.lockTracker.track(config.tableName, lockHandle);
     return lockHandle;
   }
 
@@ -557,6 +580,7 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.tableName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/tabletype/AdtDdicTableType.ts
+++ b/src/core/tabletype/AdtDdicTableType.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateTableType } from './activation';
 import { runTableTypeCheckRun } from './check';
@@ -46,16 +51,30 @@ export class AdtDdicTableType
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'TableType';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (name, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockTableType(this.connection, name, lockHandle);
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -302,6 +321,7 @@ export class AdtDdicTableType
         this.connection,
         config.tableTypeName,
       );
+      this.lockTracker.track(config.tableTypeName, lockHandle);
       this.logger?.info?.('Table type locked, handle:', lockHandle);
 
       // 2. Check inactive (TableType is XML-based, no source code check needed)
@@ -370,6 +390,7 @@ export class AdtDdicTableType
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.tableTypeName);
         lockHandle = undefined;
         this.logger?.info?.('Table type unlocked');
       }
@@ -460,6 +481,7 @@ export class AdtDdicTableType
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.tableTypeName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -583,6 +605,7 @@ export class AdtDdicTableType
       this.connection,
       config.tableTypeName,
     );
+    this.lockTracker.track(config.tableTypeName, lockHandle);
     return lockHandle;
   }
 
@@ -604,6 +627,7 @@ export class AdtDdicTableType
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.tableTypeName);
     return {
       unlockResult: result,
       errors: [],

--- a/src/core/tabletype/AdtDdicTableType.ts
+++ b/src/core/tabletype/AdtDdicTableType.ts
@@ -66,14 +66,7 @@ export class AdtDdicTableType
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (name, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockTableType(this.connection, name, lockHandle);
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (name, lockHandle) => unlockTableType(this.connection, name, lockHandle),
     );
   }
 

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -73,18 +73,8 @@ export class AdtTransformation
     this.lockTracker = createLockTracker(
       lockRegistry,
       this.objectType,
-      async (transformationName, lockHandle) => {
-        this.connection.setSessionType('stateful');
-        try {
-          await unlockTransformation(
-            this.connection,
-            transformationName,
-            lockHandle,
-          );
-        } finally {
-          this.connection.setSessionType('stateless');
-        }
-      },
+      (transformationName, lockHandle) =>
+        unlockTransformation(this.connection, transformationName, lockHandle),
     );
   }
 

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -27,6 +27,11 @@ import type {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
+import {
+  createLockTracker,
+  type LockRegistry,
+  type LockTracker,
+} from '../shared/LockRegistry';
 import type { IReadOptions } from '../shared/types';
 import { activateTransformation } from './activation';
 import { checkTransformation } from './check';
@@ -53,16 +58,34 @@ export class AdtTransformation
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
+  private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Transformation';
 
   constructor(
     connection: IAbapConnection,
     logger?: ILogger,
     systemContext?: IAdtSystemContext,
+    lockRegistry?: LockRegistry,
   ) {
     this.connection = connection;
     this.logger = logger;
     this.systemContext = systemContext ?? {};
+    this.lockTracker = createLockTracker(
+      lockRegistry,
+      this.objectType,
+      async (transformationName, lockHandle) => {
+        this.connection.setSessionType('stateful');
+        try {
+          await unlockTransformation(
+            this.connection,
+            transformationName,
+            lockHandle,
+          );
+        } finally {
+          this.connection.setSessionType('stateless');
+        }
+      },
+    );
   }
 
   /**
@@ -321,6 +344,7 @@ export class AdtTransformation
         this.connection,
         config.transformationName,
       );
+      this.lockTracker.track(config.transformationName, lockHandle);
       this.logger?.info?.('Transformation locked, handle:', lockHandle);
 
       // 2. Check inactive with code for update (from options or config)
@@ -380,6 +404,7 @@ export class AdtTransformation
           lockHandle,
         );
         this.connection.setSessionType('stateless');
+        this.lockTracker.untrack(config.transformationName);
         lockHandle = undefined;
         this.logger?.info?.('Transformation unlocked');
       }
@@ -450,6 +475,7 @@ export class AdtTransformation
             lockHandle,
           );
           this.connection.setSessionType('stateless');
+          this.lockTracker.untrack(config.transformationName);
         } catch (unlockError) {
           this.logger?.warn?.(
             'Failed to unlock during cleanup:',
@@ -586,6 +612,7 @@ export class AdtTransformation
       this.connection,
       config.transformationName,
     );
+    this.lockTracker.track(config.transformationName, lockHandle);
     return lockHandle;
   }
 
@@ -607,6 +634,7 @@ export class AdtTransformation
       lockHandle,
     );
     this.connection.setSessionType('stateless');
+    this.lockTracker.untrack(config.transformationName);
     return {
       unlockResult: result,
       errors: [],


### PR DESCRIPTION
## Summary

Adds a **session-scoped lock registry** owned by `AdtClient` that tracks every enqueue lock held by handlers created from the client. `unlockAll()` — and `await using` via `Symbol.asyncDispose` — releases any lock left dangling in a single call.

This is a **last-resort safety net** for abandoned locks (a forgot-to-unlock, or a managed flow that threw before its unlock). It deliberately does **not** try to make the lock→unlock critical section non-interruptible — preventing a client timeout from interrupting that section is the **caller's** responsibility (policy), while the library provides the mechanism.

### Design (agreed in discussion)
- One `AdtClient` == one stateful session == one registry. All handlers created from that client share it, so `unlockAll()` releases locks across **all** object types at once.
- On crash/kill where no JS hook runs, the ultimate backstop is SAP releasing the session's enqueue locks on session-drop.

## What's included
- **`LockRegistry` + `createLockTracker`** helper (`src/core/shared/LockRegistry.ts`): `track` / `untrack` / `pending` / `unlockAll()` (returns `LockFailure[]`, retains locks whose unlock throws).
- **`AdtClient`**: owns one registry, injects it into every factory, exposes `unlockAll()`, `pendingLocks`, `[Symbol.asyncDispose]`.
- **25 lock-holding handlers wired**: track at lock, untrack at unlock — public `lock()`/`unlock()`, managed `create()`/`update()` flows, and error-cleanup unlock.
  - Nested handlers (`functionModule` / `functionInclude`) use composite keys `Type/group/name` with parent-aware unlock.
  - `enhancement` captures its `enhancementType` in the unlock thunk.
  - **class-includes** (`LocalTestClass/Types/Definitions/Macros`) inherit the wired `AdtClass` lock/unlock; factories forward the registry.
- **NOOP-lock handlers skipped** (`service` / `transport` / `unitTest` / `messageClassMessage`) — their `lock()` throws "not supported".

## Tests
- **Unit** (YAML-driven via `TestConfigResolver`, with progress logging): `LockRegistry.test.ts`, `domainLockRegistry.test.ts` (incl. managed-flow retention when cleanup unlock also fails).
- **Integration** (live-verified on trial): `DomainLockRegistry.test.ts` (final-unlock releases an abandoned lock), `SessionLockRegistry.test.ts` (cross-type: Domain + DataElement locked in one session → `pendingLocks === 2` → `unlockAll()` → `[]`).

## Verification
- `npm run build:fast` ✅ · **310/310 unit tests** ✅ · Biome lint ✅ (only pre-existing `noExplicitAny` warnings) · 2 integration tests green on trial ✅

## Not in scope / follow-ups
- **Version bump + CHANGELOG** not done — this is a minor feature (likely `7.4.0`); awaiting your call on version.
- The "forbid interruption between lock and unlock" primary defense (making the critical-section timeout caller-controlled) is intentionally a **consumer** concern and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)