### PR TITLE
cleanup: remove dead source_code + featureToggle withLongPolling plumbing (7.4.3)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-dead-api-surface-cleanup.md
+++ b/docs/superpowers/plans/2026-07-16-dead-api-surface-cleanup.md
@@ -27,6 +27,7 @@
 - `src/core/featureToggle/read.ts` — remove local `IReadOptions` + the unused `_options` param.
 - `src/core/featureToggle/AdtFeatureToggle.ts` — drop the `IReadOptions` import, retype `read()` options inline, stop forwarding options to `readFeatureToggle`, drop the no-op `{ withLongPolling: true }` from the two internal readiness reads, add a doc comment.
 - `src/__tests__/unit/core/enhancementCreateParamsSurface.test.ts` — NEW: public-barrel type guard.
+- `src/__tests__/unit/core/serviceDefinitionCreateMetadataOnly.test.ts` — NEW: representative create() metadata-only wire test.
 - `src/__tests__/unit/core/featureToggleNoLongPolling.test.ts` — NEW: wire guard.
 
 ---
@@ -88,6 +89,7 @@ git commit -m "test(enhancement): guard public ICreateEnhancementParams.source_c
 ### Task 2: Remove dead `source_code` (4 internal fields, 3 pass-throughs) + deprecate the public one
 
 **Files:**
+- Test (create): `src/__tests__/unit/core/serviceDefinitionCreateMetadataOnly.test.ts`
 - Modify: `src/core/accessControl/types.ts` (remove `source_code?` from `ICreateAccessControlParams`, line ~9)
 - Modify: `src/core/functionInclude/types.ts` (remove `source_code?` from `ICreateFunctionIncludeParams`, line ~14)
 - Modify: `src/core/scalarFunction/types.ts` (remove `source_code?` from `ICreateScalarFunctionParams`, line ~12)
@@ -101,7 +103,79 @@ git commit -m "test(enhancement): guard public ICreateEnhancementParams.source_c
 - Consumes: the Task 1 guard test (must stay green — proves the public enhancement field survives).
 - Produces: none consumed by later tasks.
 
-- [ ] **Step 1: Deprecate the public enhancement field**
+- [ ] **Step 1: Write the representative create() metadata-only wire test**
+
+Characterization test for the invariant this whole cleanup rests on: `create()`
+posts metadata only, never source — even when `sourceCode` is supplied. It is
+green before and after the removals (before: the pass-through set `source_code`
+on the low-level params, but `create.ts` ignored it, so the POST body never
+carried source; after: no pass-through at all). It guards against a future
+regression that wires source into `create()`.
+
+```typescript
+/**
+ * create() is metadata-only: the POST to the SRVD create endpoint carries the
+ * object metadata (name, package, description) but never the source code, even
+ * when sourceCode is passed. This is the invariant behind removing the dead
+ * source_code create-param — source is written by update(), as in Eclipse ADT.
+ */
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { AdtServiceDefinition } from '../../../core/serviceDefinition/AdtServiceDefinition';
+import { createTestsLogger } from '../../helpers/testLogger';
+
+const logger: ILogger = createTestsLogger();
+const UNIQUE_SOURCE = 'define service ZUNIQUE_SRC_MARKER { expose ZFOO; }';
+
+function fakeConn(): { conn: IAbapConnection; calls: any[] } {
+  const calls: any[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    return { status: 201, data: '' };
+  });
+  return {
+    conn: { makeAdtRequest, setSessionType: jest.fn() } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+describe('AdtServiceDefinition.create is metadata-only', () => {
+  it('does not put source code in the create POST body', async () => {
+    const { conn, calls } = fakeConn();
+    const handler = new AdtServiceDefinition(conn, logger);
+
+    await handler.create(
+      {
+        serviceDefinitionName: 'ZMETA_ONLY',
+        packageName: 'ZPKG',
+        description: 'meta only',
+        sourceCode: UNIQUE_SOURCE,
+      },
+      { sourceCode: UNIQUE_SOURCE },
+    );
+
+    const posts = calls.filter((c) => c.method === 'POST');
+    expect(posts.length).toBeGreaterThan(0);
+    for (const req of posts) {
+      const body = typeof req.data === 'string' ? req.data : JSON.stringify(req.data ?? '');
+      expect(body).not.toContain('ZUNIQUE_SRC_MARKER');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it passes (green baseline)**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/serviceDefinitionCreateMetadataOnly.test.ts --runInBand`
+Expected: PASS, 1 test. (create() already never sends source; this pins that.)
+
+- [ ] **Step 3: Commit the characterization test**
+
+```bash
+git add src/__tests__/unit/core/serviceDefinitionCreateMetadataOnly.test.ts
+git commit -m "test(serviceDefinition): pin create() as metadata-only (no source in POST)"
+```
+
+- [ ] **Step 4: Deprecate the public enhancement field**
 
 In `src/core/enhancement/types.ts`, the `ICreateEnhancementParams` interface, change:
 
@@ -117,7 +191,7 @@ to:
   source_code?: string; // For enhoxhh only
 ```
 
-- [ ] **Step 2: Remove the field from the 4 internal create-params**
+- [ ] **Step 5: Remove the field from the 4 internal create-params**
 
 In each of these files, delete the `source_code?: string;` line **inside the `ICreateXxxParams` interface only** (leave any `source_code` on `IUpdateXxxParams` / other interfaces untouched):
 
@@ -126,7 +200,7 @@ In each of these files, delete the `source_code?: string;` line **inside the `IC
 - `src/core/scalarFunction/types.ts` — `ICreateScalarFunctionParams` → delete `  source_code?: string;`
 - `src/core/serviceDefinition/types.ts` — `ICreateServiceDefinitionParams` → delete `  source_code?: string;`
 
-- [ ] **Step 3: Remove the 3 dead create() pass-throughs**
+- [ ] **Step 6: Remove the 3 dead create() pass-throughs**
 
 `src/core/accessControl/AdtAccessControl.ts` — inside `create()`, delete the line:
 ```typescript
@@ -144,22 +218,22 @@ In each of these files, delete the `source_code?: string;` line **inside the `IC
 ```
 (Do NOT touch the separate real source upload later in `create()` that reads `options?.sourceCode || config.sourceCode` and calls `uploadFunctionIncludeSource`.)
 
-- [ ] **Step 4: Build — verify no dangling references to the removed fields**
+- [ ] **Step 7: Build — verify no dangling references to the removed fields**
 
 Run: `npm run build:fast`
 Expected: clean compile (exit 0). A failure here means some code still references a removed `ICreateXxxParams.source_code` — fix that reference (it was dead too).
 
-- [ ] **Step 5: Run the guard test + full unit suite**
+- [ ] **Step 8: Run the guard tests + full unit suite**
 
 Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand`
-Expected: all PASS, including `enhancementCreateParamsSurface` (proves the public field survived).
+Expected: all PASS, including `enhancementCreateParamsSurface` (public field survived) and `serviceDefinitionCreateMetadataOnly` (create still metadata-only).
 
-- [ ] **Step 6: Lint**
+- [ ] **Step 9: Lint**
 
 Run: `npm run lint:check`
 Expected: exit 0 (pre-existing warnings in unrelated files are fine; no new errors in the touched files).
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/core/accessControl src/core/functionInclude src/core/scalarFunction src/core/serviceDefinition src/core/enhancement
@@ -441,6 +515,7 @@ Then commit (`package.json`, `package-lock.json`, `CHANGELOG.md`), open the rele
 - public handler signatures kept per `IAdtObject` → Task 3 Step 5 (inline retype). ✓
 - doc comment on SFW plain-GET → Task 3 Steps 3, 5. ✓
 - API-surface guard imports from public barrel → Task 1 Step 1. ✓
+- representative create() metadata-only POST test → Task 2 Step 1 (serviceDefinition). ✓
 - wire test for no withLongPolling → Task 3 Step 1. ✓
 - offline test runs via MCP_ENV_PATH → all test steps. ✓
 - patch 7.4.3, one PR, established release flow → Tasks 4-5. ✓

