### PR TITLE
fix(update): poll the inactive version in post-update readiness read

### DIFF
--- a/src/__tests__/unit/core/postUpdateReadinessRead.test.ts
+++ b/src/__tests__/unit/core/postUpdateReadinessRead.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests: post-update readiness read must poll the version just written.
+ *
+ * After update() writes source/metadata under a lock, the object exists only as
+ * the INACTIVE version. Polling the ACTIVE version there is wrong twice over:
+ * for a never-activated object it 404s, and for an existing one it returns the
+ * stale pre-update content. Either way the readiness read is wrapped in
+ * try/catch, so the mistake is swallowed as a warning and never fails a test —
+ * which is exactly why this needs a wire-level assertion.
+ *
+ * A fake IAbapConnection is used because the bug is invisible from the outside:
+ * only the request URL proves which version was polled.
+ *
+ * Object names here are inert placeholders: the fake connection never reaches a
+ * SAP system, and the assertion is on the `version` query parameter, not on the
+ * object. No package/transport/system parameters are involved.
+ */
+
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { AdtAccessControl } from '../../../core/accessControl/AdtAccessControl';
+import { AdtAuthorizationField } from '../../../core/authorizationField/AdtAuthorizationField';
+import { AdtBehaviorDefinition } from '../../../core/behaviorDefinition/AdtBehaviorDefinition';
+import { AdtBehaviorImplementation } from '../../../core/behaviorImplementation/AdtBehaviorImplementation';
+import { AdtClass } from '../../../core/class/AdtClass';
+import { AdtDdl } from '../../../core/ddl/AdtDdl';
+import { AdtEnhancement } from '../../../core/enhancement/AdtEnhancement';
+import { AdtFeatureToggle } from '../../../core/featureToggle/AdtFeatureToggle';
+import { AdtFunctionInclude } from '../../../core/functionInclude/AdtFunctionInclude';
+import { AdtFunctionModule } from '../../../core/functionModule/AdtFunctionModule';
+import { AdtInterface } from '../../../core/interface/AdtInterface';
+import { AdtPackage } from '../../../core/package/AdtPackage';
+import { AdtProgram } from '../../../core/program/AdtProgram';
+import { AdtStructure } from '../../../core/structure/AdtStructure';
+import { AdtTable } from '../../../core/table/AdtTable';
+import { AdtTransformation } from '../../../core/transformation/AdtTransformation';
+import { createTestsLogger } from '../../helpers/testLogger';
+
+const testsLogger: ILogger = createTestsLogger();
+
+const LOCK_XML =
+  '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE></DATA></asx:values></asx:abap>';
+
+const OBJ = 'ZREADINESS';
+
+interface ICall {
+  method?: string;
+  url: string;
+  params?: Record<string, unknown>;
+}
+
+/** Answers LOCK with a handle; everything else 200/empty. */
+function fakeConnection(): { conn: IAbapConnection; calls: ICall[] } {
+  const calls: ICall[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    if (
+      String(req.url).includes('_action=LOCK') ||
+      req.params?._action === 'LOCK'
+    ) {
+      return { status: 200, data: LOCK_XML };
+    }
+    return { status: 200, data: '' };
+  });
+  return {
+    conn: {
+      makeAdtRequest,
+      setSessionType: jest.fn(),
+    } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+/** Superset config — each handler reads only the keys it knows about. */
+const CONFIG: Record<string, unknown> = {
+  accessControlName: OBJ,
+  authorizationFieldName: OBJ,
+  name: OBJ,
+  className: OBJ,
+  ddlName: OBJ,
+  enhancementName: OBJ,
+  enhancementType: 'enhoxhh',
+  featureToggleName: OBJ,
+  functionGroupName: OBJ,
+  includeName: OBJ,
+  functionModuleName: OBJ,
+  interfaceName: OBJ,
+  packageName: OBJ,
+  programName: OBJ,
+  structureName: OBJ,
+  tableName: OBJ,
+  transformationName: OBJ,
+  behaviorDefinition: OBJ,
+  superPackage: OBJ,
+  softwareComponent: 'ZLOCAL',
+  description: 'readiness probe',
+  sourceCode: 'X',
+  xmlContent: '<a/>',
+};
+
+/**
+ * Handlers whose update() emits a readiness read carrying a `version`.
+ * Excluded on purpose — their read() drops the version and polls a
+ * version-less URL, so there is nothing to assert:
+ * metadataExtension, domain, dataElement, functionGroup, tabletype.
+ */
+const MODULES: Array<[string, new (...args: any[]) => any]> = [
+  ['accessControl', AdtAccessControl],
+  ['authorizationField', AdtAuthorizationField],
+  ['behaviorDefinition', AdtBehaviorDefinition],
+  ['behaviorImplementation', AdtBehaviorImplementation],
+  ['class', AdtClass],
+  ['ddl', AdtDdl],
+  ['enhancement', AdtEnhancement],
+  ['featureToggle', AdtFeatureToggle],
+  ['functionInclude', AdtFunctionInclude],
+  ['functionModule', AdtFunctionModule],
+  ['interface', AdtInterface],
+  ['package', AdtPackage],
+  ['program', AdtProgram],
+  ['structure', AdtStructure],
+  ['table', AdtTable],
+  ['transformation', AdtTransformation],
+];
+
+/** Version requested by a call, from the query string or from params. */
+function versionOf(call: ICall): string | undefined {
+  const match = /[?&]version=([^&]+)/.exec(String(call.url));
+  if (match) return match[1];
+  const fromParams = call.params?.version;
+  return fromParams === undefined ? undefined : String(fromParams);
+}
+
+describe('post-update readiness read', () => {
+  it.each(
+    MODULES,
+  )('%s polls the inactive version it just wrote', async (_label, Handler) => {
+    const { conn, calls } = fakeConnection();
+    const handler = new Handler(conn, testsLogger);
+
+    await handler.update({ ...CONFIG }, { sourceCode: 'X' });
+
+    const writeIndex = calls.findIndex((c) => c.method === 'PUT');
+    expect(writeIndex).toBeGreaterThanOrEqual(0);
+
+    // The readiness read is the first version-carrying GET after the write.
+    // (A later GET returns the update result — a separate concern.)
+    const readinessRead = calls
+      .slice(writeIndex + 1)
+      .find((c) => c.method === 'GET' && versionOf(c) !== undefined);
+
+    expect(readinessRead).toBeDefined();
+    // 'workingArea' is the enhancement URI dialect for the inactive version.
+    expect(['inactive', 'workingArea']).toContain(
+      versionOf(readinessRead as ICall),
+    );
+  });
+});

--- a/src/__tests__/unit/core/serviceDefinitionUpdateRead.test.ts
+++ b/src/__tests__/unit/core/serviceDefinitionUpdateRead.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for AdtServiceDefinition.update() readiness polling.
+ *
+ * A fake IAbapConnection is used to observe which version the post-update
+ * readiness read targets. A live system cannot prove this deterministically:
+ * the readiness read is wrapped in try/catch, so a wrong version is swallowed
+ * as a warning and the flow still reports success.
+ *
+ * All object parameters come from test-config.yaml via TestConfigResolver.
+ */
+
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { AdtServiceDefinition } from '../../../core/serviceDefinition/AdtServiceDefinition';
+import { TestConfigResolver } from '../../helpers/TestConfigResolver';
+import { createTestsLogger } from '../../helpers/testLogger';
+import {
+  logTestEnd,
+  logTestStart,
+  logTestSuccess,
+} from '../../helpers/testProgressLogger';
+
+const testsLogger: ILogger = createTestsLogger();
+
+const LOCK_XML =
+  '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>HANDLE123</LOCK_HANDLE></DATA></asx:values></asx:abap>';
+
+/**
+ * Fake connection: answers LOCK with a handle, 404s any read of the active
+ * version (a freshly created service definition has no active version yet),
+ * and answers everything else with 200/empty.
+ */
+function fakeConnection(): { conn: IAbapConnection; calls: any[] } {
+  const calls: any[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    const url = String(req.url);
+    if (url.includes('_action=LOCK')) {
+      return { status: 200, data: LOCK_XML };
+    }
+    if (req.method === 'GET' && url.includes('version=active')) {
+      const error: any = new Error('Not Found');
+      error.response = { status: 404, data: '' };
+      throw error;
+    }
+    return { status: 200, data: '' };
+  });
+  const setSessionType = jest.fn();
+  return {
+    conn: { makeAdtRequest, setSessionType } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+describe('AdtServiceDefinition update readiness read', () => {
+  const resolver = new TestConfigResolver({
+    handlerName: 'create_service_definition',
+    testCaseName: 'adt_service_definition',
+    logger: testsLogger,
+  });
+  const params = resolver.getParams();
+  const serviceDefinitionName: string = params.service_definition_name;
+  const sourceCode: string =
+    params.source_code ||
+    `@EndUserText.label: 'test'\ndefine service ${serviceDefinitionName} {\n}`;
+
+  it('polls the version it just wrote (inactive), not the active one', async () => {
+    logTestStart(
+      testsLogger,
+      'ServiceDefinition update - readiness read targets inactive',
+      {
+        name: 'update_readiness_read_inactive',
+        params: { service_definition_name: serviceDefinitionName },
+      },
+    );
+
+    const { conn, calls } = fakeConnection();
+    const handler = new AdtServiceDefinition(conn, testsLogger);
+
+    await handler.update({ serviceDefinitionName, sourceCode });
+
+    const putIndex = calls.findIndex(
+      (c) => c.method === 'PUT' && String(c.url).includes('/source/main'),
+    );
+    expect(putIndex).toBeGreaterThanOrEqual(0);
+
+    const readinessRead = calls
+      .slice(putIndex + 1)
+      .find(
+        (c) => c.method === 'GET' && String(c.url).includes('withLongPolling'),
+      );
+
+    expect(readinessRead).toBeDefined();
+    expect(String(readinessRead.url)).toContain('version=inactive');
+
+    logTestSuccess(
+      testsLogger,
+      'ServiceDefinition update - readiness read targets inactive',
+    );
+    logTestEnd(
+      testsLogger,
+      'ServiceDefinition update - readiness read targets inactive',
+    );
+  });
+});

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -355,12 +355,13 @@ export class AdtAccessControl
         );
         this.logger?.info?.('Access control updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling (wait for object to be ready after update)
         this.logger?.info?.('read (wait for object ready after update)');
         try {
           await this.read(
             { accessControlName: config.accessControlName },
-            'active',
+            'inactive',
             { withLongPolling: true },
           );
           this.logger?.info?.('object is ready after update');

--- a/src/core/authorizationField/AdtAuthorizationField.ts
+++ b/src/core/authorizationField/AdtAuthorizationField.ts
@@ -353,12 +353,13 @@ export class AdtAuthorizationField
       );
       this.logger?.info?.('Authorization field updated');
 
+      // Poll the inactive version: the write above produced it; the active version may not exist yet.
       // 3.5. Read with long polling to ensure object is ready after update
       this.logger?.info?.('read (wait for object ready after update)');
       try {
         await this.read(
           { authorizationFieldName: fullConfig.authorizationFieldName },
-          'active',
+          'inactive',
           { withLongPolling: true },
         );
         this.logger?.info?.('object is ready after update');

--- a/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
+++ b/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
@@ -410,10 +410,11 @@ export class AdtBehaviorDefinition
         state.updateResult = updateResponse;
         this.logger?.info?.('Behavior definition updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling (wait for object to be ready after update)
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ name: config.name }, 'active', {
+          await this.read({ name: config.name }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
+++ b/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
@@ -418,10 +418,11 @@ ENDCLASS.`;
           'Behavior implementation implementations include updated',
         );
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 5.5. Read with long polling (wait for object to be ready after update)
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ className: config.className }, 'active', {
+          await this.read({ className: config.className }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -394,10 +394,11 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
         );
         this.logger?.info?.('Class updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling to ensure object is ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ className: config.className }, 'active', {
+          await this.read({ className: config.className }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/ddl/AdtDdl.ts
+++ b/src/core/ddl/AdtDdl.ts
@@ -352,10 +352,11 @@ export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
         );
         this.logger?.info?.('View updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling to ensure object is ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ ddlName: config.ddlName }, 'active', {
+          await this.read({ ddlName: config.ddlName }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -514,6 +514,7 @@ export class AdtEnhancement
         state.updateResult = updateResponse;
         this.logger?.info?.('Enhancement updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling (wait for object to be ready after update)
         this.logger?.info?.('read (wait for object ready after update)');
         try {
@@ -522,7 +523,7 @@ export class AdtEnhancement
               enhancementName: config.enhancementName,
               enhancementType: config.enhancementType,
             },
-            'active',
+            'inactive',
             { withLongPolling: true },
           );
           this.logger?.info?.('object is ready after update');

--- a/src/core/featureToggle/AdtFeatureToggle.ts
+++ b/src/core/featureToggle/AdtFeatureToggle.ts
@@ -444,12 +444,13 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
         this.logger?.info?.('Feature toggle source uploaded');
       }
 
+      // Poll the inactive version: the write above produced it; the active version may not exist yet.
       // 3.5. Read with long polling to ensure object is ready after update
       this.logger?.info?.('read (wait for object ready after update)');
       try {
         const readState = await this.read(
           { featureToggleName: fullConfig.featureToggleName },
-          'active',
+          'inactive',
           { withLongPolling: true },
         );
         if (readState) {

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -561,6 +561,7 @@ export class AdtFunctionInclude
           fullConfig.transportRequest,
         );
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // Wait for object to be ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
@@ -569,7 +570,7 @@ export class AdtFunctionInclude
               functionGroupName: fullConfig.functionGroupName,
               includeName: fullConfig.includeName,
             },
-            'active',
+            'inactive',
             { withLongPolling: true },
           );
           this.logger?.info?.('object is ready after update');

--- a/src/core/functionModule/AdtFunctionModule.ts
+++ b/src/core/functionModule/AdtFunctionModule.ts
@@ -419,6 +419,7 @@ export class AdtFunctionModule
         );
         this.logger?.info?.('Function module updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling (wait for object to be ready after update)
         this.logger?.info?.('read (wait for object ready after update)');
         try {
@@ -427,7 +428,7 @@ export class AdtFunctionModule
               functionModuleName: config.functionModuleName,
               functionGroupName: config.functionGroupName,
             },
-            'active',
+            'inactive',
             { withLongPolling: true },
           );
           this.logger?.info?.('object is ready after update');

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -327,10 +327,11 @@ export class AdtInterface
         // upload() returns void, so we don't store it in state
         this.logger?.info?.('Interface updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling to ensure object is ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ interfaceName: config.interfaceName }, 'active', {
+          await this.read({ interfaceName: config.interfaceName }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/package/AdtPackage.ts
+++ b/src/core/package/AdtPackage.ts
@@ -440,10 +440,11 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
         );
         this.logger?.info?.('Package updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling (wait for object to be ready after update)
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ packageName: config.packageName }, 'active', {
+          await this.read({ packageName: config.packageName }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -347,10 +347,11 @@ export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
         state.updateResult = updateResponse;
         this.logger?.info?.('Program updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling to ensure object is ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ programName: config.programName }, 'active', {
+          await this.read({ programName: config.programName }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -1,5 +1,5 @@
 /**
- * AdtServiceDefinition - High-level CRUD operations for Service Definition (DDLS) objects
+ * AdtServiceDefinition - High-level CRUD operations for Service Definition (SRVD/SRV) objects
  *
  * Implements IAdtObject interface with automatic operation chains,
  * error handling, and resource cleanup.
@@ -13,7 +13,8 @@
  * - activate uses same session/cookies (no stateful needed)
  *
  * Operation chains:
- * - Create: validate → create → check → lock → check(inactive) → update → unlock → check → activate
+ * - Create: create (POST metadata only — creates an empty source; the source
+ *   code is written by a subsequent update(), mirroring what Eclipse ADT does)
  * - Update: lock → check(inactive) → update → unlock → check → activate
  * - Delete: check(deletion) → delete
  */
@@ -361,11 +362,12 @@ export class AdtServiceDefinition
         this.logger?.info?.('Service definition updated');
 
         // 3.5. Read with long polling (wait for object to be ready after update)
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         this.logger?.info?.('read (wait for object ready after update)');
         try {
           await this.read(
             { serviceDefinitionName: config.serviceDefinitionName },
-            'active',
+            'inactive',
             { withLongPolling: true },
           );
           this.logger?.info?.('object is ready after update');

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -353,10 +353,11 @@ export class AdtStructure
         );
         this.logger?.info?.('Structure updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling to ensure object is ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ structureName: config.structureName }, 'active', {
+          await this.read({ structureName: config.structureName }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -334,10 +334,11 @@ export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
         );
         this.logger?.info?.('Table updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling to ensure object is ready after update
         this.logger?.info?.('read (wait for object ready after update)');
         try {
-          await this.read({ tableName: config.tableName }, 'active', {
+          await this.read({ tableName: config.tableName }, 'inactive', {
             withLongPolling: true,
           });
           this.logger?.info?.('object is ready after update');

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -366,12 +366,13 @@ export class AdtTransformation
         );
         this.logger?.info?.('Transformation updated');
 
+        // Poll the inactive version: the write above produced it; the active version may not exist yet.
         // 3.5. Read with long polling (wait for object to be ready after update)
         this.logger?.info?.('read (wait for object ready after update)');
         try {
           await this.read(
             { transformationName: config.transformationName },
-            'active',
+            'inactive',
             { withLongPolling: true },
           );
           this.logger?.info?.('object is ready after update');


### PR DESCRIPTION
## What

After `update()` writes source/metadata under a lock, the object exists only as the **inactive** version. The post-update readiness read (step 3.5) polled the **active** version — so it could never observe the write it was meant to wait for.

This changes that read to `'inactive'` across the 16 handlers whose `read()` actually forwards the version.

## Evidence (live SAP, trial)

While an activated service definition is updated and not yet reactivated — exactly the readiness-read window:

```
version=active   -> HTTP 200 | label="VERSION-ONE"   <- content predating the update
version=inactive -> HTTP 200 | label="VERSION-TWO"   <- what the PUT just wrote
```

The step was structurally incapable of observing the update it waited for.

## Why nobody noticed

- `read()` swallows the miss: 404 returns `undefined`, and on cloud this endpoint answers **200 with an empty body** rather than 404.
- The call sits in `try/catch`, so the flow logged `object is ready after update` either way.
- `BaseTester.flowTest` compares content only *after* a separate `update()` + `activate()`, so the readiness read is never asserted on.

Net effect of the bug: a silent no-op step, not a hard failure — which is why it survived.

## Scope

**Fixed (16):** accessControl, authorizationField, behaviorDefinition, behaviorImplementation, class, ddl, enhancement, featureToggle, functionInclude, functionModule, interface, package, program, serviceDefinition, structure, table, transformation.

**Deliberately untouched (5):** metadataExtension, domain, dataElement, functionGroup, tabletype — their `read()` drops the version (`_version`) and polls a version-less URL, so the literal changes nothing there.

`enhancement` maps `inactive -> workingArea` in its URI dialect (`enhancement/read.ts:88`); the test accepts both.

The post-activation read (step 6.5) still reads `'active'` — correct there.

## Tests

- `postUpdateReadinessRead.test.ts` — table-driven over all 16 handlers, asserts at the wire level which version the readiness read polls. Verified failing 16/16 against the unfixed code.
- `serviceDefinitionUpdateRead.test.ts` — the same assertion for SRVD, with a fake connection that 404s the active version.
- Full unit suite: 330 passed / 63 suites. `build:fast` clean, `lint:check` exit 0.
- `npm test -- integration/core/serviceDefinition` green against trial.

## Known adjacent issues (not in this PR)

- The **final** read at the end of `update()` still returns `version=active` in several handlers — same class of staleness, separate fix.
- `featureToggle/read.ts:17` ignores `_options`, so `withLongPolling` is never sent.
- `ICreateXxxParams.source_code` is declared but unused in 25 of 26 modules (only `program` reads it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)