### PR TITLE
fix(update): final read returns the written inactive version, not stale active

### DIFF
--- a/src/__tests__/unit/core/updateNoActivateReadsInactive.test.ts
+++ b/src/__tests__/unit/core/updateNoActivateReadsInactive.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit test: update() without activation must never read the ACTIVE version.
+ *
+ * When update() runs without activateOnUpdate, it writes the source under a
+ * lock and stops — the object is left as the inactive version, and the active
+ * version still holds the pre-update content (or nothing, for a never-activated
+ * object). Every read the flow performs in this path — the readiness poll and
+ * the final "read and return result" — must therefore target the version just
+ * written, not the stale active one. Reading active there returns content that
+ * cannot reflect the update, and the returned readResult misleads the caller.
+ *
+ * A fake IAbapConnection is used because the defect is invisible from the
+ * outside: only the request URL reveals which version was read, and the miss is
+ * swallowed (404 -> undefined, or 200 + empty body on cloud).
+ *
+ * Object names are inert placeholders — the fake never reaches a SAP system and
+ * the assertion is on the `version` query parameter only.
+ *
+ * Package is excluded on purpose: verified live that a package returns identical
+ * content for version=active and version=inactive (no distinct inactive
+ * version), so reading active there is equivalent and not stale.
+ */
+
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { AdtAccessControl } from '../../../core/accessControl/AdtAccessControl';
+import { AdtAuthorizationField } from '../../../core/authorizationField/AdtAuthorizationField';
+import { AdtBehaviorDefinition } from '../../../core/behaviorDefinition/AdtBehaviorDefinition';
+import { AdtBehaviorImplementation } from '../../../core/behaviorImplementation/AdtBehaviorImplementation';
+import { AdtClass } from '../../../core/class/AdtClass';
+import { AdtDdl } from '../../../core/ddl/AdtDdl';
+import { AdtEnhancement } from '../../../core/enhancement/AdtEnhancement';
+import { AdtFeatureToggle } from '../../../core/featureToggle/AdtFeatureToggle';
+import { AdtFunctionInclude } from '../../../core/functionInclude/AdtFunctionInclude';
+import { AdtFunctionModule } from '../../../core/functionModule/AdtFunctionModule';
+import { AdtInterface } from '../../../core/interface/AdtInterface';
+import { AdtProgram } from '../../../core/program/AdtProgram';
+import { AdtStructure } from '../../../core/structure/AdtStructure';
+import { AdtTable } from '../../../core/table/AdtTable';
+import { AdtTransformation } from '../../../core/transformation/AdtTransformation';
+import { createTestsLogger } from '../../helpers/testLogger';
+
+const testsLogger: ILogger = createTestsLogger();
+
+const LOCK_XML =
+  '<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE></DATA></asx:values></asx:abap>';
+
+const OBJ = 'ZNOACTIVATE';
+
+interface ICall {
+  method?: string;
+  url: string;
+  params?: Record<string, unknown>;
+}
+
+function fakeConnection(): { conn: IAbapConnection; calls: ICall[] } {
+  const calls: ICall[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    if (
+      String(req.url).includes('_action=LOCK') ||
+      req.params?._action === 'LOCK'
+    ) {
+      return { status: 200, data: LOCK_XML };
+    }
+    return { status: 200, data: '' };
+  });
+  return {
+    conn: {
+      makeAdtRequest,
+      setSessionType: jest.fn(),
+    } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+const CONFIG: Record<string, unknown> = {
+  accessControlName: OBJ,
+  authorizationFieldName: OBJ,
+  name: OBJ,
+  className: OBJ,
+  ddlName: OBJ,
+  enhancementName: OBJ,
+  enhancementType: 'enhoxhh',
+  featureToggleName: OBJ,
+  functionGroupName: OBJ,
+  includeName: OBJ,
+  functionModuleName: OBJ,
+  interfaceName: OBJ,
+  packageName: OBJ,
+  programName: OBJ,
+  structureName: OBJ,
+  tableName: OBJ,
+  transformationName: OBJ,
+  behaviorDefinition: OBJ,
+  description: 'no-activate probe',
+  sourceCode: 'X',
+  xmlContent: '<a/>',
+};
+
+// Source-bearing handlers with an inactive -> activate lifecycle. Package is
+// excluded (no distinct inactive version — see file header).
+const MODULES: Array<[string, new (...args: any[]) => any]> = [
+  ['accessControl', AdtAccessControl],
+  ['authorizationField', AdtAuthorizationField],
+  ['behaviorDefinition', AdtBehaviorDefinition],
+  ['behaviorImplementation', AdtBehaviorImplementation],
+  ['class', AdtClass],
+  ['ddl', AdtDdl],
+  ['enhancement', AdtEnhancement],
+  ['featureToggle', AdtFeatureToggle],
+  ['functionInclude', AdtFunctionInclude],
+  ['functionModule', AdtFunctionModule],
+  ['interface', AdtInterface],
+  ['program', AdtProgram],
+  ['structure', AdtStructure],
+  ['table', AdtTable],
+  ['transformation', AdtTransformation],
+];
+
+function versionOf(call: ICall): string | undefined {
+  const match = /[?&]version=([^&]+)/.exec(String(call.url));
+  if (match) return match[1];
+  const fromParams = call.params?.version;
+  return fromParams === undefined ? undefined : String(fromParams);
+}
+
+describe('update() without activation never reads the active version', () => {
+  it.each(
+    MODULES,
+  )('%s reads only the written (inactive) version after the write', async (_label, Handler) => {
+    const { conn, calls } = fakeConnection();
+    const handler = new Handler(conn, testsLogger);
+
+    // activateOnUpdate omitted → no activation happens in this path.
+    await handler.update({ ...CONFIG }, { sourceCode: 'X' });
+
+    const writeIndex = calls.findIndex((c) => c.method === 'PUT');
+    expect(writeIndex).toBeGreaterThanOrEqual(0);
+
+    const versionedReads = calls
+      .slice(writeIndex + 1)
+      .filter((c) => c.method === 'GET' && versionOf(c) !== undefined);
+
+    expect(versionedReads.length).toBeGreaterThan(0);
+    // 'workingArea' is the enhancement URI dialect for the inactive version.
+    for (const call of versionedReads) {
+      expect(versionOf(call)).not.toBe('active');
+    }
+  });
+});

--- a/src/core/authorizationField/AdtAuthorizationField.ts
+++ b/src/core/authorizationField/AdtAuthorizationField.ts
@@ -423,10 +423,12 @@ export class AdtAuthorizationField
           );
         }
       } else {
+        // No activation happened: return the version just written (inactive),
+        // not the stale active one.
         const readResponse = await readAuthorizationField(
           this.connection,
           fullConfig.authorizationFieldName,
-          'active',
+          'inactive',
         );
         state.readResult = readResponse;
       }

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -599,11 +599,15 @@ export class AdtEnhancement
         return state;
       }
 
