### PR TITLE
release(7.4.2): final read in update() returns the written inactive version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.2] - 2026-07-16
+
+### Fixed
+- **Final read in `update()` returned the stale active version instead of the written one.** Follow-up to 7.4.1, which fixed the readiness read (step 3.5); this fixes the *final* read at the end of `update()` in the non-activate path. When `update()` runs without `activateOnUpdate`, it writes the source under a lock and stops, then reads the object back into `readResult` — three handlers read the **active** version there, which (with no activation) holds pre-update content, or nothing for a never-activated object, so the returned `readResult` could not reflect the write.
+  - `authorizationField` and `functionInclude` passed `'active'` explicitly; `enhancement`'s `getEnhancementSource` defaults to `'active'` and now passes `'inactive'` (mapped to `workingArea` in the enhancement URI dialect). The other 12 source-bearing handlers already read `inactive` here.
+  - `package` is deliberately unchanged: verified live that a package returns identical content for `version=active` and `version=inactive` (no distinct inactive version, no activation step), so reading active there is equivalent, not stale.
+  - No API change: the final read is an internal step of `update()`. New unit test asserts the invariant across all 15 source-bearing handlers — `update()` without activation never issues a `version=active` read.
+
 ## [7.4.1] - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "7.4.1",
+      "version": "7.4.2",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release for #72.

- `package.json` / `package-lock.json` → 7.4.2
- CHANGELOG entry for the final-read fix

No source changes beyond #72 (already on `main`); this PR carries the version bump and changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)