### PR TITLE
fix(activation): activateObjectInSession throws on failed activation (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.5.1] - 2026-07-21
+
+### Fixed
+- **`activateObjectInSession` no longer masks a failed activation as success (#78).** ADT's `/sap/bc/adt/activation` endpoint returns HTTP 200 even when activation fails (object locked by another session, syntax errors), carrying a `<chkl:messages>` body with `chkl:properties activationExecuted="false"` and/or `<msg type="E">` entries. The shared helper previously returned that response unchecked, so every object type built on it (domain, program, table, structure, class, interface, ddl, tabletype, functionModule, functionInclude, metadataExtension, behaviorDefinition, enhancement, unitTest — 15 in total) reported a false success on a locked/failed activation. This is the root cause of the downstream false `success:true` in fr0ster/mcp-abap-adt#154 (`UpdateDomain` on a locked domain). The helper now inspects the body and throws on an **explicit** failure signal only (`activationExecuted="false"` or error-severity `<msg>`), collecting the ADT error text into the thrown message. Empty, unparseable, or unrecognized bodies are still treated as success, so the differing success-body shapes across the 15 types are never regressed into false failures. The 9 object types that already parse their own activation response (dataElement, serviceDefinition, accessControl, scalarFunction, scalarFunctionImplementation, transformation, appendStructure, authorizationField, featureToggle) are unaffected — they do not route through the shared helper.
+
 ## [7.5.0] - 2026-07-19
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/unit/utils/activateObjectInSession.test.ts
+++ b/src/__tests__/unit/utils/activateObjectInSession.test.ts
@@ -1,0 +1,81 @@
+import type { IAbapConnection } from '@mcp-abap-adt/interfaces';
+import { activateObjectInSession } from '../../../utils/activationUtils';
+
+/**
+ * Regression guard for the false-success masking bug (issue #78).
+ *
+ * ADT `/sap/bc/adt/activation` returns HTTP 200 even when activation fails
+ * (object locked by another session, syntax errors). The body then carries
+ * `<chkl:properties activationExecuted="false">` and/or `<msg type="E">`.
+ * `activateObjectInSession` must throw on that explicit failure signal, while
+ * preserving success for empty / unrecognized bodies.
+ */
+describe('activateObjectInSession — failed activation must not masquerade as success', () => {
+  const OBJECT_URI = '/sap/bc/adt/ddic/domains/zd_mask_test';
+  const OBJECT_NAME = 'ZD_MASK_TEST';
+
+  function connectionReturning(data: string): IAbapConnection {
+    return {
+      makeAdtRequest: jest.fn().mockResolvedValue({ status: 200, data }),
+    } as unknown as IAbapConnection;
+  }
+
+  const LOCKED_FAILURE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklistmessages">
+  <msg objDescr="Domain ZD_MASK_TEST" type="E" line="0">
+    <shortText>
+      <txt>Domain ZD_MASK_TEST is locked by user OTHERUSER</txt>
+    </shortText>
+  </msg>
+  <chkl:properties activationExecuted="false" checkExecuted="true"/>
+</chkl:messages>`;
+
+  const SUCCESS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<chkl:messages xmlns:chkl="http://www.sap.com/abapxml/checklistmessages">
+  <chkl:properties activationExecuted="true" checkExecuted="true"/>
+</chkl:messages>`;
+
+  it('throws when activationExecuted="false" (locked object)', async () => {
+    const connection = connectionReturning(LOCKED_FAILURE_XML);
+    await expect(
+      activateObjectInSession(connection, OBJECT_URI, OBJECT_NAME),
+    ).rejects.toThrow(/ZD_MASK_TEST/);
+  });
+
+  it('surfaces the error-severity message text in the thrown error', async () => {
+    const connection = connectionReturning(LOCKED_FAILURE_XML);
+    await expect(
+      activateObjectInSession(connection, OBJECT_URI, OBJECT_NAME),
+    ).rejects.toThrow(/locked by user OTHERUSER/);
+  });
+
+  it('resolves when activationExecuted="true"', async () => {
+    const connection = connectionReturning(SUCCESS_XML);
+    const res = await activateObjectInSession(
+      connection,
+      OBJECT_URI,
+      OBJECT_NAME,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('resolves on an empty success body (no failure signal)', async () => {
+    const connection = connectionReturning('');
+    const res = await activateObjectInSession(
+      connection,
+      OBJECT_URI,
+      OBJECT_NAME,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('resolves on an unrecognized body (never infers failure)', async () => {
+    const connection = connectionReturning('<something:else/>');
+    const res = await activateObjectInSession(
+      connection,
+      OBJECT_URI,
+      OBJECT_NAME,
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/utils/activationUtils.ts
+++ b/src/utils/activationUtils.ts
@@ -10,9 +10,103 @@ import type {
   IAdtResponse as AxiosResponse,
   IAbapConnection,
 } from '@mcp-abap-adt/interfaces';
+import { XMLParser } from 'fast-xml-parser';
 import { CT_ACTIVATION } from '../constants/contentTypes';
 import { encodeSapObjectName } from './internalUtils';
 import { getTimeout } from './timeouts';
+
+/**
+ * Extract a human-readable text from a single ADT `<msg>` node.
+ */
+function extractActivationMsgText(msg: {
+  shortText?: { txt?: unknown } | string;
+  objDescr?: unknown;
+}): string {
+  const shortText = msg?.shortText;
+  if (shortText && typeof shortText === 'object' && 'txt' in shortText) {
+    const txt = (shortText as { txt?: unknown }).txt;
+    if (typeof txt === 'string' && txt.trim()) {
+      return txt.trim();
+    }
+  }
+  if (typeof shortText === 'string' && shortText.trim()) {
+    return shortText.trim();
+  }
+  if (typeof msg?.objDescr === 'string' && msg.objDescr.trim()) {
+    return msg.objDescr.trim();
+  }
+  return 'activation error';
+}
+
+/**
+ * Inspect an ADT activation response body for an **explicit failure signal**.
+ *
+ * ADT's `/sap/bc/adt/activation` endpoint returns HTTP 200 even when activation
+ * fails (object locked by another session, syntax errors), carrying a
+ * `<chkl:messages>` body with `chkl:properties activationExecuted="false"` and/or
+ * `<msg type="E">` entries. Treating "no HTTP error" as success masks these
+ * failures (issue #78).
+ *
+ * Conservative by design: returns a failure detail string ONLY on a positive
+ * error signal. Empty, unparseable, or unrecognized bodies return `null`
+ * (success) so the many object types whose success-body shape differs are never
+ * regressed into false failures.
+ *
+ * @returns failure detail text, or `null` when no failure signal is present
+ */
+function detectActivationFailure(responseData: unknown): string | null {
+  if (typeof responseData !== 'string' || responseData.trim() === '') {
+    return null;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    const parser = new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '',
+    });
+    parsed = parser.parse(responseData) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const messages = parsed?.['chkl:messages'] as
+    | {
+        'chkl:properties'?: { activationExecuted?: unknown };
+        msg?: unknown;
+      }
+    | undefined;
+  if (!messages) {
+    return null;
+  }
+
+  const activationExecuted = messages['chkl:properties']?.activationExecuted;
+  const executedFalse =
+    activationExecuted === 'false' || activationExecuted === false;
+
+  const rawMsg = messages.msg;
+  const msgList = Array.isArray(rawMsg) ? rawMsg : rawMsg ? [rawMsg] : [];
+  const errorTexts = msgList
+    .filter((m) => {
+      const severity =
+        (m as { type?: unknown; severity?: unknown })?.type ??
+        (m as { severity?: unknown })?.severity;
+      return typeof severity === 'string' && severity.toUpperCase() === 'E';
+    })
+    .map((m) =>
+      extractActivationMsgText(
+        m as Parameters<typeof extractActivationMsgText>[0],
+      ),
+    );
+
+  if (executedFalse || errorTexts.length > 0) {
+    return errorTexts.length > 0
+      ? errorTexts.join('; ')
+      : 'activationExecuted=false';
+  }
+
+  return null;
+}
 
 /**
  * Build object URI from name and type
@@ -163,11 +257,21 @@ export async function activateObjectInSession(
     Accept: 'application/xml',
   };
 
-  return await connection.makeAdtRequest({
+  const response = await connection.makeAdtRequest({
     url,
     method: 'POST',
     timeout: getTimeout('default'),
     data: activationXml,
     headers,
   });
+
+  // ADT returns HTTP 200 even on failed activation (locked object, syntax
+  // errors). Surface an explicit failure signal as a thrown error instead of
+  // letting callers report a false success (issue #78).
+  const failure = detectActivationFailure(response.data);
+  if (failure) {
+    throw new Error(`Activation of ${objectName} failed: ${failure}`);
+  }
+
+  return response;
 }


### PR DESCRIPTION
Closes #78. Root cause of the downstream false `success:true` in fr0ster/mcp-abap-adt#154.

## Problem

ADT's `/sap/bc/adt/activation` returns **HTTP 200 even when activation fails**
(object locked by another session, syntax errors), carrying a `<chkl:messages>`
body with `chkl:properties activationExecuted="false"` and/or `<msg type="E">`.

The shared `activateObjectInSession` helper returned that response unchecked, so
**15 object types** built on it reported a false success on a locked/failed
activation: domain, program, table, structure, class (+testclasses), interface,
ddl, tabletype, functionModule, functionInclude, metadataExtension,
behaviorDefinition, enhancement, unitTest.

Downstream, `UpdateDomain` on a domain locked in another session (confirmed in
SM12) returned `{"success":true,"status":"active","message":"... updated and
activated successfully"}` — an LLM-agent consumer then loops forever retrying an
"apparently successful" update.

## Fix (conservative, source-level)

`activateObjectInSession` now inspects the response body and throws on an
**explicit failure signal only**:

- `chkl:properties.activationExecuted === "false"` → throw
- error-severity `<msg>` (`type`/`severity` === "E") → throw, with collected message text
- empty / unparseable / unrecognized body → success (unchanged)

The "throw only on a positive error signal" rule means the 15 types' success
paths — whose bodies differ per type (group activation, for instance, returns an
empty body on success) — are **never** regressed into false failures.

The 9 object types that already parse their own activation response
(dataElement, serviceDefinition, accessControl, scalarFunction,
scalarFunctionImplementation, transformation, appendStructure,
authorizationField, featureToggle) are unaffected — they call
`makeAdtRequest` directly and never route through the shared helper.

## Before / after

```ts
// before: locked object → HTTP 200 with activationExecuted="false"
await activateObjectInSession(conn, uri, name);  // resolves → caller reports success

// after
await activateObjectInSession(conn, uri, name);  // throws:
//   "Activation of ZD_MASK_TEST failed: Domain ZD_MASK_TEST is locked by user OTHERUSER"
```

## Tests

New unit suite `src/__tests__/unit/utils/activateObjectInSession.test.ts` (5 cases):
throws on `activationExecuted="false"`, surfaces the error-message text, and
still resolves on `activationExecuted="true"` / empty body / unrecognized body.

- `npm run build` — clean (tsc + biome error-level)
- `npx jest src/__tests__/unit` — 68 suites, 353 tests pass (incl. the 5 new)

## Verification note

The failed-activation XML in the unit test is reconstructed from the ADT
contract. Recommend confirming the parser against a **live locked-object
activation** in the integration suite before closing the downstream
fr0ster/mcp-abap-adt#154.

## Consumer realignment

After publish, fr0ster/mcp-abap-adt bumps the dep to 7.5.1; `handleUpdateDomain`
then surfaces `isError:true` automatically (its catch maps a locked error → McpError).

🤖 Generated with [Claude Code](https://claude.com/claude-code)