-      // Read and return result (no stateful needed)
+      // Read and return result (no stateful needed).
+      // No activation happened: return the version just written (inactive,
+      // i.e. workingArea in the enhancement URI dialect), not the stale active
+      // one. getEnhancementSource defaults to 'active', so pass it explicitly.
       const readResponse = await getEnhancementSource(
         this.connection,
         config.enhancementType,
         config.enhancementName,
+        'inactive',
       );
       state.readResult = readResponse;
 

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -634,11 +634,13 @@ export class AdtFunctionInclude
           );
         }
       } else {
+        // No activation happened: return the version just written (inactive),
+        // not the stale active one.
         const readResponse = await readFunctionInclude(
           this.connection,
           fullConfig.functionGroupName,
           fullConfig.includeName,
-          'active',
+          'inactive',
         );
         state.readResult = readResponse;
       }


### PR DESCRIPTION
## What

Follow-up to #70 (7.4.1). That PR fixed the **readiness read** (step 3.5); this fixes the **final read** at the end of `update()` in the non-activate path — the same defect class, a different read.

When `update()` runs without `activateOnUpdate`, it writes the source under a lock and stops, then reads the object back into `readResult`. Three handlers read the **active** version there. With no activation, the active version holds pre-update content (or nothing, for a never-activated object), so the returned `readResult` cannot reflect the write:

| handler | before | cause |
|---|---|---|
| authorizationField | `active` | explicit literal |
| functionInclude | `active` | explicit literal |
| enhancement | `active` | `getEnhancementSource` defaults to `active`; now passes `inactive` → `workingArea` in the URI dialect |

The other 12 source-bearing handlers already read `inactive` here — confirmed by probe.

## Why inactive is correct

Established live in #70: while an activated object is updated and not reactivated, `version=active` returns pre-update content and `version=inactive` returns what the `PUT` just wrote. The final read must return the written version.

## Package deliberately excluded

Verified live (read-only) that `ZADT_BLD_PKG03` returns **identical** content for `version=active` and `version=inactive` — a package has no distinct inactive version and no activation step. Reading `active` there is equivalent, not stale, so it is left unchanged. Applying the pattern blindly would have been change-for-no-reason.

## Tests

- `updateNoActivateReadsInactive.test.ts` — table-driven over all 15 source-bearing handlers, asserts at the wire level that `update()` without activation never issues a `version=active` read. Verified failing **3/15** against the unfixed code (authorizationField, enhancement, functionInclude), green after.
- Full unit suite: 345 passed / 64 suites. `build:fast` clean, `lint:check` exit 0.
- `npm test -- integration/core/serviceDefinition` green against trial; the 3 handlers' flow tests are cloud-skipped (onprem-only), read-only parts green.

## Not in scope (still open)

- `featureToggle/read.ts` ignores `withLongPolling` (`_options` unused).
- `ICreateXxxParams.source_code` declared but unused in 25 of 26 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)