--- a/docs/superpowers/plans/2026-07-16-dead-api-surface-cleanup.md
+++ b/docs/superpowers/plans/2026-07-16-dead-api-surface-cleanup.md
@@ -1,0 +1,450 @@
+# Dead / misleading API-surface cleanup (7.4.3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove two dead/misleading API surfaces — the no-op `source_code` on 5 `ICreateXxxParams`, and the ignored `withLongPolling` plumbing in featureToggle's low-level read — without breaking the published API.
+
+**Architecture:** Two independent cleanups plus a release. `source_code`: delete the field from the 4 internal create-params and their 3 dead pass-throughs, keep + `@deprecate` the one publicly-exported field (`ICreateEnhancementParams`). featureToggle: delete the unused `_options`/local `IReadOptions` from `readFeatureToggle`, keep the public handler signatures (mandated by `IAdtObject`), document that SFW readiness is a plain GET. Guarded by two characterization tests plus the TypeScript build.
+
+**Tech Stack:** TypeScript (strict, CommonJS), Jest + ts-jest, Biome, published types via `@mcp-abap-adt/interfaces`.
+
+## Global Constraints
+
+- Code, comments, error messages in English. Comments explain "why" not "what".
+- Biome: single quotes, semicolons always, indent 2 spaces.
+- Never change `package.json` version except in the explicit release task.
+- After changing the version, run `npm install --package-lock-only` and commit the lockfile in the same commit. Verify `package-lock.json` has no `"link": true`.
+- Run unit tests offline with `MCP_ENV_PATH=/tmp/nonexistent-env` prefix (skips the SAP preflight in globalSetup that aborts on an expired trial JWT).
+- Do NOT touch `program` (genuinely uploads source via camelCase `sourceCode`), the `IUpdateXxxParams` `source_code` fields (live), or the shared `IReadOptions` in `src/core/shared/types.ts` (its `withLongPolling` is honored elsewhere).
+- Branch already checked out: `cleanup/dead-api-surface-7.4.3`.
+
+## File Structure
+
+- `src/core/{accessControl,functionInclude,scalarFunction,serviceDefinition}/types.ts` — remove `source_code?` from the `ICreateXxxParams` interface.
+- `src/core/enhancement/types.ts` — keep `source_code?` on `ICreateEnhancementParams`, add `@deprecated`.
+- `src/core/accessControl/AdtAccessControl.ts`, `src/core/serviceDefinition/AdtServiceDefinition.ts` — remove the dead `source_code:` line from `create()`.
+- `src/core/functionInclude/AdtFunctionInclude.ts` — remove the dead `source_code: config.sourceCode` line from `buildCreateParams`.
+- `src/core/featureToggle/read.ts` — remove local `IReadOptions` + the unused `_options` param.
+- `src/core/featureToggle/AdtFeatureToggle.ts` — drop the `IReadOptions` import, retype `read()` options inline, stop forwarding options to `readFeatureToggle`, drop the no-op `{ withLongPolling: true }` from the two internal readiness reads, add a doc comment.
+- `src/__tests__/unit/core/enhancementCreateParamsSurface.test.ts` — NEW: public-barrel type guard.
+- `src/__tests__/unit/core/featureToggleNoLongPolling.test.ts` — NEW: wire guard.
+
+---
+
+### Task 1: Public-surface guard for `ICreateEnhancementParams.source_code`
+
+Characterization test first — it passes against current code and must keep passing after Task 2's field removals. It pins the compatibility decision (the one public field stays) so an accidental future removal fails a test, not just a consumer's build.
+
+**Files:**
+- Test (create): `src/__tests__/unit/core/enhancementCreateParamsSurface.test.ts`
+
+**Interfaces:**
+- Consumes: `ICreateEnhancementParams` from the published barrel `src/index` (which re-exports `src/index.core`).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the guard test**
+
+```typescript
+/**
+ * Public API-surface guard: ICreateEnhancementParams is publicly exported
+ * (src/index.core.ts -> src/index.ts). Its `source_code` field is a deprecated
+ * no-op that is intentionally KEPT for backward compatibility (removing it would
+ * break TS consumers). This test imports from the published barrel — not from
+ * core/enhancement/types — so it guards the real exported surface, including the
+ * barrel re-export. If the field or its export is removed, the type index below
+ * stops compiling and this suite fails to build.
+ */
+import type { ICreateEnhancementParams } from '../../../index';
+
+// Compile-time guards (checked by ts-jest at build):
+// 1. The field still exists on the exported type.
+type _FieldExists = ICreateEnhancementParams['source_code'];
+// 2. It is still optional (undefined is assignable to it).
+const _optional: _FieldExists = undefined;
+
+describe('ICreateEnhancementParams public surface', () => {
+  it('keeps source_code as an optional field on the published type', () => {
+    // The real assertion is the compile-time type index above; this runtime
+    // body exists so Jest registers a passing test once the file type-checks.
+    expect(_optional).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it passes (green baseline)**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/enhancementCreateParamsSurface.test.ts --runInBand`
+Expected: PASS, 1 test. (It compiles because `source_code` currently exists on the exported type.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/unit/core/enhancementCreateParamsSurface.test.ts
+git commit -m "test(enhancement): guard public ICreateEnhancementParams.source_code surface"
+```
+
+---
+
+### Task 2: Remove dead `source_code` (4 internal fields, 3 pass-throughs) + deprecate the public one
+
+**Files:**
+- Modify: `src/core/accessControl/types.ts` (remove `source_code?` from `ICreateAccessControlParams`, line ~9)
+- Modify: `src/core/functionInclude/types.ts` (remove `source_code?` from `ICreateFunctionIncludeParams`, line ~14)
+- Modify: `src/core/scalarFunction/types.ts` (remove `source_code?` from `ICreateScalarFunctionParams`, line ~12)
+- Modify: `src/core/serviceDefinition/types.ts` (remove `source_code?` from `ICreateServiceDefinitionParams`, line ~13)
+- Modify: `src/core/enhancement/types.ts` (add `@deprecated` to `source_code?` on `ICreateEnhancementParams`, line ~46)
+- Modify: `src/core/accessControl/AdtAccessControl.ts:143` (remove `source_code:` line)
+- Modify: `src/core/serviceDefinition/AdtServiceDefinition.ts:148` (remove `source_code:` line)
+- Modify: `src/core/functionInclude/AdtFunctionInclude.ts:118` (remove `source_code: config.sourceCode` line)
+
+**Interfaces:**
+- Consumes: the Task 1 guard test (must stay green — proves the public enhancement field survives).
+- Produces: none consumed by later tasks.
+
+- [ ] **Step 1: Deprecate the public enhancement field**
+
+In `src/core/enhancement/types.ts`, the `ICreateEnhancementParams` interface, change:
+
+```typescript
+  source_code?: string; // For enhoxhh only
+```
+to:
+```typescript
+  /**
+   * @deprecated No-op. `create()` posts metadata only; the source is written by
+   * `update()`. Kept for backward compatibility — this field is never read.
+   */
+  source_code?: string; // For enhoxhh only
+```
+
+- [ ] **Step 2: Remove the field from the 4 internal create-params**
+
+In each of these files, delete the `source_code?: string;` line **inside the `ICreateXxxParams` interface only** (leave any `source_code` on `IUpdateXxxParams` / other interfaces untouched):
+
+- `src/core/accessControl/types.ts` — `ICreateAccessControlParams` → delete `  source_code?: string;`
+- `src/core/functionInclude/types.ts` — `ICreateFunctionIncludeParams` → delete `  source_code?: string;`
+- `src/core/scalarFunction/types.ts` — `ICreateScalarFunctionParams` → delete `  source_code?: string;`
+- `src/core/serviceDefinition/types.ts` — `ICreateServiceDefinitionParams` → delete `  source_code?: string;`
+
+- [ ] **Step 3: Remove the 3 dead create() pass-throughs**
+
+`src/core/accessControl/AdtAccessControl.ts` — inside `create()`, delete the line:
+```typescript
+        source_code: options?.sourceCode || config.sourceCode,
+```
+
+`src/core/serviceDefinition/AdtServiceDefinition.ts` — inside `create()`, delete the line:
+```typescript
+        source_code: options?.sourceCode || config.sourceCode,
+```
+
+`src/core/functionInclude/AdtFunctionInclude.ts` — inside `buildCreateParams`, delete the line:
+```typescript
+      source_code: config.sourceCode,
+```
+(Do NOT touch the separate real source upload later in `create()` that reads `options?.sourceCode || config.sourceCode` and calls `uploadFunctionIncludeSource`.)
+
+- [ ] **Step 4: Build — verify no dangling references to the removed fields**
+
+Run: `npm run build:fast`
+Expected: clean compile (exit 0). A failure here means some code still references a removed `ICreateXxxParams.source_code` — fix that reference (it was dead too).
+
+- [ ] **Step 5: Run the guard test + full unit suite**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand`
+Expected: all PASS, including `enhancementCreateParamsSurface` (proves the public field survived).
+
+- [ ] **Step 6: Lint**
+
+Run: `npm run lint:check`
+Expected: exit 0 (pre-existing warnings in unrelated files are fine; no new errors in the touched files).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/accessControl src/core/functionInclude src/core/scalarFunction src/core/serviceDefinition src/core/enhancement
+git commit -m "refactor(create): drop dead source_code from create-params; deprecate public enhancement field
+
+Remove the no-op source_code field from 4 internal ICreateXxxParams
+(accessControl, functionInclude, scalarFunction, serviceDefinition) and the 3
+dead create() pass-throughs (accessControl, serviceDefinition direct;
+functionInclude buildCreateParams). create() posts metadata only; source is
+written by update(). ICreateEnhancementParams is publicly exported, so its
+field is kept and marked @deprecated instead of removed. program and the live
+IUpdateXxxParams.source_code fields are untouched."
+```
+
+---
+
+### Task 3: featureToggle — remove ignored `withLongPolling` plumbing
+
+Characterization test first (passes now — featureToggle already never sends the param), then remove the dead plumbing while keeping the public handler signatures (mandated by `IAdtObject`).
+
+**Files:**
+- Test (create): `src/__tests__/unit/core/featureToggleNoLongPolling.test.ts`
+- Modify: `src/core/featureToggle/read.ts` (remove local `IReadOptions` + `_options` param)
+- Modify: `src/core/featureToggle/AdtFeatureToggle.ts` (import line 44, `read()` at 262-289, readiness reads at ~454 and ~507)
+
+**Interfaces:**
+- Consumes: `readFeatureToggle(connection, name, version?)` — final signature after this task (no options param).
+- Produces: none consumed by later tasks.
+
+- [ ] **Step 1: Write the wire guard test**
+
+```typescript
+/**
+ * featureToggle readiness reads are a plain GET: the SFW endpoint's support for
+ * withLongPolling could not be verified from the cloud trial (SFW is on-prem),
+ * so we deliberately never send it. This test pins that — readFeatureToggle must
+ * not put withLongPolling in the request URL or params. It guards against a
+ * future "fix" that wires an unverified parameter.
+ */
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { readFeatureToggle } from '../../../core/featureToggle/read';
+
+function fakeConn(): { conn: IAbapConnection; calls: any[] } {
+  const calls: any[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    return { status: 200, data: '' };
+  });
+  return {
+    conn: { makeAdtRequest, setSessionType: jest.fn() } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+describe('readFeatureToggle never sends withLongPolling', () => {
+  it('omits withLongPolling from url and params', async () => {
+    const { conn, calls } = fakeConn();
+    await readFeatureToggle(conn, 'ZTEST_FT', 'inactive');
+    expect(calls).toHaveLength(1);
+    const req = calls[0];
+    expect(String(req.url)).not.toContain('withLongPolling');
+    expect(req.params?.withLongPolling).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it passes (green baseline)**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/featureToggleNoLongPolling.test.ts --runInBand`
+Expected: PASS, 1 test.
+
+- [ ] **Step 3: Remove local `IReadOptions` and the `_options` param from `read.ts`**
+
+Replace the whole of `src/core/featureToggle/read.ts` with:
+
+```typescript
+import type {
+  IAdtResponse as AxiosResponse,
+  IAbapConnection,
+} from '@mcp-abap-adt/interfaces';
+import { ACCEPT_FEATURE_TOGGLE_METADATA } from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+
+// NOTE: withLongPolling is intentionally not accepted here. The SFW feature-
+// toggle endpoint's support for it is unverified (on-prem only), so readiness
+// reads are a plain GET. The public AdtFeatureToggle.read()/readMetadata()
+// still accept withLongPolling to satisfy IAdtObject, but it is not forwarded.
+export async function readFeatureToggle(
+  connection: IAbapConnection,
+  name: string,
+  version: 'active' | 'inactive' = 'active',
+): Promise<AxiosResponse> {
+  const encoded = encodeSapObjectName(name.toLowerCase());
+  return connection.makeAdtRequest({
+    method: 'GET',
+    url: `/sap/bc/adt/sfw/featuretoggles/${encoded}`,
+    timeout: getTimeout('default'),
+    params: { version },
+    headers: { Accept: ACCEPT_FEATURE_TOGGLE_METADATA },
+  });
+}
+```
+
+- [ ] **Step 4: Fix the import in `AdtFeatureToggle.ts:44`**
+
+Change:
+```typescript
+import { type IReadOptions, readFeatureToggle } from './read';
+```
+to:
+```typescript
+import { readFeatureToggle } from './read';
+```
+
+- [ ] **Step 5: Retype `read()` options inline and stop forwarding to `readFeatureToggle`**
+
+In `AdtFeatureToggle.ts`, the `read()` method (around line 262). Change the signature option type:
+```typescript
+    options?: IReadOptions,
+```
+to (inline, matching `IAdtObject.read`):
+```typescript
+    // withLongPolling accepted per IAdtObject, but not forwarded: SFW readiness
+    // is a plain GET (endpoint support unverified — on-prem only).
+    options?: { withLongPolling?: boolean },
+```
+And change the `readFeatureToggle` call (currently passing `options`):
+```typescript
+      const response = await readFeatureToggle(
+        this.connection,
+        config.featureToggleName,
+        version ?? 'active',
+        options,
+      );
+```
+to:
+```typescript
+      const response = await readFeatureToggle(
+        this.connection,
+        config.featureToggleName,
+        version ?? 'active',
+      );
+```
+
+- [ ] **Step 6: Drop the no-op `{ withLongPolling: true }` from the two internal readiness reads**
+
+In `AdtFeatureToggle.ts` around line 451 (post-update readiness) change:
+```typescript
+        const readState = await this.read(
+          { featureToggleName: fullConfig.featureToggleName },
+          'inactive',
+          { withLongPolling: true },
+        );
+```
+to:
+```typescript
+        const readState = await this.read(
+          { featureToggleName: fullConfig.featureToggleName },
+          'inactive',
+        );
+```
+
+And around line 504 (post-activation readiness) change:
+```typescript
+          const readState = await this.read(
+            { featureToggleName: fullConfig.featureToggleName },
+            'active',
+            { withLongPolling: true },
+          );
+```
+to:
+```typescript
+          const readState = await this.read(
+            { featureToggleName: fullConfig.featureToggleName },
+            'active',
+          );
+```
+
+- [ ] **Step 7: Build**
+
+Run: `npm run build:fast`
+Expected: clean compile (exit 0). Confirms no remaining reference to the removed `IReadOptions` and that `read()` still satisfies `IAdtObject`.
+
+- [ ] **Step 8: Run the wire test + full unit suite**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand`
+Expected: all PASS, including `featureToggleNoLongPolling`.
+
+- [ ] **Step 9: Lint**
+
+Run: `npm run lint:check`
+Expected: exit 0.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/core/featureToggle/read.ts src/core/featureToggle/AdtFeatureToggle.ts src/__tests__/unit/core/featureToggleNoLongPolling.test.ts
+git commit -m "refactor(featureToggle): remove ignored withLongPolling plumbing from low-level read
+
+readFeatureToggle accepted an _options/withLongPolling it never sent. Remove the
+dead param and the local IReadOptions duplicate; keep the public read()/
+readMetadata() signatures (mandated by IAdtObject) but document that SFW
+readiness is a plain GET (endpoint support unverified, on-prem). Drop the two
+no-op { withLongPolling: true } args from featureToggle's own readiness reads.
+New wire test guards that readFeatureToggle never sends the parameter."
+```
+
+---
+
+### Task 4: Open the PR
+
+**Files:** none (git/gh only).
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin cleanup/dead-api-surface-7.4.3`
+
+- [ ] **Step 2: Open the PR** (title + body summarizing both cleanups, the 5→4+1 split, the featureToggle interface constraint, and that it is internal-only / non-breaking → patch 7.4.3). Do NOT merge — await review.
+
+---
+
+### Task 5: Release 7.4.3 (after PR review + merge)
+
+Follows the established flow (Claude merges + tags + GitHub-releases; user runs `npm publish`).
+
+**Files:**
+- Modify: `package.json` (version → 7.4.3)
+- Modify: `package-lock.json` (via `npm install --package-lock-only`)
+- Modify: `CHANGELOG.md` (new `## [7.4.3]` section)
+
+- [ ] **Step 1: On a fresh `chore/release-7.4.3` branch off updated `main`, bump `package.json` version `7.4.2` → `7.4.3`.**
+
+- [ ] **Step 2: Refresh the lockfile**
+
+Run: `npm install --package-lock-only`
+Then verify: `grep -c '"link": true' package-lock.json` → expect `0`, and the top-level version reads `7.4.3`.
+
+- [ ] **Step 3: Add the CHANGELOG entry** under a new `## [7.4.3] - <date>` heading:
+
+```markdown
+## [7.4.3] - <date>
+
+### Changed
+- **Removed dead `source_code` from create-params.** The no-op `source_code`
+  field is removed from 4 internal `ICreateXxxParams` (accessControl,
+  functionInclude, scalarFunction, serviceDefinition) and its 3 dead `create()`
+  pass-throughs. `create()` posts metadata only — source is written by
+  `update()`. `ICreateEnhancementParams.source_code` is publicly exported, so it
+  is kept and marked `@deprecated` rather than removed (no API break). `program`
+  and the live `IUpdateXxxParams.source_code` fields are untouched.
+- **featureToggle: removed ignored `withLongPolling` plumbing.** The low-level
+  `readFeatureToggle` accepted a `withLongPolling` option it never sent. The dead
+  parameter and its local `IReadOptions` duplicate are removed; the public
+  `read()`/`readMetadata()` keep the option (mandated by `IAdtObject`) but it is
+  documented as not forwarded — SFW readiness is a plain GET (endpoint support
+  unverified, on-prem).
+
+No published-API break: the one public field (`ICreateEnhancementParams.
+source_code`) is preserved as `@deprecated`; everything else removed is internal.
+```
+
+- [ ] **Step 4: Verify, commit, PR, merge, tag**
+
+Run: `npm run build:fast && npm run lint:check && MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand`
+Expected: build clean, lint exit 0, all unit tests pass.
+Then commit (`package.json`, `package-lock.json`, `CHANGELOG.md`), open the release PR, merge after review, then `git tag -a v7.4.3` + push, and update the CI-created GitHub release notes. `npm publish` is the user's step.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- source_code type-field removal (4 internal) → Task 2 Step 2. ✓
+- enhancement public field deprecation → Task 2 Step 1; guarded by Task 1. ✓
+- 3 create() pass-through removals → Task 2 Step 3. ✓
+- functionInclude real upload untouched → Task 2 Step 3 explicit note. ✓
+- featureToggle `_options`/local `IReadOptions` removal → Task 3 Steps 3-5. ✓
+- public handler signatures kept per `IAdtObject` → Task 3 Step 5 (inline retype). ✓
+- doc comment on SFW plain-GET → Task 3 Steps 3, 5. ✓
+- API-surface guard imports from public barrel → Task 1 Step 1. ✓
+- wire test for no withLongPolling → Task 3 Step 1. ✓
+- offline test runs via MCP_ENV_PATH → all test steps. ✓
+- patch 7.4.3, one PR, established release flow → Tasks 4-5. ✓
+
+**Placeholder scan:** `<date>` in Task 5 is a genuine runtime value (release date), not a plan gap. No other placeholders.
+
+**Type consistency:** `readFeatureToggle(connection, name, version?)` final signature is consistent between Task 3 Step 3 (definition) and Steps 5-6 (call sites). `options?: { withLongPolling?: boolean }` matches `IAdtObject.read`. Guard test type index `ICreateEnhancementParams['source_code']` matches the kept field.

--- a/docs/superpowers/plans/2026-07-16-dead-api-surface-cleanup.md
+++ b/docs/superpowers/plans/2026-07-16-dead-api-surface-cleanup.md
@@ -4,7 +4,7 @@
 
 **Goal:** Remove two dead/misleading API surfaces — the no-op `source_code` on 5 `ICreateXxxParams`, and the ignored `withLongPolling` plumbing in featureToggle's low-level read — without breaking the published API.
 
-**Architecture:** Two independent cleanups plus a release. `source_code`: delete the field from the 4 internal create-params and their 3 dead pass-throughs, keep + `@deprecate` the one publicly-exported field (`ICreateEnhancementParams`). featureToggle: delete the unused `_options`/local `IReadOptions` from `readFeatureToggle`, keep the public handler signatures (mandated by `IAdtObject`), document that SFW readiness is a plain GET. Guarded by two characterization tests plus the TypeScript build.
+**Architecture:** Two independent cleanups plus a release. `source_code`: delete the field from the 4 internal create-params and their 3 dead pass-throughs, keep + `@deprecated` the one publicly-exported field (`ICreateEnhancementParams`). featureToggle: delete the unused `_options`/local `IReadOptions` from `readFeatureToggle`, keep the public handler signatures (mandated by `IAdtObject`), document that SFW readiness is a plain GET. Guarded by three characterization tests (enhancement public-surface, serviceDefinition create metadata-only, featureToggle no-long-polling) plus the TypeScript build.
 
 **Tech Stack:** TypeScript (strict, CommonJS), Jest + ts-jest, Biome, published types via `@mcp-abap-adt/interfaces`.
 

--- a/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
@@ -1,0 +1,78 @@
+# Dead / misleading API-surface cleanup (7.4.3)
+
+## Problem
+
+Two internal API surfaces claim capabilities the code never delivers:
+
+1. **`source_code` in `ICreateXxxParams`** — declared in 9 modules
+   (accessControl, appendStructure, enhancement, functionInclude, interface,
+   scalarFunctionImplementation, scalarFunction, serviceDefinition,
+   transformation), never read by any `create.ts`. In 8 of them the high-level
+   `create()` even populates it (`source_code: options?.sourceCode || …`), a
+   dead pass-through. By design `create()` posts metadata only — the source is
+   written by a later `update()`, mirroring Eclipse ADT (verified live for SRVD
+   in 7.4.1). The field is a no-op that misleads callers into thinking `create()`
+   uploads source.
+
+2. **`withLongPolling` in featureToggle's read path** — `readFeatureToggle`
+   accepts `_options?: IReadOptions` (a featureToggle-local duplicate of the
+   shared type) but ignores it, so `withLongPolling` is never appended to the
+   request. Every other module wires it into the URL; featureToggle silently
+   drops it.
+
+Both were deferred from the 7.4.1/7.4.2 readiness-read work.
+
+## Scope decisions
+
+- **`source_code`: remove entirely.** Delete the field from the 9
+  `ICreateXxxParams` and remove the dead pass-through in the 8 `create()`
+  handlers. `program` is untouched — it is the only module that genuinely
+  uploads source (as a separate step inside its create flow).
+
+- **`withLongPolling`: remove the dead plumbing only.** The published
+  `IAdtObject` interface (`@mcp-abap-adt/interfaces`,
+  `IAdtObject.d.ts:169-187`) **mandates** that `read()` and `readMetadata()`
+  accept `options.withLongPolling`. `AdtFeatureToggle implements IAdtObject`, so
+  its public `read()`/`readMetadata()` signatures MUST keep the option — removing
+  them would break the published contract. Therefore:
+  - Remove the unused `_options?: IReadOptions` parameter from
+    `readFeatureToggle` and the featureToggle-local duplicate `IReadOptions`.
+  - Keep `withLongPolling` on the public `read()`/`readMetadata()` (interface).
+  - Add a doc comment: feature-toggle readiness is a plain GET; long polling is
+    not sent because the SFW endpoint's support could not be verified from the
+    cloud trial (SFW is on-prem). Wiring it is left to a future on-prem probe.
+  - Drop the internal threading of `withLongPolling` in featureToggle's own
+    readiness reads where it went nowhere.
+
+## Non-goals
+
+- The shared `IReadOptions` (`src/core/shared/types.ts`) is untouched — its
+  `withLongPolling` is honored by the 15 source-bearing handlers.
+- `program` create is untouched.
+- No public API signature changes: `ICreateXxxParams` are internal (not exported
+  from `src/index.ts`); the featureToggle public signatures stay per interface.
+
+## Versioning
+
+Both changes are internal-only, no published-API break → **patch bump 7.4.3**,
+one PR.
+
+## Testing
+
+- **`source_code` removal:** the TypeScript build is the primary proof — no
+  handler references the removed field. A unit test asserts a representative
+  `create()` (e.g. serviceDefinition) issues a metadata-only POST with no source
+  in the body.
+- **`withLongPolling`:** a wire-level unit test asserts `readFeatureToggle` never
+  appends `withLongPolling` to the request, documenting the deliberate choice
+  not to send an unverified parameter.
+- All tests run offline via `MCP_ENV_PATH=/tmp/nonexistent-env` (skips the SAP
+  preflight in globalSetup).
+- Full unit suite + `build:fast` + `lint:check` green before commit.
+
+## Risk
+
+Low. `source_code` removal is compile-checked across the tree; anyone who was
+setting it on an internal create-params object gets a TS error pointing at a
+field that never did anything. featureToggle keeps its public signature, so no
+caller of the handler is affected.

--- a/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
@@ -2,7 +2,8 @@
 
 ## Problem
 
-Two internal API surfaces claim capabilities the code never delivers:
+Two dead / misleading API surfaces claim capabilities the code never delivers
+(one is internal, one — `ICreateEnhancementParams` — is publicly exported):
 
 1. **`source_code` in `ICreateXxxParams`** — declared in 9 modules
    (accessControl, appendStructure, enhancement, functionInclude, interface,
@@ -29,7 +30,9 @@ Both were deferred from the 7.4.1/7.4.2 readiness-read work.
 - **`source_code`: two distinct removals — the type field, and the dead
   `create()` pass-through — which do NOT cover the same modules.** Verified
   against current code (see table). The low-level `create.ts` of all 9 ignores
-  the field (metadata-only POST); `program`'s does read it and is out of scope.
+  the snake_case `source_code` field (metadata-only POST). `program` is out of
+  scope — it genuinely uploads source, reading the camelCase `sourceCode` config,
+  not this dead `source_code` param.
 
   **(a) Type field `source_code` in `ICreateXxxParams` — 9 modules.** Eight are
   internal (absent from the built `dist/index*.d.ts`): accessControl,

--- a/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
@@ -24,10 +24,32 @@ Both were deferred from the 7.4.1/7.4.2 readiness-read work.
 
 ## Scope decisions
 
-- **`source_code`: remove entirely.** Delete the field from the 9
-  `ICreateXxxParams` and remove the dead pass-through in the 8 `create()`
-  handlers. `program` is untouched — it is the only module that genuinely
-  uploads source (as a separate step inside its create flow).
+- **`source_code`: remove the dead pass-through everywhere; remove the field
+  from the 8 internal types, deprecate it on the 1 public type.**
+
+  Of the 9 `ICreateXxxParams`, eight are internal (not exported from
+  `src/index.ts` — confirmed absent from the built `dist/index*.d.ts`):
+  accessControl, appendStructure, functionInclude, interface,
+  scalarFunctionImplementation, scalarFunction, serviceDefinition,
+  transformation. The field is deleted from all eight.
+
+  The ninth, **`ICreateEnhancementParams`, is publicly exported**
+  (`src/index.core.ts:80` → root `src/index.ts:25` → present in
+  `dist/index.core.d.ts`). Deleting `source_code?: string` there
+  (`src/core/enhancement/types.ts:46`) would be a source-level break for TS
+  consumers referencing the field. To keep the release non-breaking, the public
+  field is **kept and marked `@deprecated`** ("no-op — `create()` posts metadata
+  only; source is written by `update()`"), while its dead runtime pass-through in
+  `AdtEnhancement.create()` is removed like the others.
+
+  Note: `enhancement/types.ts` also declares `source_code` on the *update* params
+  (`:55`, required) — that one is live (enhancement update writes source) and is
+  NOT touched. Only the create-params field is deprecated.
+
+  In all 9 modules the dead pass-through in the high-level `create()` (8 of them
+  set `source_code:` on the low-level call; `interface` does not) is removed.
+  `program` is untouched — it is the only module that genuinely uploads source
+  (as a separate step inside its create flow).
 
 - **`withLongPolling`: remove the dead plumbing only.** The published
   `IAdtObject` interface (`@mcp-abap-adt/interfaces`,
@@ -49,20 +71,29 @@ Both were deferred from the 7.4.1/7.4.2 readiness-read work.
 - The shared `IReadOptions` (`src/core/shared/types.ts`) is untouched — its
   `withLongPolling` is honored by the 15 source-bearing handlers.
 - `program` create is untouched.
-- No public API signature changes: `ICreateXxxParams` are internal (not exported
-  from `src/index.ts`); the featureToggle public signatures stay per interface.
+- No public API break: the 8 internal `ICreateXxxParams` are not exported; the
+  public `ICreateEnhancementParams` keeps its `source_code` field (deprecated,
+  not removed); the featureToggle public signatures stay per interface.
 
 ## Versioning
 
-Both changes are internal-only, no published-API break → **patch bump 7.4.3**,
-one PR.
+No published-API break — the one public field (`ICreateEnhancementParams.
+source_code`) is preserved as `@deprecated`, everything else removed is internal.
+→ **patch bump 7.4.3**, one PR.
 
 ## Testing
 
-- **`source_code` removal:** the TypeScript build is the primary proof — no
-  handler references the removed field. A unit test asserts a representative
-  `create()` (e.g. serviceDefinition) issues a metadata-only POST with no source
-  in the body.
+- **`source_code` removal (internal 8):** the TypeScript build is the primary
+  proof — no handler references the removed field. A unit test asserts a
+  representative `create()` (e.g. serviceDefinition) issues a metadata-only POST
+  with no source in the body.
+- **Public API-surface guard (enhancement):** a type-level unit test asserts the
+  intended public surface is preserved — `ICreateEnhancementParams` still carries
+  an optional `source_code` field (compile-time: a value of the type may set it,
+  and omitting it is valid). This pins the compatibility decision so an
+  accidental future removal fails a test, not just a downstream consumer's build.
+  (`@deprecated` is a doc annotation and is not itself type-checkable; the test
+  guards the field's continued existence.)
 - **`withLongPolling`:** a wire-level unit test asserts `readFeatureToggle` never
   appends `withLongPolling` to the request, documenting the deliberate choice
   not to send an unverified parameter.
@@ -72,7 +103,9 @@ one PR.
 
 ## Risk
 
-Low. `source_code` removal is compile-checked across the tree; anyone who was
-setting it on an internal create-params object gets a TS error pointing at a
-field that never did anything. featureToggle keeps its public signature, so no
-caller of the handler is affected.
+Low. The 8 internal `source_code` removals are compile-checked across the tree;
+those types are not part of the published surface, so no external consumer is
+affected. The one public type (`ICreateEnhancementParams`) keeps its field, so no
+external TS build breaks. featureToggle keeps its public signature per interface,
+so no caller of the handler is affected. Net published-API delta: one field newly
+annotated `@deprecated`.

--- a/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
@@ -105,7 +105,7 @@ source_code`) is preserved as `@deprecated`, everything else removed is internal
 
 ## Testing
 
-- **`source_code` removal (internal 8):** the TypeScript build is the primary
+- **`source_code` removal (4 internal fields):** the TypeScript build is the primary
   proof — no handler references the removed field. A unit test asserts a
   representative `create()` (e.g. serviceDefinition) issues a metadata-only POST
   with no source in the body.

--- a/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
@@ -5,10 +5,12 @@
 Two dead / misleading API surfaces claim capabilities the code never delivers
 (one is internal, one — `ICreateEnhancementParams` — is publicly exported):
 
-1. **`source_code` in `ICreateXxxParams`** — declared in 9 modules
-   (accessControl, appendStructure, enhancement, functionInclude, interface,
-   scalarFunctionImplementation, scalarFunction, serviceDefinition,
-   transformation), never read by any `create.ts`. In three of them
+1. **`source_code` in `ICreateXxxParams`** — declared in **5** modules'
+   *create* params (accessControl, enhancement, functionInclude, scalarFunction,
+   serviceDefinition), never read by any `create.ts`. (A coarse grep for
+   `source_code` matches 9 files, but in the other 4 — appendStructure,
+   interface, scalarFunctionImplementation, transformation — the field lives on
+   the *update* params, which are live and out of scope.) In three of the five
    (accessControl, serviceDefinition, functionInclude) the high-level `create()`
    also populates it on the low-level call — a dead pass-through (see Scope for
    the exact per-module breakdown). By design `create()` posts metadata only —
@@ -29,20 +31,22 @@ Both were deferred from the 7.4.1/7.4.2 readiness-read work.
 
 - **`source_code`: two distinct removals — the type field, and the dead
   `create()` pass-through — which do NOT cover the same modules.** Verified
-  against current code (see table). The low-level `create.ts` of all 9 ignores
+  against current code (see table). The low-level `create.ts` of all five ignores
   the snake_case `source_code` field (metadata-only POST). `program` is out of
   scope — it genuinely uploads source, reading the camelCase `sourceCode` config,
   not this dead `source_code` param.
 
-  **(a) Type field `source_code` in `ICreateXxxParams` — 9 modules.** Eight are
+  **(a) Type field `source_code` in `ICreateXxxParams` — 5 modules.** Four are
   internal (absent from the built `dist/index*.d.ts`): accessControl,
-  appendStructure, functionInclude, interface, scalarFunctionImplementation,
-  scalarFunction, serviceDefinition, transformation → field deleted. The ninth,
+  functionInclude, scalarFunction, serviceDefinition → field deleted. The fifth,
   **`ICreateEnhancementParams`, is publicly exported** (`src/index.core.ts:80` →
   root `src/index.ts:25` → present in `dist/index.core.d.ts`), so deleting
   `source_code?: string` (`enhancement/types.ts:46`) would break TS consumers.
   It is **kept and marked `@deprecated`** ("no-op — `create()` posts metadata
-  only; source is written by `update()`").
+  only; source is written by `update()`"). The four modules whose `source_code`
+  lives only on their *update* params (appendStructure, interface,
+  scalarFunctionImplementation, transformation) are NOT touched — those fields
+  are live.
 
   **(b) Dead `create()` pass-through — exactly 3 modules.** Only these set the
   field on the low-level create call: `accessControl` and `serviceDefinition`
@@ -50,20 +54,17 @@ Both were deferred from the 7.4.1/7.4.2 readiness-read work.
   `functionInclude` (via `buildCreateParams`,
   `AdtFunctionInclude.ts:118 → source_code: config.sourceCode`). Removing the
   type field forces removing these three lines (they would otherwise not
-  compile). The other 6 modules never pass `source_code` in `create()` — nothing
-  to remove there beyond the type field.
+  compile). accessControl, serviceDefinition and functionInclude are all in the
+  five-module set (a); scalarFunction and enhancement declare the dead field but
+  never pass it in `create()`.
 
-  | module | type field (a) | create() pass-through (b) |
-  |---|---|---|
-  | accessControl | remove | remove (direct) |
-  | serviceDefinition | remove | remove (direct) |
-  | functionInclude | remove | remove (`buildCreateParams:118`) |
-  | appendStructure | remove | — none |
-  | interface | remove | — none |
-  | scalarFunction | remove | — none |
-  | scalarFunctionImplementation | remove | — none |
-  | transformation | remove | — none |
-  | enhancement (public) | **deprecate, keep** | — none (already doesn't pass) |
+  | module | create params declare `source_code` | type field (a) | create() pass-through (b) |
+  |---|---|---|---|
+  | accessControl | yes (internal) | remove | remove (direct) |
+  | serviceDefinition | yes (internal) | remove | remove (direct) |
+  | functionInclude | yes (internal) | remove | remove (`buildCreateParams:118`) |
+  | scalarFunction | yes (internal) | remove | — none |
+  | enhancement | yes (**public**) | **deprecate, keep** | — none |
 
   **Do NOT touch:** `functionInclude`'s real source upload — its `create()`
   genuinely uploads source via `uploadFunctionIncludeSource` (like `program`),
@@ -92,7 +93,7 @@ Both were deferred from the 7.4.1/7.4.2 readiness-read work.
 - The shared `IReadOptions` (`src/core/shared/types.ts`) is untouched — its
   `withLongPolling` is honored by the 15 source-bearing handlers.
 - `program` create is untouched.
-- No public API break: the 8 internal `ICreateXxxParams` are not exported; the
+- No public API break: the 4 internal `ICreateXxxParams` are not exported; the
   public `ICreateEnhancementParams` keeps its `source_code` field (deprecated,
   not removed); the featureToggle public signatures stay per interface.
 
@@ -127,7 +128,7 @@ source_code`) is preserved as `@deprecated`, everything else removed is internal
 
 ## Risk
 
-Low. The 8 internal `source_code` removals are compile-checked across the tree;
+Low. The 4 internal `source_code` removals are compile-checked across the tree;
 those types are not part of the published surface, so no external consumer is
 affected. The one public type (`ICreateEnhancementParams`) keeps its field, so no
 external TS build breaks. featureToggle keeps its public signature per interface,

--- a/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-16-dead-api-surface-cleanup-design.md
@@ -7,9 +7,11 @@ Two internal API surfaces claim capabilities the code never delivers:
 1. **`source_code` in `ICreateXxxParams`** — declared in 9 modules
    (accessControl, appendStructure, enhancement, functionInclude, interface,
    scalarFunctionImplementation, scalarFunction, serviceDefinition,
-   transformation), never read by any `create.ts`. In 8 of them the high-level
-   `create()` even populates it (`source_code: options?.sourceCode || …`), a
-   dead pass-through. By design `create()` posts metadata only — the source is
+   transformation), never read by any `create.ts`. In three of them
+   (accessControl, serviceDefinition, functionInclude) the high-level `create()`
+   also populates it on the low-level call — a dead pass-through (see Scope for
+   the exact per-module breakdown). By design `create()` posts metadata only —
+   the source is
    written by a later `update()`, mirroring Eclipse ADT (verified live for SRVD
    in 7.4.1). The field is a no-op that misleads callers into thinking `create()`
    uploads source.
@@ -24,32 +26,48 @@ Both were deferred from the 7.4.1/7.4.2 readiness-read work.
 
 ## Scope decisions
 
-- **`source_code`: remove the dead pass-through everywhere; remove the field
-  from the 8 internal types, deprecate it on the 1 public type.**
+- **`source_code`: two distinct removals — the type field, and the dead
+  `create()` pass-through — which do NOT cover the same modules.** Verified
+  against current code (see table). The low-level `create.ts` of all 9 ignores
+  the field (metadata-only POST); `program`'s does read it and is out of scope.
 
-  Of the 9 `ICreateXxxParams`, eight are internal (not exported from
-  `src/index.ts` — confirmed absent from the built `dist/index*.d.ts`):
-  accessControl, appendStructure, functionInclude, interface,
-  scalarFunctionImplementation, scalarFunction, serviceDefinition,
-  transformation. The field is deleted from all eight.
+  **(a) Type field `source_code` in `ICreateXxxParams` — 9 modules.** Eight are
+  internal (absent from the built `dist/index*.d.ts`): accessControl,
+  appendStructure, functionInclude, interface, scalarFunctionImplementation,
+  scalarFunction, serviceDefinition, transformation → field deleted. The ninth,
+  **`ICreateEnhancementParams`, is publicly exported** (`src/index.core.ts:80` →
+  root `src/index.ts:25` → present in `dist/index.core.d.ts`), so deleting
+  `source_code?: string` (`enhancement/types.ts:46`) would break TS consumers.
+  It is **kept and marked `@deprecated`** ("no-op — `create()` posts metadata
+  only; source is written by `update()`").
 
-  The ninth, **`ICreateEnhancementParams`, is publicly exported**
-  (`src/index.core.ts:80` → root `src/index.ts:25` → present in
-  `dist/index.core.d.ts`). Deleting `source_code?: string` there
-  (`src/core/enhancement/types.ts:46`) would be a source-level break for TS
-  consumers referencing the field. To keep the release non-breaking, the public
-  field is **kept and marked `@deprecated`** ("no-op — `create()` posts metadata
-  only; source is written by `update()`"), while its dead runtime pass-through in
-  `AdtEnhancement.create()` is removed like the others.
+  **(b) Dead `create()` pass-through — exactly 3 modules.** Only these set the
+  field on the low-level create call: `accessControl` and `serviceDefinition`
+  (direct `source_code: options?.sourceCode || config.sourceCode`), and
+  `functionInclude` (via `buildCreateParams`,
+  `AdtFunctionInclude.ts:118 → source_code: config.sourceCode`). Removing the
+  type field forces removing these three lines (they would otherwise not
+  compile). The other 6 modules never pass `source_code` in `create()` — nothing
+  to remove there beyond the type field.
 
-  Note: `enhancement/types.ts` also declares `source_code` on the *update* params
-  (`:55`, required) — that one is live (enhancement update writes source) and is
-  NOT touched. Only the create-params field is deprecated.
+  | module | type field (a) | create() pass-through (b) |
+  |---|---|---|
+  | accessControl | remove | remove (direct) |
+  | serviceDefinition | remove | remove (direct) |
+  | functionInclude | remove | remove (`buildCreateParams:118`) |
+  | appendStructure | remove | — none |
+  | interface | remove | — none |
+  | scalarFunction | remove | — none |
+  | scalarFunctionImplementation | remove | — none |
+  | transformation | remove | — none |
+  | enhancement (public) | **deprecate, keep** | — none (already doesn't pass) |
 
-  In all 9 modules the dead pass-through in the high-level `create()` (8 of them
-  set `source_code:` on the low-level call; `interface` does not) is removed.
-  `program` is untouched — it is the only module that genuinely uploads source
-  (as a separate step inside its create flow).
+  **Do NOT touch:** `functionInclude`'s real source upload — its `create()`
+  genuinely uploads source via `uploadFunctionIncludeSource` (like `program`),
+  reading `options?.sourceCode || config.sourceCode`; only the dead
+  `buildCreateParams` field-set is removed. `enhancement/types.ts` also declares
+  `source_code` on the *update* params (`:55`, required) — live, untouched.
+  `program` is entirely out of scope.
 
 - **`withLongPolling`: remove the dead plumbing only.** The published
   `IAdtObject` interface (`@mcp-abap-adt/interfaces`,
@@ -90,10 +108,13 @@ source_code`) is preserved as `@deprecated`, everything else removed is internal
 - **Public API-surface guard (enhancement):** a type-level unit test asserts the
   intended public surface is preserved — `ICreateEnhancementParams` still carries
   an optional `source_code` field (compile-time: a value of the type may set it,
-  and omitting it is valid). This pins the compatibility decision so an
-  accidental future removal fails a test, not just a downstream consumer's build.
-  (`@deprecated` is a doc annotation and is not itself type-checkable; the test
-  guards the field's continued existence.)
+  and omitting it is valid). **The test MUST import `ICreateEnhancementParams`
+  from the published barrel (`src/index` or `src/index.core`), not from
+  `src/core/enhancement/types`** — otherwise it guards the internal type while the
+  public barrel export could still break. This pins the compatibility decision so
+  an accidental future removal (of the field or its re-export) fails a test, not
+  just a downstream consumer's build. (`@deprecated` is a doc annotation and is
+  not itself type-checkable; the test guards the field's continued existence.)
 - **`withLongPolling`:** a wire-level unit test asserts `readFeatureToggle` never
   appends `withLongPolling` to the request, documenting the deliberate choice
   not to send an unverified parameter.

--- a/src/__tests__/unit/core/enhancementCreateParamsSurface.test.ts
+++ b/src/__tests__/unit/core/enhancementCreateParamsSurface.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Public API-surface guard: ICreateEnhancementParams is publicly exported
+ * (src/index.core.ts -> src/index.ts). Its `source_code` field is a deprecated
+ * no-op that is intentionally KEPT for backward compatibility (removing it would
+ * break TS consumers). This test imports from the published barrel — not from
+ * core/enhancement/types — so it guards the real exported surface, including the
+ * barrel re-export. If the field or its export is removed, the type index below
+ * stops compiling and this suite fails to build.
+ */
+import type { ICreateEnhancementParams } from '../../../index';
+
+// Compile-time guards (checked by ts-jest at build):
+// 1. The field still exists on the exported type.
+type _FieldExists = ICreateEnhancementParams['source_code'];
+// 2. It is still optional (undefined is assignable to it).
+const _optional: _FieldExists = undefined;
+
+describe('ICreateEnhancementParams public surface', () => {
+  it('keeps source_code as an optional field on the published type', () => {
+    // The real assertion is the compile-time type index above; this runtime
+    // body exists so Jest registers a passing test once the file type-checks.
+    expect(_optional).toBeUndefined();
+  });
+});

--- a/src/__tests__/unit/core/featureToggleNoLongPolling.test.ts
+++ b/src/__tests__/unit/core/featureToggleNoLongPolling.test.ts
@@ -1,0 +1,35 @@
+/**
+ * featureToggle readiness reads are a plain GET: the SFW endpoint's support for
+ * withLongPolling could not be verified from the cloud trial (SFW is on-prem),
+ * so we deliberately never send it. This test pins that — readFeatureToggle must
+ * not put withLongPolling in the request URL or params. It guards against a
+ * future "fix" that wires an unverified parameter.
+ */
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { readFeatureToggle } from '../../../core/featureToggle/read';
+
+function fakeConn(): { conn: IAbapConnection; calls: any[] } {
+  const calls: any[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    return { status: 200, data: '' };
+  });
+  return {
+    conn: {
+      makeAdtRequest,
+      setSessionType: jest.fn(),
+    } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+describe('readFeatureToggle never sends withLongPolling', () => {
+  it('omits withLongPolling from url and params', async () => {
+    const { conn, calls } = fakeConn();
+    await readFeatureToggle(conn, 'ZTEST_FT', 'inactive');
+    expect(calls).toHaveLength(1);
+    const req = calls[0];
+    expect(String(req.url)).not.toContain('withLongPolling');
+    expect(req.params?.withLongPolling).toBeUndefined();
+  });
+});

--- a/src/__tests__/unit/core/serviceDefinitionCreateMetadataOnly.test.ts
+++ b/src/__tests__/unit/core/serviceDefinitionCreateMetadataOnly.test.ts
@@ -1,0 +1,54 @@
+/**
+ * create() is metadata-only: the POST to the SRVD create endpoint carries the
+ * object metadata (name, package, description) but never the source code, even
+ * when sourceCode is passed. This is the invariant behind removing the dead
+ * source_code create-param — source is written by update(), as in Eclipse ADT.
+ */
+import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import { AdtServiceDefinition } from '../../../core/serviceDefinition/AdtServiceDefinition';
+import { createTestsLogger } from '../../helpers/testLogger';
+
+const logger: ILogger = createTestsLogger();
+const UNIQUE_SOURCE = 'define service ZUNIQUE_SRC_MARKER { expose ZFOO; }';
+
+function fakeConn(): { conn: IAbapConnection; calls: any[] } {
+  const calls: any[] = [];
+  const makeAdtRequest = jest.fn(async (req: any) => {
+    calls.push(req);
+    return { status: 201, data: '' };
+  });
+  return {
+    conn: {
+      makeAdtRequest,
+      setSessionType: jest.fn(),
+    } as unknown as IAbapConnection,
+    calls,
+  };
+}
+
+describe('AdtServiceDefinition.create is metadata-only', () => {
+  it('does not put source code in the create POST body', async () => {
+    const { conn, calls } = fakeConn();
+    const handler = new AdtServiceDefinition(conn, logger);
+
+    await handler.create(
+      {
+        serviceDefinitionName: 'ZMETA_ONLY',
+        packageName: 'ZPKG',
+        description: 'meta only',
+        sourceCode: UNIQUE_SOURCE,
+      },
+      { sourceCode: UNIQUE_SOURCE },
+    );
+
+    const posts = calls.filter((c) => c.method === 'POST');
+    expect(posts.length).toBeGreaterThan(0);
+    for (const req of posts) {
+      const body =
+        typeof req.data === 'string'
+          ? req.data
+          : JSON.stringify(req.data ?? '');
+      expect(body).not.toContain('ZUNIQUE_SRC_MARKER');
+    }
+  });
+});

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -117,7 +117,7 @@ export class AdtAccessControl
    */
   async create(
     config: IAccessControlConfig,
-    options?: IAdtOperationOptions,
+    _options?: IAdtOperationOptions,
   ): Promise<IAccessControlState> {
     const state: IAccessControlState = { errors: [] };
     if (!config.accessControlName) {
@@ -140,7 +140,6 @@ export class AdtAccessControl
         package_name: config.packageName,
         transport_request: config.transportRequest,
         description: config.description,
-        source_code: options?.sourceCode || config.sourceCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
         masterLanguage:

--- a/src/core/accessControl/types.ts
+++ b/src/core/accessControl/types.ts
@@ -6,7 +6,6 @@ export interface ICreateAccessControlParams {
   description?: string;
   package_name: string;
   transport_request?: string;
-  source_code?: string;
   masterSystem?: string;
   responsible?: string;
   masterLanguage?: string;

--- a/src/core/enhancement/types.ts
+++ b/src/core/enhancement/types.ts
@@ -43,6 +43,10 @@ export interface ICreateEnhancementParams {
   transport_request?: string;
   enhancement_spot?: string; // Required for implementations
   badi_definition?: string; // Required for BAdI implementations
+  /**
+   * @deprecated No-op. `create()` posts metadata only; the source is written by
+   * `update()`. Kept for backward compatibility — this field is never read.
+   */
   source_code?: string; // For enhoxhh only
   masterSystem?: string;
   responsible?: string;

--- a/src/core/featureToggle/AdtFeatureToggle.ts
+++ b/src/core/featureToggle/AdtFeatureToggle.ts
@@ -41,7 +41,7 @@ import { create as createFeatureToggle } from './create';
 import { checkDeletion, deleteFeatureToggle } from './delete';
 import { getFeatureToggleState } from './getState';
 import { lockFeatureToggle } from './lock';
-import { type IReadOptions, readFeatureToggle } from './read';
+import { readFeatureToggle } from './read';
 import { readFeatureToggleSource } from './readSource';
 import { toggleFeatureToggle } from './switch';
 import type {
@@ -262,7 +262,9 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
   async read(
     config: Partial<IFeatureToggleConfig>,
     version?: 'active' | 'inactive',
-    options?: IReadOptions,
+    // withLongPolling accepted per IAdtObject, but not forwarded: SFW readiness
+    // is a plain GET (endpoint support unverified — on-prem only).
+    options?: { withLongPolling?: boolean },
   ): Promise<IFeatureToggleState | undefined> {
     if (!config.featureToggleName) {
       throw new Error('Feature toggle name is required');
@@ -273,7 +275,6 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
         this.connection,
         config.featureToggleName,
         version ?? 'active',
-        options,
       );
       return {
         readResult: response,
@@ -451,7 +452,6 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
         const readState = await this.read(
           { featureToggleName: fullConfig.featureToggleName },
           'inactive',
-          { withLongPolling: true },
         );
         if (readState) {
           state.readResult = readState.readResult;
@@ -504,7 +504,6 @@ export class AdtFeatureToggle implements IFeatureToggleObject {
           const readState = await this.read(
             { featureToggleName: fullConfig.featureToggleName },
             'active',
-            { withLongPolling: true },
           );
           if (readState) {
             state.readResult = readState.readResult;

--- a/src/core/featureToggle/read.ts
+++ b/src/core/featureToggle/read.ts
@@ -6,15 +6,14 @@ import { ACCEPT_FEATURE_TOGGLE_METADATA } from '../../constants/contentTypes';
 import { encodeSapObjectName } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
 
-export interface IReadOptions {
-  withLongPolling?: boolean;
-}
-
+// NOTE: withLongPolling is intentionally not accepted here. The SFW feature-
+// toggle endpoint's support for it is unverified (on-prem only), so readiness
+// reads are a plain GET. The public AdtFeatureToggle.read()/readMetadata()
+// still accept withLongPolling to satisfy IAdtObject, but it is not forwarded.
 export async function readFeatureToggle(
   connection: IAbapConnection,
   name: string,
   version: 'active' | 'inactive' = 'active',
-  _options?: IReadOptions,
 ): Promise<AxiosResponse> {
   const encoded = encodeSapObjectName(name.toLowerCase());
   return connection.makeAdtRequest({

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -115,7 +115,6 @@ export class AdtFunctionInclude
       transport_request: config.transportRequest,
       master_system: config.masterSystem ?? this.systemContext.masterSystem,
       responsible: config.responsible ?? this.systemContext.responsible,
-      source_code: config.sourceCode,
     };
   }
 

--- a/src/core/functionInclude/types.ts
+++ b/src/core/functionInclude/types.ts
@@ -11,7 +11,6 @@ export interface ICreateFunctionIncludeParams {
   transport_request?: string;
   master_system?: string;
   responsible?: string;
-  source_code?: string;
 }
 
 export interface IFunctionIncludeConfig {

--- a/src/core/scalarFunction/types.ts
+++ b/src/core/scalarFunction/types.ts
@@ -9,7 +9,6 @@ export interface ICreateScalarFunctionParams {
   description?: string;
   package_name: string;
   transport_request?: string;
-  source_code?: string;
   masterSystem?: string;
   responsible?: string;
   masterLanguage?: string;

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -122,7 +122,7 @@ export class AdtServiceDefinition
    */
   async create(
     config: IServiceDefinitionConfig,
-    options?: IAdtOperationOptions,
+    _options?: IAdtOperationOptions,
   ): Promise<IServiceDefinitionState> {
     const state: IServiceDefinitionState = { errors: [] };
     if (!config.serviceDefinitionName) {
@@ -145,7 +145,6 @@ export class AdtServiceDefinition
         package_name: config.packageName,
         transport_request: config.transportRequest,
         description: config.description,
-        source_code: options?.sourceCode || config.sourceCode,
         masterSystem: this.systemContext.masterSystem,
         responsible: this.systemContext.responsible,
         masterLanguage:

--- a/src/core/serviceDefinition/types.ts
+++ b/src/core/serviceDefinition/types.ts
@@ -10,7 +10,6 @@ export interface ICreateServiceDefinitionParams {
   description?: string;
   package_name: string;
   transport_request?: string;
-  source_code?: string;
   masterSystem?: string;
   responsible?: string;
   masterLanguage?: string;


### PR DESCRIPTION
Two internal dead/misleading API-surface cleanups. **Non-breaking → patch 7.4.3.** Executed via subagent-driven development (3 code tasks, each spec+quality reviewed; final whole-branch review clean).

## 1. Dead `source_code` on create-params

`create()` posts object metadata only — source is written by a later `update()` (verified live for SRVD in 7.4.1). A `source_code` field on several `ICreateXxxParams` was never read.

- **Removed** the field from 4 **internal** create-params: `ICreateAccessControlParams`, `ICreateFunctionIncludeParams`, `ICreateScalarFunctionParams`, `ICreateServiceDefinitionParams`.
- **Removed** the 3 dead `create()` pass-throughs: `AdtAccessControl`/`AdtServiceDefinition` (direct), `AdtFunctionInclude.buildCreateParams`.
- **Kept + `@deprecated`**: `ICreateEnhancementParams.source_code` is **publicly exported** (`src/index.core.ts`), so removing it would break TS consumers. Preserved as a deprecated no-op instead → no API break.
- **Untouched**: `program` (genuinely uploads source), all `IUpdateXxxParams.source_code` (live), and functionInclude's real `uploadFunctionIncludeSource` path.

## 2. featureToggle `withLongPolling`

`readFeatureToggle` accepted a `withLongPolling` option (via a local `IReadOptions` duplicate) it never sent.

- **Removed** the dead `_options` param and the local `IReadOptions` duplicate.
- **Kept** the public `AdtFeatureToggle.read()`/`readMetadata()` acceptance of `withLongPolling` — the published `IAdtObject` interface mandates it — but it is no longer forwarded. Documented that SFW readiness is a plain GET (endpoint support unverified — SFW is on-prem).

## Tests

Three new guard/characterization tests:
- `enhancementCreateParamsSurface` — imports `ICreateEnhancementParams` from the **public barrel** and pins the deprecated field's existence (fails to compile if the public field/export is removed).
- `serviceDefinitionCreateMetadataOnly` — drives `create()` with a source marker and asserts no POST body carries it.
- `featureToggleNoLongPolling` — asserts the low-level GET never sends `withLongPolling`.

Full unit suite 348/348, `build:fast` clean, `lint:check` exit 0. No published-API break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)