### PR TITLE
release(7.4.4): bump @mcp-abap-adt/interfaces to ^10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.4.4] - 2026-07-17
+
+### Changed
+- **Bump `@mcp-abap-adt/interfaces` to `^10.0.0`.** interfaces 10.0.0 removes the no-op `source_code` from its create-params (completing the 7.4.3 drift resolution — see interfaces CHANGELOG). No adt-clients code change: adt-clients uses its own local param copies and never imported the removed fields. Build, lint, and the full unit suite (348) pass against interfaces 10.0.0.
+
 ## [7.4.3] - 2026-07-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.4.3",
+  "version": "7.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "7.4.3",
+      "version": "7.4.4",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^9.2.0",
+        "@mcp-abap-adt/interfaces": "^10.0.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-9.2.0.tgz",
-      "integrity": "sha512-iMb3OOjMsMxAf8dSXz763uq+Q4CV32fuSjc6GSL4Uu8cCxjJs3AWjNgbQFyhmzIhw0LlSlYWChCkrZBOUJI7GA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-10.0.0.tgz",
+      "integrity": "sha512-fnXWmqMQHUulKQtSZH1a7L3uhgutGgSCpyWMCQHQNu4VMR5oguLtMsX2cBU90wxj3CJup0/n/HRdDMj05liwAw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.4.3",
+  "version": "7.4.4",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -113,7 +113,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^9.2.0",
+    "@mcp-abap-adt/interfaces": "^10.0.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.18.1",
     "fast-xml-parser": "^5.9.3"


### PR DESCRIPTION
Realigns adt-clients onto `@mcp-abap-adt/interfaces@^10.0.0` (interfaces 10.0.0 removed the no-op `source_code` from create-params — completing the 7.4.3 drift resolution).

- **No adt-clients code change**: it uses its own local param copies and never imported the removed fields.
- Verified against interfaces 10.0.0: `build:fast` clean, `lint:check` exit 0, full unit suite 348/348.
- `package-lock.json` resolves interfaces 10.0.0 from the npm registry (no `link:true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)