### PR TITLE
release(7.6.0): capability-composition pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.6.0] - 2026-07-21
+
+### Changed
+- **Pilot of the capability-composition architecture.** `AdtClass`, `AdtDomain` and `AdtServiceDefinition` now route lock/unlock (and, for the two source-backed types, version history) through shared `LockCapability` / `VersionsCapability` implementations parameterized by a per-handler strategy, instead of bespoke per-type wrappers. `AdtDomain` composes no `VersionsCapability` — it has no `/source/main`, so the absence is structural rather than a throwing stub. Requires `@mcp-abap-adt/interfaces ^11.2.0` (the capability atom interfaces `IAdtCrud`, `IAdtLockable`, `IAdtVersionable`, …).
+
+No API change from the composition work: the `IAdtObject` public surface is byte-identical (verified across all seven entry points — empty diff) and behaviour is unchanged (full unit suite, including cross-handler lock/unlock ordering conformance). This release also carries the 7.5.1 activation fix below.
+
 ## [7.5.1] - 2026-07-21
 
 ### Fixed

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -532,14 +532,20 @@ import type { ICapabilityContext, ILockStrategy } from './types';
  *
  * DELIBERATELY byte-identical to the current handlers, including the failure
  * path: if `acquire`/`release` throws, the session is left as-is (stateful) and
- * the error propagates — exactly as today. In the current architecture,
- * failure cleanup is the OPERATION CHAIN's job (its create/update catch blocks
- * call setSessionType('stateless')), NOT lock()/unlock()'s. Adding a
- * try/finally here would change behaviour and move that responsibility, so the
- * atom-level "restore stateless on failure" contract is deferred to the
- * behavioural-conformance work (same bucket as activate/check error
- * unification), where the chain interaction is reconciled rather than
- * double-cleaned.
+ * the error propagates — exactly as today. Failure/abandonment handling is
+ * DISTRIBUTED and this capability owns none of it:
+ *   - the consumer largely owns lock/unlock atomicity (it decides when to lock
+ *     and unlock);
+ *   - adt-clients' `LockRegistry.unlockAll()` is a disposal safety net that
+ *     raw-releases abandoned locks — deliberately WITHOUT toggling the session,
+ *     because `unlockAll()` manages the session once for the whole batch;
+ *   - the operation chain's create/update catch blocks also call
+ *     setSessionType('stateless').
+ * Adding a try/finally here would change behaviour and relocate responsibility
+ * across those layers, so the atom-level "restore stateless on failure"
+ * contract is deferred to the behavioural-conformance work (same bucket as
+ * activate/check error unification), where all three layers are reconciled
+ * rather than double-cleaned.
  */
 export class LockCapability<TConfig, TReadResult>
   implements IAdtLockable<TConfig, TReadResult>
@@ -756,6 +762,15 @@ private readonly versionsCap = new VersionsCapability<IClassConfig>(
 ```
 
 Note: `AdtClass.lock` currently also calls `this.lockTracker.track(...)`. Preserve that — keep it in the handler `lock` wrapper (Step 2), not the capability, because the tracker is handler state.
+
+**DO NOT TOUCH the constructor's `createLockTracker(...)` setup.** It passes a
+raw-unlock thunk `(name, handle) => unlockClass(this.connection, name, handle)`
+that deliberately does NOT toggle the session — it is the `LockRegistry.unlockAll()`
+disposal safety net, and `unlockAll()` manages the session for the whole batch.
+This is a SEPARATE unlock path from the `unlock()` method (which goes through the
+capability and DOES toggle). Both must survive: only the lock/unlock/versions
+method BODIES change; the constructor's tracker wiring stays exactly as it is.
+The same applies to `AdtDomain` and `AdtServiceDefinition` in Tasks B6 and B7.
 
 - [ ] **Step 2: Replace the four method bodies with capability delegation, preserving lock tracking**
 
@@ -1174,7 +1189,7 @@ Report to the user: PR opened, ready for review + merge + tag + GitHub release; 
 
 - The remaining 32 handlers — a separate migration plan, using the classification (fits-strategy vs bespoke) the spec requires; includes `AdtFunctionModule` (composite key), `AdtBehaviorImplementation` (delegates to `AdtClass`), `AdtMessageClassMessage` (double-lock).
 - `ActivateCapability` / `CheckCapability` with error-envelope unification — a deliberate behavioural change; its own plan with conformance tests and a CHANGELOG note naming the changed error shapes.
-- **The atom-level failure-path contract** (lock/unlock restore stateless on a thrown error). Today that cleanup lives in the operation chain's catch blocks, not in lock()/unlock(); this pilot preserves that exactly. Moving it into the capabilities is a deliberate behavioural change that must reconcile with the chain's existing cleanup (to avoid double-restore), so it belongs with the error-unification work, not here.
+- **The atom-level failure-path contract** (lock/unlock restore stateless on a thrown error). Today failure/abandonment handling is distributed — the consumer owns lock/unlock atomicity, `LockRegistry.unlockAll()` is a disposal safety net (raw release, no session toggle), and the operation chain's catch blocks also restore stateless. This pilot preserves all three exactly. Moving restoration into the capabilities is a deliberate behavioural change that must reconcile with all three layers (to avoid double-restore), so it belongs with the error-unification work, not here.
 - `TransportCapability` extraction.
 - Narrowing `AdtClient.getXxx()` return types (the breaking flip) and deprecating the fat contract.
 - The ATC client + `runSync` + MCP tools, built on this architecture once proven.

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -644,9 +644,12 @@ describe('VersionsCapability', () => {
     expect(await cap.getVersionSource('/uri/1')).toBe('source-of:/uri/1');
   });
 
-  it('getVersions rethrows a missing name', async () => {
+  it('getVersions rethrows a missing name', () => {
     const cap = new VersionsCapability<Cfg>(getCtx, strategy);
-    await expect(cap.getVersions({})).rejects.toThrow('name is required');
+    // getVersions is NOT async (byte-identical to the current handlers, whose
+    // getVersions throws synchronously on a missing name), so nameOf's throw
+    // propagates synchronously — assert a sync throw, not a rejection.
+    expect(() => cap.getVersions({})).toThrow('name is required');
   });
 });
 ```

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -1,0 +1,1127 @@
+# Capability Interfaces + Pilot Conversion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Declare the capability-atom interfaces in `@mcp-abap-adt/interfaces`, then pilot the composition architecture in `adt-clients` by routing two lifecycle capabilities (lock/unlock, versions) through shared implementations on three existing handlers — with the public `IAdtObject` surface and observable behaviour unchanged.
+
+**Architecture:** Phase A declares seven small capability interfaces next to `IAdtObject` (additive; `IAdtObject` stays byte-for-byte, and a compile-time proof asserts the intersection of the atoms is structurally identical to it). Phase B extracts two capability *implementations* — parameterized by a per-handler strategy — and converts `AdtClass`, `AdtDomain`, `AdtServiceDefinition` to compose them. `AdtClass` still `implements IAdtObject`; consumers see no change. The remaining 32 handlers, the error-envelope unification for activate/check, and the ATC client are explicitly out of scope — future plans.
+
+**Tech Stack:** TypeScript (strict, CommonJS output), Biome (lint/format, single quotes, semicolons, 2-space indent), ts-jest, the TypeScript compiler API for the surface snapshot and the capability matrix.
+
+## Global Constraints
+
+- All repository artifacts (code, comments, commit messages, docs) in English; communication with the user in the user's language.
+- Never change `package.json` version without explicit request; the user chooses CHANGELOG versions.
+- After changing a version, run `npm install --package-lock-only` and commit the lockfile in the same commit.
+- All dependencies resolve from the npm registry only. After every `npm install`, verify `package-lock.json` has zero `"link": true` entries.
+- The user runs `npm publish`, never the agent. The agent merges PRs, tags, and creates GitHub releases; publishing is the maintainer's step.
+- Publish the dependency (interfaces) to npm FIRST; Phase B is blocked until interfaces 11.2.0 is on npm.
+- Tests: never pipe through grep/tail/head — save the full log with `tee`, then read the log file.
+- Warn the user before launching trial integration tests (they need a browser with the right profile and a fresh JWT).
+- Unit tests without SAP: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand`.
+- Biome must pass with zero errors; the warning/info baseline is 45 warnings / 25 infos in adt-clients — do not increase it.
+- Capability atoms are additive in Phase A: `IAdtObject` is NOT redefined, no handler is modified, no `AdtClient.getXxx()` return type is narrowed.
+
+**Repos and paths:**
+- interfaces: `/home/okyslytsia/prj/mcp-abap-adt-interfaces` (Phase A)
+- adt-clients: `/home/okyslytsia/prj/mcp-abap-adt-clients` (Phase B)
+- consumer: `/home/okyslytsia/prj/mcp-abap-adt` (Phase B verification only)
+- Spec: `docs/superpowers/specs/2026-07-20-capability-interfaces-design.md`
+- Capability matrix tool: `scripts/capability-matrix.mjs` (already present)
+
+---
+
+## File Structure
+
+**Phase A — interfaces** (`src/adt/`):
+- Create `src/adt/IAdtCapabilities.ts` — the seven atom interfaces + the correctness proof.
+- Modify `src/index.ts` — export the atoms from the root barrel.
+
+**Phase B — adt-clients** (`src/`):
+- Create `src/core/shared/capabilities/types.ts` — `ICapabilityContext`, `ILockStrategy`, `IVersionsStrategy`, `INormalizedLock`.
+- Create `src/core/shared/capabilities/LockCapability.ts` — shared lock/unlock implementation.
+- Create `src/core/shared/capabilities/VersionsCapability.ts` — shared getVersions/getVersionSource implementation.
+- Create `src/core/shared/capabilities/index.ts` — re-exports.
+- Modify `src/core/class/AdtClass.ts`, `src/core/domain/AdtDomain.ts`, `src/core/serviceDefinition/AdtServiceDefinition.ts` — compose the capabilities.
+- Create `src/__tests__/unit/core/capabilities/lockCapability.test.ts`, `versionsCapability.test.ts` — capability unit tests with a fake connection.
+- Create `src/__tests__/unit/core/capabilities/conformance.test.ts` — table-driven behavioural conformance across the three pilot handlers.
+
+---
+
+# PHASE A — interfaces (release 11.2.0)
+
+Branch: `feat/capability-atoms`, created from `main` (NOT from `feat/atc-unittest-types`; the ATC types stay on their own branch and are released separately when their client lands).
+
+### Task A1: Declare the seven capability atom interfaces
+
+**Files:**
+- Create: `/home/okyslytsia/prj/mcp-abap-adt-interfaces/src/adt/IAdtCapabilities.ts`
+
+**Interfaces:**
+- Consumes: existing `IAdtObject` generics `<TConfig, TReadResult>` and `IAdtOperationOptions`, `IObjectVersion` from `./IAdtObject`.
+- Produces: `IAdtCrud`, `IAdtValidatable`, `IAdtCheckable`, `IAdtActivatable`, `IAdtLockable`, `IAdtVersionable`, `IAdtTransportAware` — each generic over `<TConfig, TReadResult = TConfig>` (except `IAdtVersionable<TConfig>` and `IAdtLockable` which also carries `TReadResult` for `unlock`).
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /home/okyslytsia/prj/mcp-abap-adt-interfaces
+git checkout main && git pull
+git checkout -b feat/capability-atoms
+```
+
+- [ ] **Step 2: Write the atom interfaces**
+
+Create `src/adt/IAdtCapabilities.ts`. Method signatures are copied verbatim from `IAdtObject` in `src/adt/IAdtObject.ts` so the intersection is structurally identical (Task A2 proves it):
+
+```ts
+/**
+ * Capability atoms — the methods of IAdtObject, partitioned so each method
+ * belongs to exactly one small interface. See
+ * docs/superpowers/specs/2026-07-20-capability-interfaces-design.md.
+ *
+ * These are ADDITIVE. IAdtObject is unchanged; a handler implementing the
+ * atoms satisfies IAdtObject structurally (Task A2 proves the equivalence).
+ */
+import type {
+  IAdtOperationOptions,
+  IObjectVersion,
+} from './IAdtObject';
+
+/** create / read / readMetadata / update / delete — universal, never partial. */
+export interface IAdtCrud<TConfig, TReadResult = TConfig> {
+  create(config: TConfig, options?: IAdtOperationOptions): Promise<TReadResult>;
+  read(
+    config: Partial<TConfig>,
+    version?: 'active' | 'inactive',
+    options?: { withLongPolling?: boolean },
+  ): Promise<TReadResult | undefined>;
+  readMetadata(
+    config: Partial<TConfig>,
+    options?: { withLongPolling?: boolean; version?: 'active' | 'inactive' },
+  ): Promise<TReadResult>;
+  update(config: Partial<TConfig>, options?: IAdtOperationOptions): Promise<TReadResult>;
+  delete(config: Partial<TConfig>): Promise<TReadResult>;
+}
+
+export interface IAdtValidatable<TConfig, TReadResult = TConfig> {
+  validate(config: Partial<TConfig>): Promise<TReadResult>;
+}
+
+export interface IAdtCheckable<TConfig, TReadResult = TConfig> {
+  check(config: Partial<TConfig>, status?: string): Promise<TReadResult>;
+}
+
+export interface IAdtActivatable<TConfig, TReadResult = TConfig> {
+  activate(config: Partial<TConfig>): Promise<TReadResult>;
+}
+
+export interface IAdtLockable<TConfig, TReadResult = TConfig> {
+  lock(config: Partial<TConfig>): Promise<string>;
+  unlock(config: Partial<TConfig>, lockHandle: string): Promise<TReadResult>;
+}
+
+export interface IAdtVersionable<TConfig> {
+  getVersions(config: Partial<TConfig>): Promise<IObjectVersion[]>;
+  getVersionSource(contentUri: string): Promise<string>;
+}
+
+export interface IAdtTransportAware<TConfig, TReadResult = TConfig> {
+  readTransport(
+    config: Partial<TConfig>,
+    options?: { withLongPolling?: boolean },
+  ): Promise<TReadResult>;
+}
+```
+
+- [ ] **Step 3: Build to confirm the file compiles**
+
+Run: `cd /home/okyslytsia/prj/mcp-abap-adt-interfaces && npm run build`
+Expected: exit 0, no diagnostics.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/adt/IAdtCapabilities.ts
+git commit -m "feat(atoms): declare the seven capability interfaces"
+```
+
+---
+
+### Task A2: Add the correctness proof
+
+**Files:**
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-interfaces/src/adt/IAdtCapabilities.ts` (append)
+
+**Interfaces:**
+- Consumes: the seven atoms from A1, `IAdtObject` from `./IAdtObject`, a concrete config/state pair to instantiate the proof (`IClassConfig`, `IClassState` from `./IAdtClass`).
+- Produces: nothing exported; a compile-time assertion only.
+
+- [ ] **Step 1: Append the proof**
+
+Add to the end of `src/adt/IAdtCapabilities.ts`:
+
+```ts
+import type { IAdtObject } from './IAdtObject';
+import type { IClassConfig, IClassState } from './IAdtClass';
+
+/** Assertion helper: instantiating with `false` is a compile error. */
+type Assert<T extends true> = T;
+
+/** The intersection of every atom that composes IAdtObject. */
+type AllAtoms<C, R> = IAdtCrud<C, R> &
+  IAdtValidatable<C, R> &
+  IAdtCheckable<C, R> &
+  IAdtActivatable<C, R> &
+  IAdtLockable<C, R> &
+  IAdtVersionable<C> &
+  IAdtTransportAware<C, R>;
+
+/**
+ * Proof that the partition is exact: IAdtObject and the atom intersection are
+ * mutually assignable. Both directions are required. The generic parameters
+ * are bound and the alias is instantiated below, or nothing is checked.
+ */
+type _PartitionIsExact<C, R> = [
+  Assert<IAdtObject<C, R> extends AllAtoms<C, R> ? true : false>,
+  Assert<AllAtoms<C, R> extends IAdtObject<C, R> ? true : false>,
+];
+
+// Instantiate at a concrete pair so the constraints are actually evaluated.
+type _Check = _PartitionIsExact<IClassConfig, IClassState>;
+```
+
+- [ ] **Step 2: Build — expect PASS**
+
+Run: `npm run build`
+Expected: exit 0. The proof holds.
+
+- [ ] **Step 3: Verify the proof actually checks — temporarily break it**
+
+Edit `IAdtLockable` to remove the `unlock` method (comment it out). Run `npm run build`.
+Expected: FAIL with `TS2344: Type 'false' does not satisfy the constraint 'true'` on `_PartitionIsExact`.
+Then restore the `unlock` method and rebuild — exit 0.
+
+This step produces no commit; it is a manual confirmation the assertion is load-bearing, mirroring the ATC vocabulary-guard discipline.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/adt/IAdtCapabilities.ts
+git commit -m "test(atoms): compile-time proof that the atoms partition IAdtObject exactly"
+```
+
+---
+
+### Task A3: Export atoms from the barrel, version, changelog, PR
+
+**Files:**
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-interfaces/src/index.ts`
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-interfaces/package.json` (version)
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-interfaces/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: the seven atoms from A1.
+- Produces: the atoms exported from the package root, so `import type { IAdtLockable } from '@mcp-abap-adt/interfaces'` resolves.
+
+- [ ] **Step 1: Add the barrel export block**
+
+In `src/index.ts`, add (alphabetical position — after the `IAdtAppendStructure` export block, matching the existing ordering convention):
+
+```ts
+export type {
+  IAdtActivatable,
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
+  IAdtTransportAware,
+  IAdtValidatable,
+  IAdtVersionable,
+} from './adt/IAdtCapabilities';
+```
+
+- [ ] **Step 2: Build and confirm the exports resolve from the built barrel**
+
+Run:
+```bash
+npm run build
+node -e "const ts=require('typescript');const p=ts.createProgram(['dist/index.d.ts'],{});const s=p.getTypeChecker().getSymbolAtLocation(p.getSourceFile('dist/index.d.ts'));const n=p.getTypeChecker().getExportsOfModule(s).map(x=>x.getName());const want=['IAdtCrud','IAdtValidatable','IAdtCheckable','IAdtActivatable','IAdtLockable','IAdtVersionable','IAdtTransportAware'];const miss=want.filter(w=>!n.includes(w));console.log(miss.length?'MISSING: '+miss.join(', '):'all 7 atoms exported from root');"
+```
+Expected: `all 7 atoms exported from root`.
+
+- [ ] **Step 3: Bump version to 11.2.0**
+
+```bash
+npm version 11.2.0 --no-git-tag-version
+npm install --package-lock-only
+grep -c '"link": true' package-lock.json
+```
+Expected: version line shows `11.2.0`; `"link": true` count is `0`.
+
+- [ ] **Step 4: Add the CHANGELOG entry**
+
+Prepend under the top heading in `CHANGELOG.md`:
+
+```markdown
+## [11.2.0] - 2026-07-20
+
+### Added
+- **Capability atom interfaces.** Seven small interfaces — `IAdtCrud`,
+  `IAdtValidatable`, `IAdtCheckable`, `IAdtActivatable`, `IAdtLockable`,
+  `IAdtVersionable`, `IAdtTransportAware` — partition the 13 methods of
+  `IAdtObject` so each method belongs to exactly one. Purely additive:
+  `IAdtObject` is unchanged, and a compile-time proof asserts the intersection
+  of the atoms is structurally identical to it. Consumers may depend on a
+  narrow capability instead of the whole contract.
+```
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+git add src/index.ts package.json package-lock.json CHANGELOG.md
+git commit -m "release(11.2.0): export capability atoms from the root barrel"
+git push -u origin feat/capability-atoms
+gh pr create --title "release(11.2.0): capability atom interfaces" --body "Additive: seven capability atoms partitioning IAdtObject, with a compile-time exactness proof. IAdtObject unchanged. See docs/superpowers/specs/2026-07-20-capability-interfaces-design.md."
+```
+
+- [ ] **Step 6: STOP — publish gate**
+
+Report to the user: PR opened, ready for review + merge + tag + **`npm publish` (user's step)**. Phase B does not begin until `@mcp-abap-adt/interfaces@11.2.0` is on npm.
+
+---
+
+# PHASE B — adt-clients pilot (after interfaces 11.2.0 is published)
+
+Branch: `feat/capability-pilot`, created from `main`.
+
+### Task B1: Consume 11.2.0 and capture the surface baseline
+
+**Files:**
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-clients/package.json` (dependency floor)
+
+**Interfaces:**
+- Consumes: `@mcp-abap-adt/interfaces@11.2.0` (the atoms).
+- Produces: a clean build against 11.2.0 and a recorded public-surface baseline for Task B8 to diff against.
+
+- [ ] **Step 1: Create the branch and bump the dependency**
+
+```bash
+cd /home/okyslytsia/prj/mcp-abap-adt-clients
+git checkout main && git pull && git checkout -b feat/capability-pilot
+# edit package.json: "@mcp-abap-adt/interfaces": "^11.2.0"
+rm -rf node_modules/@mcp-abap-adt/interfaces
+npm install @mcp-abap-adt/interfaces@11.2.0
+grep -c '"link": true' package-lock.json
+```
+Expected: `"link": true` count is `0`.
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build:fast`
+Expected: exit 0.
+
+- [ ] **Step 3: Capture the surface baseline**
+
+The snapshot script `_surface-snapshot.mjs` is the one used for the 7.5.0 migration (git-excluded, in the project root). If absent, recreate it:
+
+```js
+import ts from 'typescript';
+const entries=['index','index.core','index.runtime','index.batch','index.ws','index.abapgit','index.executors'];
+const prog=ts.createProgram(entries.map(e=>`dist/${e}.d.ts`),{allowJs:true});
+const ch=prog.getTypeChecker();
+for(const e of entries){const sf=prog.getSourceFile(`dist/${e}.d.ts`);const s=sf&&ch.getSymbolAtLocation(sf);const names=s?ch.getExportsOfModule(s).map(x=>x.getName()).sort():[];console.log(`== ${e} ==`);console.log(names.join('\n'));}
+```
+
+Run: `node _surface-snapshot.mjs > /tmp/surface-before.txt && wc -l /tmp/surface-before.txt`
+Expected: a line count is printed (the exact number is the baseline; Task B8 diffs against it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: consume @mcp-abap-adt/interfaces ^11.2.0 (pre-pilot)"
+```
+
+---
+
+### Task B2: Define the capability strategy types
+
+**Files:**
+- Create: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/core/shared/capabilities/types.ts`
+
+**Interfaces:**
+- Consumes: `IAbapConnection`, `ILogger`, `IObjectVersion` from `@mcp-abap-adt/interfaces`.
+- Produces: `ICapabilityContext`, `INormalizedLock`, `ILockStrategy`, `IVersionsStrategy`.
+
+- [ ] **Step 1: Write the strategy types**
+
+Create `src/core/shared/capabilities/types.ts`:
+
+```ts
+import type {
+  IAbapConnection,
+  ILogger,
+  IObjectVersion,
+} from '@mcp-abap-adt/interfaces';
+
+/** The connection + logger every capability implementation needs. */
+export interface ICapabilityContext {
+  readonly connection: IAbapConnection;
+  readonly logger?: ILogger;
+}
+
+/**
+ * Normalized lock result. The per-type helpers return different shapes
+ * (bare string vs { lockHandle, corrNr }); the capability normalizes up to
+ * this superset. See the spec's "lock normalization contract".
+ */
+export interface INormalizedLock {
+  lockHandle: string;
+  corrNr?: string;
+}
+
+/**
+ * Per-handler strategy for LockCapability. The handler supplies its own
+ * endpoint knowledge — there is no centralized lifecycle-URI resolver
+ * (buildObjectUri is for group operations only).
+ */
+export interface ILockStrategy<TConfig> {
+  /** Extract the object name from config, or throw if missing. */
+  nameOf(config: Partial<TConfig>): string;
+  /** POST _action=LOCK, return the normalized handle. */
+  acquire(ctx: ICapabilityContext, name: string): Promise<INormalizedLock>;
+  /** POST _action=UNLOCK with the handle. */
+  release(ctx: ICapabilityContext, name: string, lockHandle: string): Promise<void>;
+}
+
+/** Per-handler strategy for VersionsCapability. */
+export interface IVersionsStrategy<TConfig> {
+  nameOf(config: Partial<TConfig>): string;
+  list(ctx: ICapabilityContext, name: string): Promise<IObjectVersion[]>;
+  /** GET the content URI, return the source text. */
+  source(ctx: ICapabilityContext, contentUri: string): Promise<string>;
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `npm run build:fast`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/shared/capabilities/types.ts
+git commit -m "feat(capabilities): strategy types for lock and versions"
+```
+
+---
+
+### Task B3: LockCapability with the normalization contract (TDD)
+
+**Files:**
+- Create: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/core/shared/capabilities/LockCapability.ts`
+- Test: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/__tests__/unit/core/capabilities/lockCapability.test.ts`
+
+**Interfaces:**
+- Consumes: `ICapabilityContext`, `INormalizedLock`, `ILockStrategy` from `./types`.
+- Produces: `class LockCapability<TConfig> implements IAdtLockable<TConfig, TReadResult>` with constructor `(ctx: ICapabilityContext, strategy: ILockStrategy<TConfig>, buildState: () => TReadResult)`. Methods: `lock(config): Promise<string>`, `unlock(config, lockHandle): Promise<TReadResult>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/unit/core/capabilities/lockCapability.test.ts`:
+
+```ts
+import { LockCapability } from '../../../../core/shared/capabilities/LockCapability';
+import type {
+  ICapabilityContext,
+  ILockStrategy,
+} from '../../../../core/shared/capabilities/types';
+
+type Cfg = { name?: string };
+
+function fakeCtx(): ICapabilityContext & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    connection: {
+      setSessionType: (t: string) => calls.push(`session:${t}`),
+    } as any,
+    logger: undefined,
+  };
+}
+
+const strategy: ILockStrategy<Cfg> = {
+  nameOf: (c) => {
+    if (!c.name) throw new Error('name is required');
+    return c.name;
+  },
+  acquire: async (ctx, name) => {
+    (ctx as any).calls.push(`acquire:${name}`);
+    return { lockHandle: 'H1', corrNr: 'C1' };
+  },
+  release: async (ctx, name, h) => {
+    (ctx as any).calls.push(`release:${name}:${h}`);
+  },
+};
+
+describe('LockCapability', () => {
+  it('lock sets stateful, acquires, returns the handle', async () => {
+    const ctx = fakeCtx();
+    const cap = new LockCapability<Cfg, { errors: string[] }>(
+      ctx,
+      strategy,
+      () => ({ errors: [] }),
+    );
+    const handle = await cap.lock({ name: 'ZFOO' });
+    expect(handle).toBe('H1');
+    expect(ctx.calls).toEqual(['session:stateful', 'acquire:ZFOO']);
+  });
+
+  it('unlock releases then restores stateless', async () => {
+    const ctx = fakeCtx();
+    const cap = new LockCapability<Cfg, { errors: string[] }>(
+      ctx,
+      strategy,
+      () => ({ errors: [] }),
+    );
+    await cap.unlock({ name: 'ZFOO' }, 'H1');
+    expect(ctx.calls).toEqual(['release:ZFOO:H1', 'session:stateless']);
+  });
+
+  it('lock rethrows a missing name from the strategy', async () => {
+    const ctx = fakeCtx();
+    const cap = new LockCapability<Cfg, { errors: string[] }>(
+      ctx,
+      strategy,
+      () => ({ errors: [] }),
+    );
+    await expect(cap.lock({})).rejects.toThrow('name is required');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/capabilities/lockCapability.test.ts --runInBand 2>&1 | tee /tmp/b3.log`
+Then read `/tmp/b3.log`. Expected: FAIL — `Cannot find module '.../LockCapability'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/core/shared/capabilities/LockCapability.ts`:
+
+```ts
+import type { IAdtLockable } from '@mcp-abap-adt/interfaces';
+import type { ICapabilityContext, ILockStrategy } from './types';
+
+/**
+ * Shared lock/unlock for handlers whose lock differs only by endpoint and
+ * name field. `lock` leaves the session stateful (the caller must unlock);
+ * `unlock` restores stateless. See the spec's IAdtLockable obligations —
+ * idempotent unlock is a TARGET, not implemented here, and is left to the
+ * per-endpoint probe + adaptation rule of the full-migration plan.
+ */
+export class LockCapability<TConfig, TReadResult>
+  implements IAdtLockable<TConfig, TReadResult>
+{
+  constructor(
+    private readonly ctx: ICapabilityContext,
+    private readonly strategy: ILockStrategy<TConfig>,
+    private readonly buildState: () => TReadResult,
+  ) {}
+
+  async lock(config: Partial<TConfig>): Promise<string> {
+    const name = this.strategy.nameOf(config);
+    // Stay stateful while the lock is held; the caller releases via unlock().
+    this.ctx.connection.setSessionType('stateful');
+    const { lockHandle } = await this.strategy.acquire(this.ctx, name);
+    return lockHandle;
+  }
+
+  async unlock(
+    config: Partial<TConfig>,
+    lockHandle: string,
+  ): Promise<TReadResult> {
+    const name = this.strategy.nameOf(config);
+    await this.strategy.release(this.ctx, name, lockHandle);
+    this.ctx.connection.setSessionType('stateless');
+    return this.buildState();
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/capabilities/lockCapability.test.ts --runInBand 2>&1 | tee /tmp/b3.log`
+Then read `/tmp/b3.log`. Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/shared/capabilities/LockCapability.ts src/__tests__/unit/core/capabilities/lockCapability.test.ts
+git commit -m "feat(capabilities): LockCapability with normalized lock result"
+```
+
+---
+
+### Task B4: VersionsCapability (TDD)
+
+**Files:**
+- Create: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/core/shared/capabilities/VersionsCapability.ts`
+- Test: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/__tests__/unit/core/capabilities/versionsCapability.test.ts`
+
+**Interfaces:**
+- Consumes: `ICapabilityContext`, `IVersionsStrategy` from `./types`; `IObjectVersion` from `@mcp-abap-adt/interfaces`.
+- Produces: `class VersionsCapability<TConfig> implements IAdtVersionable<TConfig>` with constructor `(ctx, strategy)`. Methods: `getVersions(config): Promise<IObjectVersion[]>`, `getVersionSource(contentUri): Promise<string>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/__tests__/unit/core/capabilities/versionsCapability.test.ts`:
+
+```ts
+import { VersionsCapability } from '../../../../core/shared/capabilities/VersionsCapability';
+import type {
+  ICapabilityContext,
+  IVersionsStrategy,
+} from '../../../../core/shared/capabilities/types';
+
+type Cfg = { name?: string };
+const ctx: ICapabilityContext = { connection: {} as any, logger: undefined };
+
+const strategy: IVersionsStrategy<Cfg> = {
+  nameOf: (c) => {
+    if (!c.name) throw new Error('name is required');
+    return c.name;
+  },
+  list: async (_ctx, name) => [
+    { version: '000001', versionTitle: name } as any,
+  ],
+  source: async (_ctx, uri) => `source-of:${uri}`,
+};
+
+describe('VersionsCapability', () => {
+  it('getVersions delegates to the strategy', async () => {
+    const cap = new VersionsCapability<Cfg>(ctx, strategy);
+    const v = await cap.getVersions({ name: 'ZBAR' });
+    expect(v).toHaveLength(1);
+    expect(v[0].versionTitle).toBe('ZBAR');
+  });
+
+  it('getVersionSource delegates to the strategy', async () => {
+    const cap = new VersionsCapability<Cfg>(ctx, strategy);
+    expect(await cap.getVersionSource('/uri/1')).toBe('source-of:/uri/1');
+  });
+
+  it('getVersions rethrows a missing name', async () => {
+    const cap = new VersionsCapability<Cfg>(ctx, strategy);
+    await expect(cap.getVersions({})).rejects.toThrow('name is required');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/capabilities/versionsCapability.test.ts --runInBand 2>&1 | tee /tmp/b4.log`
+Then read `/tmp/b4.log`. Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/core/shared/capabilities/VersionsCapability.ts`:
+
+```ts
+import type { IAdtVersionable, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import type { ICapabilityContext, IVersionsStrategy } from './types';
+
+/**
+ * Shared version history for source-backed objects. Types without a
+ * /source/main resource do NOT compose this capability and do not implement
+ * IAdtVersionable — absence is expressed structurally, not by throwing.
+ */
+export class VersionsCapability<TConfig>
+  implements IAdtVersionable<TConfig>
+{
+  constructor(
+    private readonly ctx: ICapabilityContext,
+    private readonly strategy: IVersionsStrategy<TConfig>,
+  ) {}
+
+  getVersions(config: Partial<TConfig>): Promise<IObjectVersion[]> {
+    const name = this.strategy.nameOf(config);
+    return this.strategy.list(this.ctx, name);
+  }
+
+  getVersionSource(contentUri: string): Promise<string> {
+    return this.strategy.source(this.ctx, contentUri);
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/capabilities/versionsCapability.test.ts --runInBand 2>&1 | tee /tmp/b4.log`
+Then read `/tmp/b4.log`. Expected: 3 passed.
+
+- [ ] **Step 5: Add the barrel and commit**
+
+Create `src/core/shared/capabilities/index.ts`:
+
+```ts
+export * from './types';
+export { LockCapability } from './LockCapability';
+export { VersionsCapability } from './VersionsCapability';
+```
+
+```bash
+git add src/core/shared/capabilities/VersionsCapability.ts src/core/shared/capabilities/index.ts src/__tests__/unit/core/capabilities/versionsCapability.test.ts
+git commit -m "feat(capabilities): VersionsCapability + barrel"
+```
+
+---
+
+### Task B5: Convert AdtClass to compose the capabilities
+
+**Files:**
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/core/class/AdtClass.ts`
+
+**Interfaces:**
+- Consumes: `LockCapability`, `VersionsCapability`, `ICapabilityContext` from `../shared/capabilities`; the existing low-level `lockClass`, `unlockClass`, `getClassIncludeVersions`, `getClassVersionSource` (already imported in the module).
+- Produces: `AdtClass` with `lock`/`unlock`/`getVersions`/`getVersionSource` routed through the capabilities; `create`/`read`/`update`/`delete`/`validate`/`check`/`activate`/`readTransport` unchanged; `implements IAdtObject<IClassConfig, IClassState>` unchanged.
+
+- [ ] **Step 1: Add the capability instances and lock/versions strategies**
+
+In `AdtClass.ts`, inside the class, add a private capability context and instances built from the existing low-level functions. The strategies wrap the current helpers so behaviour is byte-identical:
+
+```ts
+// near the other imports
+import {
+  LockCapability,
+  VersionsCapability,
+  type ICapabilityContext,
+} from '../shared/capabilities';
+
+// inside the class body
+private get capCtx(): ICapabilityContext {
+  return { connection: this.connection, logger: this.logger };
+}
+
+private readonly lockCap = new LockCapability<IClassConfig, IClassState>(
+  this.capCtx,
+  {
+    nameOf: (c) => {
+      if (!c.className) throw new Error('Class name is required');
+      return c.className;
+    },
+    acquire: async (ctx, name) => ({
+      lockHandle: await lockClass(ctx.connection, name),
+    }),
+    release: async (ctx, name, handle) => {
+      await unlockClass(ctx.connection, name, handle);
+    },
+  },
+  () => ({ errors: [] }),
+);
+
+private readonly versionsCap = new VersionsCapability<IClassConfig>(
+  this.capCtx,
+  {
+    nameOf: (c) => {
+      if (!c.className) throw new Error('className is required');
+      return c.className;
+    },
+    list: (ctx, name) => getClassIncludeVersions(ctx.connection, name, 'main'),
+    source: (ctx, uri) => getClassVersionSource(ctx.connection, uri),
+  },
+);
+```
+
+Note: `AdtClass.lock` currently also calls `this.lockTracker.track(...)`. Preserve that — keep it in the handler `lock` wrapper (Step 2), not the capability, because the tracker is handler state.
+
+- [ ] **Step 2: Replace the four method bodies with capability delegation, preserving lock tracking**
+
+Replace the existing `lock`, `unlock`, `getVersions`, `getVersionSource` method bodies:
+
+```ts
+async lock(config: Partial<IClassConfig>): Promise<string> {
+  const handle = await this.lockCap.lock(config);
+  this.lockTracker.track(config.className as string, handle);
+  return handle;
+}
+
+async unlock(
+  config: Partial<IClassConfig>,
+  lockHandle: string,
+): Promise<IClassState> {
+  const state = await this.lockCap.unlock(config, lockHandle);
+  this.lockTracker.untrack(config.className as string);
+  return state;
+}
+
+getVersions(config: Partial<IClassConfig>): Promise<IObjectVersion[]> {
+  return this.versionsCap.getVersions(config);
+}
+
+getVersionSource(contentUri: string): Promise<string> {
+  return this.versionsCap.getVersionSource(contentUri);
+}
+```
+
+(Confirm the exact current `unlock` body first with `sed -n '/async unlock(/,/^  }/p' src/core/class/AdtClass.ts` and preserve any `untrack` / stateless call semantics — the capability already restores stateless, so remove a duplicate `setSessionType('stateless')` from the handler if present.)
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build:fast`
+Expected: exit 0. If `AdtClass` no longer satisfies `IAdtObject`, the build fails here — that is the structural check doing its job.
+
+- [ ] **Step 4: Run the class unit tests**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b5.log`
+Then read `/tmp/b5.log`. Expected: all pass (the prior 348 plus the 6 new capability tests = 354).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/class/AdtClass.ts
+git commit -m "refactor(class): compose LockCapability + VersionsCapability"
+```
+
+---
+
+### Task B6: Convert AdtDomain — the no-versions case
+
+**Files:**
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/core/domain/AdtDomain.ts`
+
+**Interfaces:**
+- Consumes: `LockCapability` from `../shared/capabilities`; existing `lockDomain`, `unlockDomain`.
+- Produces: `AdtDomain` with `lock`/`unlock` routed through `LockCapability`; `getVersions`/`getVersionSource` continue to call `throwUnsupportedVersions('domain')` — Domain does NOT compose `VersionsCapability`. This proves the absent-capability case.
+
+- [ ] **Step 1: Add the LockCapability instance**
+
+In `AdtDomain.ts`, mirror the AdtClass pattern but only for lock (Domain has no `/source/main`, so no VersionsCapability):
+
+```ts
+import {
+  LockCapability,
+  type ICapabilityContext,
+} from '../shared/capabilities';
+
+private get capCtx(): ICapabilityContext {
+  return { connection: this.connection, logger: this.logger };
+}
+
+private readonly lockCap = new LockCapability<IDomainConfig, IDomainState>(
+  this.capCtx,
+  {
+    nameOf: (c) => {
+      if (!c.domainName) throw new Error('Domain name is required');
+      return c.domainName;
+    },
+    acquire: async (ctx, name) => ({
+      lockHandle: await lockDomain(ctx.connection, name),
+    }),
+    release: async (ctx, name, handle) => {
+      await unlockDomain(ctx.connection, name, handle);
+    },
+  },
+  () => ({ errors: [] }),
+);
+```
+
+(Confirm `lockDomain`/`unlockDomain` signatures first: `sed -n '/export async function lockDomain/,/{/p' src/core/domain/lock.ts` and `.../unlockDomain/.../ src/core/domain/unlock.ts`. If `lockDomain` returns `{ lockHandle }` rather than a bare string, adapt `acquire` to return it directly.)
+
+- [ ] **Step 2: Replace lock/unlock, leave getVersions untouched**
+
+Replace `AdtDomain.lock` and `AdtDomain.unlock` bodies with the capability delegation (mirroring B5 Step 2, using `domainName` and Domain's lock tracker if present). Do NOT touch `getVersions`/`getVersionSource` — they must still throw via `throwUnsupportedVersions('domain')`.
+
+```ts
+async lock(config: Partial<IDomainConfig>): Promise<string> {
+  const handle = await this.lockCap.lock(config);
+  this.lockTracker?.track(config.domainName as string, handle);
+  return handle;
+}
+
+async unlock(
+  config: Partial<IDomainConfig>,
+  lockHandle: string,
+): Promise<IDomainState> {
+  const state = await this.lockCap.unlock(config, lockHandle);
+  this.lockTracker?.untrack(config.domainName as string);
+  return state;
+}
+```
+
+- [ ] **Step 3: Build and unit test**
+
+Run: `npm run build:fast && MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b6.log`
+Then read `/tmp/b6.log`. Expected: exit 0, all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/domain/AdtDomain.ts
+git commit -m "refactor(domain): compose LockCapability; versions stay unsupported"
+```
+
+---
+
+### Task B7: Convert AdtServiceDefinition — capability reuse across a third type
+
+**Files:**
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/core/serviceDefinition/AdtServiceDefinition.ts`
+
+**Interfaces:**
+- Consumes: `LockCapability`, `VersionsCapability`; existing `lockServiceDefinition`, `unlockServiceDefinition`, `getServiceDefinitionVersions`, `getServiceDefinitionVersionSource`.
+- Produces: `AdtServiceDefinition` with lock/unlock/versions routed through the same shared capabilities — proving reuse across a third, differently-endpointed type.
+
+- [ ] **Step 1: Confirm the low-level names**
+
+Run: `grep -n "export async function\|export function" src/core/serviceDefinition/lock.ts src/core/serviceDefinition/unlock.ts src/core/serviceDefinition/versions.ts`
+Note the exact function names and use them in Step 2 (they may be `lockServiceDefinition` / `unlockServiceDefinition` / `getServiceDefinitionVersions` / `getServiceDefinitionVersionSource`).
+
+- [ ] **Step 2: Add both capability instances and delegate**
+
+Mirror B5 exactly, with `serviceDefinitionName` as the config field and the ServiceDefinition low-level functions in the strategies. Replace `lock`/`unlock`/`getVersions`/`getVersionSource` bodies with capability delegation, preserving any lock tracking.
+
+```ts
+import {
+  LockCapability,
+  VersionsCapability,
+  type ICapabilityContext,
+} from '../shared/capabilities';
+
+private get capCtx(): ICapabilityContext {
+  return { connection: this.connection, logger: this.logger };
+}
+
+private readonly lockCap = new LockCapability<IServiceDefinitionConfig, IServiceDefinitionState>(
+  this.capCtx,
+  {
+    nameOf: (c) => {
+      if (!c.serviceDefinitionName) throw new Error('Service definition name is required');
+      return c.serviceDefinitionName;
+    },
+    acquire: async (ctx, name) => ({
+      lockHandle: await lockServiceDefinition(ctx.connection, name),
+    }),
+    release: async (ctx, name, handle) => {
+      await unlockServiceDefinition(ctx.connection, name, handle);
+    },
+  },
+  () => ({ errors: [] }),
+);
+
+private readonly versionsCap = new VersionsCapability<IServiceDefinitionConfig>(
+  this.capCtx,
+  {
+    nameOf: (c) => {
+      if (!c.serviceDefinitionName) throw new Error('serviceDefinitionName is required');
+      return c.serviceDefinitionName;
+    },
+    list: (ctx, name) => getServiceDefinitionVersions(ctx.connection, name),
+    source: (ctx, uri) => getServiceDefinitionVersionSource(ctx.connection, uri),
+  },
+);
+```
+
+- [ ] **Step 3: Build and unit test**
+
+Run: `npm run build:fast && MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b7.log`
+Then read `/tmp/b7.log`. Expected: exit 0, all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/serviceDefinition/AdtServiceDefinition.ts
+git commit -m "refactor(serviceDefinition): compose LockCapability + VersionsCapability"
+```
+
+---
+
+### Task B8: Conformance tests + surface unchanged + full suite
+
+**Files:**
+- Create: `/home/okyslytsia/prj/mcp-abap-adt-clients/src/__tests__/unit/core/capabilities/conformance.test.ts`
+
+**Interfaces:**
+- Consumes: the three converted handlers (constructed with a fake connection).
+- Produces: a table-driven test asserting the shared behavioural obligations hold identically across the three, plus a verified-unchanged public surface.
+
+- [ ] **Step 1: Write the conformance test**
+
+Create `src/__tests__/unit/core/capabilities/conformance.test.ts`. It asserts the lock/unlock session-toggle contract holds for every handler that composes `LockCapability`, using a fake connection that records `setSessionType` calls:
+
+```ts
+import { AdtClass } from '../../../../core/class/AdtClass';
+import { AdtDomain } from '../../../../core/domain/AdtDomain';
+import { AdtServiceDefinition } from '../../../../core/serviceDefinition/AdtServiceDefinition';
+
+function recordingConnection() {
+  const sessions: string[] = [];
+  return {
+    sessions,
+    setSessionType: (t: string) => sessions.push(t),
+    makeAdtRequest: async () => ({
+      status: 200,
+      headers: {},
+      // minimal LOCK response shape the low-level parsers accept
+      data: `<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE></DATA></asx:values></asx:abap>`,
+    }),
+  } as any;
+}
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} } as any;
+
+const cases = [
+  { name: 'AdtClass', make: (c: any) => new AdtClass(c, noopLogger), cfg: { className: 'ZC' } },
+  { name: 'AdtDomain', make: (c: any) => new AdtDomain(c, noopLogger), cfg: { domainName: 'ZD' } },
+  {
+    name: 'AdtServiceDefinition',
+    make: (c: any) => new AdtServiceDefinition(c, noopLogger),
+    cfg: { serviceDefinitionName: 'ZS' },
+  },
+];
+
+describe('LockCapability conformance across handlers', () => {
+  it.each(cases)('$name: lock leaves session stateful', async ({ make, cfg }) => {
+    const conn = recordingConnection();
+    const handler = make(conn);
+    await handler.lock(cfg);
+    expect(conn.sessions[conn.sessions.length - 1]).toBe('stateful');
+  });
+
+  it.each(cases)('$name: unlock restores stateless', async ({ make, cfg }) => {
+    const conn = recordingConnection();
+    const handler = make(conn);
+    await handler.unlock(cfg, 'H1');
+    expect(conn.sessions[conn.sessions.length - 1]).toBe('stateless');
+  });
+});
+```
+
+(Adjust the constructor arity per handler if any takes options; confirm with `grep -n "constructor" src/core/class/AdtClass.ts`.)
+
+- [ ] **Step 2: Run the conformance test**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/core/capabilities/conformance.test.ts --runInBand 2>&1 | tee /tmp/b8.log`
+Then read `/tmp/b8.log`. Expected: 6 passed.
+
+- [ ] **Step 3: Full unit suite**
+
+Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b8-unit.log`
+Then read `/tmp/b8-unit.log`. Expected: all pass (~356).
+
+- [ ] **Step 4: Public surface unchanged**
+
+Run:
+```bash
+npm run build:fast
+node _surface-snapshot.mjs > /tmp/surface-after.txt
+diff /tmp/surface-before.txt /tmp/surface-after.txt && echo "SURFACE IDENTICAL"
+```
+Expected: `SURFACE IDENTICAL` (empty diff). A non-empty diff means the refactor changed the public API and must be fixed before proceeding.
+
+- [ ] **Step 5: Lint**
+
+Run: `npm run lint:check 2>&1 | tee /tmp/b8-lint.log`
+Then read `/tmp/b8-lint.log`. Expected: 0 errors; warnings/infos at or below the 45/25 baseline.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/__tests__/unit/core/capabilities/conformance.test.ts
+git commit -m "test(capabilities): cross-handler lock/unlock conformance; surface unchanged"
+```
+
+---
+
+### Task B9: Verify against the trial system and the consumer
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Warn the user, then run the three pilot integration suites on trial**
+
+WARN the user first: trial integration needs a browser with the right profile and a fresh JWT. Then, with the user's go-ahead:
+
+```bash
+cp ~/.config/mcp-abap-adt/sessions/trial.env .env
+npm test -- integration/core/class integration/core/domain integration/core/serviceDefinition 2>&1 | tee integration-pilot.log
+```
+Then read `integration-pilot.log` — read the summary block (`Test Suites:` … onward). Expected: the previously-passing tests for these three still pass; any pre-existing skips remain skips. A NEW failure that was passing before the refactor is a regression to investigate before release.
+
+- [ ] **Step 2: Verify the consumer still builds and type-checks against the pilot build**
+
+The consumer (`~/prj/mcp-abap-adt`) pins `@mcp-abap-adt/adt-clients` and exercises the `IAdtObject` surface. To prove transparency without publishing, point it at the local pilot build in a throwaway way (do NOT commit the consumer lockfile change):
+
+```bash
+cd /home/okyslytsia/prj/mcp-abap-adt-clients && npm run build && npm pack
+# produces mcp-abap-adt-adt-clients-<ver>.tgz
+cd /home/okyslytsia/prj/mcp-abap-adt
+npm install --no-save /home/okyslytsia/prj/mcp-abap-adt-clients/mcp-abap-adt-adt-clients-*.tgz
+npm run build 2>&1 | tee /tmp/consumer-build.log
+```
+Then read `/tmp/consumer-build.log`. Expected: the consumer compiles clean against the pilot build — proof the `IAdtObject` surface is transparent. Restore the consumer's dependency afterward: `cd ~/prj/mcp-abap-adt && npm install` (re-pulls the published version; confirm no `"link": true` and no tarball path left in its lockfile).
+
+- [ ] **Step 3: Record the verification outcome**
+
+No commit. Summarize for the user: unit (count), trial integration (pass/skip/fail per suite with the actual numbers from the log), surface diff (empty), consumer build (clean). If anything regressed, STOP and report rather than proceeding to release.
+
+---
+
+### Task B10: Version, changelog, PR
+
+**Files:**
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-clients/package.json` (version)
+- Modify: `/home/okyslytsia/prj/mcp-abap-adt-clients/CHANGELOG.md`
+
+- [ ] **Step 1: Ask the user for the version**
+
+Per the global constraint, the user chooses the CHANGELOG version. Recommend **minor** (e.g. 7.6.0): additive and internal, public surface proven unchanged. Wait for confirmation.
+
+- [ ] **Step 2: Bump and refresh the lockfile**
+
+```bash
+npm version <chosen> --no-git-tag-version
+npm install --package-lock-only
+grep -c '"link": true' package-lock.json
+```
+Expected: version updated; `"link": true` count `0`.
+
+- [ ] **Step 3: Add the CHANGELOG entry**
+
+```markdown
+## [<chosen>] - 2026-07-20
+
+### Changed
+- **Pilot of the capability-composition architecture.** `AdtClass`, `AdtDomain`
+  and `AdtServiceDefinition` now route lock/unlock (and, for the two
+  source-backed types, version history) through shared `LockCapability` /
+  `VersionsCapability` implementations parameterized by a per-handler strategy,
+  instead of bespoke per-type wrappers. `AdtDomain` composes no
+  `VersionsCapability` — it has no `/source/main`, so the absence is structural.
+  Requires `@mcp-abap-adt/interfaces ^11.2.0` (the capability atoms).
+
+No API change: the `IAdtObject` surface is byte-identical (verified across all
+seven entry points) and behaviour is unchanged (unit + trial integration for
+the three handlers, plus a clean consumer build against this release).
+```
+
+- [ ] **Step 4: Commit, PR, and stop at the release gate**
+
+```bash
+git add package.json package-lock.json CHANGELOG.md
+git commit -m "release(<chosen>): pilot capability composition on 3 handlers"
+git push -u origin feat/capability-pilot
+gh pr create --title "release(<chosen>): capability-composition pilot" --body "Routes lock/versions through shared capabilities on AdtClass/AdtDomain/AdtServiceDefinition. IAdtObject surface unchanged (empty diff across 7 entry points); consumer builds clean. Consumes interfaces ^11.2.0. Remaining 32 handlers, activate/check error-unification, and the ATC client are future plans."
+```
+
+Report to the user: PR opened, ready for review + merge + tag + GitHub release; **`npm publish` is the user's step**.
+
+---
+
+## Out of scope (future plans)
+
+- The remaining 32 handlers — a separate migration plan, using the classification (fits-strategy vs bespoke) the spec requires; includes `AdtFunctionModule` (composite key), `AdtBehaviorImplementation` (delegates to `AdtClass`), `AdtMessageClassMessage` (double-lock).
+- `ActivateCapability` / `CheckCapability` with error-envelope unification — a deliberate behavioural change; its own plan with conformance tests and a CHANGELOG note naming the changed error shapes.
+- `TransportCapability` extraction.
+- Narrowing `AdtClient.getXxx()` return types (the breaking flip) and deprecating the fat contract.
+- The ATC client + `runSync` + MCP tools, built on this architecture once proven.
+- The search capability (`IAdtObjectHit` + breaking `adtType`→`type` normalization) — its own spec.

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -433,7 +433,7 @@ git commit -m "feat(capabilities): strategy types for lock and versions"
 
 **Interfaces:**
 - Consumes: `ICapabilityContext`, `INormalizedLock`, `ILockStrategy` from `./types`.
-- Produces: `class LockCapability<TConfig, TReadResult> implements IAdtLockable<TConfig, TReadResult>` with constructor `(ctx: ICapabilityContext, strategy: ILockStrategy<TConfig, TReadResult>)`. Methods: `lock(config): Promise<string>`, `unlock(config, lockHandle): Promise<TReadResult>`. The state is built by `strategy.release`, so there is no `buildState` constructor param.
+- Produces: `class LockCapability<TConfig, TReadResult> implements IAdtLockable<TConfig, TReadResult>` with constructor `(getCtx: () => ICapabilityContext, strategy: ILockStrategy<TConfig, TReadResult>)`. Methods: `lock(config): Promise<string>`, `unlock(config, lockHandle): Promise<TReadResult>`. The context is a LAZY thunk — read at method-call time, not construction — so a handler can build the capability as a class field even though `this.connection` is assigned later in the constructor body. The state is built by `strategy.release`, so there is no `buildState` constructor param.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -479,7 +479,7 @@ const strategy: ILockStrategy<Cfg, State> = {
 describe('LockCapability', () => {
   it('lock sets stateful, acquires, returns the handle', async () => {
     const ctx = fakeCtx();
-    const cap = new LockCapability<Cfg, State>(ctx, strategy);
+    const cap = new LockCapability<Cfg, State>(() => ctx, strategy);
     const handle = await cap.lock({ name: 'ZFOO' });
     expect(handle).toBe('H1');
     expect(ctx.calls).toEqual(['session:stateful', 'acquire:ZFOO']);
@@ -487,7 +487,7 @@ describe('LockCapability', () => {
 
   it('unlock is stateful during release, restores stateless, returns state', async () => {
     const ctx = fakeCtx();
-    const cap = new LockCapability<Cfg, State>(ctx, strategy);
+    const cap = new LockCapability<Cfg, State>(() => ctx, strategy);
     const state = await cap.unlock({ name: 'ZFOO' }, 'H1');
     // stateful BEFORE the UNLOCK (older BASIS), stateless AFTER.
     expect(ctx.calls).toEqual([
@@ -501,7 +501,7 @@ describe('LockCapability', () => {
 
   it('lock rethrows a missing name from the strategy', async () => {
     const ctx = fakeCtx();
-    const cap = new LockCapability<Cfg, State>(ctx, strategy);
+    const cap = new LockCapability<Cfg, State>(() => ctx, strategy);
     await expect(cap.lock({})).rejects.toThrow('name is required');
   });
 });
@@ -551,15 +551,18 @@ export class LockCapability<TConfig, TReadResult>
   implements IAdtLockable<TConfig, TReadResult>
 {
   constructor(
-    private readonly ctx: ICapabilityContext,
+    // LAZY: read at method-call time, so the handler can build this capability
+    // as a class field before its constructor assigns this.connection.
+    private readonly getCtx: () => ICapabilityContext,
     private readonly strategy: ILockStrategy<TConfig, TReadResult>,
   ) {}
 
   async lock(config: Partial<TConfig>): Promise<string> {
+    const ctx = this.getCtx();
     const name = this.strategy.nameOf(config);
     // Stay stateful while the lock is held; the caller releases via unlock().
-    this.ctx.connection.setSessionType('stateful');
-    const { lockHandle } = await this.strategy.acquire(this.ctx, name);
+    ctx.connection.setSessionType('stateful');
+    const { lockHandle } = await this.strategy.acquire(ctx, name);
     return lockHandle;
   }
 
@@ -567,11 +570,12 @@ export class LockCapability<TConfig, TReadResult>
     config: Partial<TConfig>,
     lockHandle: string,
   ): Promise<TReadResult> {
+    const ctx = this.getCtx();
     const name = this.strategy.nameOf(config);
     // UNLOCK must run stateful (older BASIS #106); restore stateless after.
-    this.ctx.connection.setSessionType('stateful');
-    const state = await this.strategy.release(this.ctx, name, lockHandle);
-    this.ctx.connection.setSessionType('stateless');
+    ctx.connection.setSessionType('stateful');
+    const state = await this.strategy.release(ctx, name, lockHandle);
+    ctx.connection.setSessionType('stateless');
     return state;
   }
 }
@@ -599,7 +603,7 @@ git commit -m "feat(capabilities): LockCapability with normalized lock result"
 
 **Interfaces:**
 - Consumes: `ICapabilityContext`, `IVersionsStrategy` from `./types`; `IObjectVersion` from `@mcp-abap-adt/interfaces`.
-- Produces: `class VersionsCapability<TConfig> implements IAdtVersionable<TConfig>` with constructor `(ctx, strategy)`. Methods: `getVersions(config): Promise<IObjectVersion[]>`, `getVersionSource(contentUri): Promise<string>`.
+- Produces: `class VersionsCapability<TConfig> implements IAdtVersionable<TConfig>` with constructor `(getCtx: () => ICapabilityContext, strategy)`. Methods: `getVersions(config): Promise<IObjectVersion[]>`, `getVersionSource(contentUri): Promise<string>`. The context is a lazy thunk, same reason as `LockCapability`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -614,6 +618,7 @@ import type {
 
 type Cfg = { name?: string };
 const ctx: ICapabilityContext = { connection: {} as any, logger: undefined };
+const getCtx = () => ctx;
 
 const strategy: IVersionsStrategy<Cfg> = {
   nameOf: (c) => {
@@ -628,19 +633,19 @@ const strategy: IVersionsStrategy<Cfg> = {
 
 describe('VersionsCapability', () => {
   it('getVersions delegates to the strategy', async () => {
-    const cap = new VersionsCapability<Cfg>(ctx, strategy);
+    const cap = new VersionsCapability<Cfg>(getCtx, strategy);
     const v = await cap.getVersions({ name: 'ZBAR' });
     expect(v).toHaveLength(1);
     expect(v[0].versionTitle).toBe('ZBAR');
   });
 
   it('getVersionSource delegates to the strategy', async () => {
-    const cap = new VersionsCapability<Cfg>(ctx, strategy);
+    const cap = new VersionsCapability<Cfg>(getCtx, strategy);
     expect(await cap.getVersionSource('/uri/1')).toBe('source-of:/uri/1');
   });
 
   it('getVersions rethrows a missing name', async () => {
-    const cap = new VersionsCapability<Cfg>(ctx, strategy);
+    const cap = new VersionsCapability<Cfg>(getCtx, strategy);
     await expect(cap.getVersions({})).rejects.toThrow('name is required');
   });
 });
@@ -668,17 +673,18 @@ export class VersionsCapability<TConfig>
   implements IAdtVersionable<TConfig>
 {
   constructor(
-    private readonly ctx: ICapabilityContext,
+    // LAZY: see LockCapability — read at call time so it can be a class field.
+    private readonly getCtx: () => ICapabilityContext,
     private readonly strategy: IVersionsStrategy<TConfig>,
   ) {}
 
   getVersions(config: Partial<TConfig>): Promise<IObjectVersion[]> {
     const name = this.strategy.nameOf(config);
-    return this.strategy.list(this.ctx, name);
+    return this.strategy.list(this.getCtx(), name);
   }
 
   getVersionSource(contentUri: string): Promise<string> {
-    return this.strategy.source(this.ctx, contentUri);
+    return this.strategy.source(this.getCtx(), contentUri);
   }
 }
 ```
@@ -726,10 +732,14 @@ import {
   type ICapabilityContext,
 } from '../shared/capabilities';
 
-// inside the class body
-private get capCtx(): ICapabilityContext {
-  return { connection: this.connection, logger: this.logger };
-}
+// inside the class body — a LAZY thunk, not a getter that snapshots.
+// As a field arrow it captures `this` but reads this.connection only when
+// invoked (at a capability method call, after the constructor has run), so
+// building the capabilities as class fields below is safe.
+private readonly capCtx = (): ICapabilityContext => ({
+  connection: this.connection,
+  logger: this.logger,
+});
 
 private readonly lockCap = new LockCapability<IClassConfig, IClassState>(
   this.capCtx,
@@ -846,9 +856,11 @@ import {
   type ICapabilityContext,
 } from '../shared/capabilities';
 
-private get capCtx(): ICapabilityContext {
-  return { connection: this.connection, logger: this.logger };
-}
+// LAZY thunk (see Task B5) — read at call time, safe as a class field.
+private readonly capCtx = (): ICapabilityContext => ({
+  connection: this.connection,
+  logger: this.logger,
+});
 
 private readonly lockCap = new LockCapability<IDomainConfig, IDomainState>(
   this.capCtx,
@@ -930,9 +942,11 @@ import {
   type ICapabilityContext,
 } from '../shared/capabilities';
 
-private get capCtx(): ICapabilityContext {
-  return { connection: this.connection, logger: this.logger };
-}
+// LAZY thunk (see Task B5) — read at call time, safe as a class field.
+private readonly capCtx = (): ICapabilityContext => ({
+  connection: this.connection,
+  logger: this.logger,
+});
 
 private readonly lockCap = new LockCapability<IServiceDefinitionConfig, IServiceDefinitionState>(
   this.capCtx,

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -50,7 +50,7 @@
 
 # PHASE A — interfaces (release 11.2.0)
 
-Branch: `feat/capability-atoms`, created from `main` (NOT from `feat/atc-unittest-types`; the ATC types stay on their own branch and are released separately when their client lands).
+Branch: `feat/capability-atoms`, created from `master` (the interfaces repo's default branch is **master**, not main — confirmed HEAD `68a5e7b`, ATC-free; NOT from `feat/atc-unittest-types`; the ATC types stay on their own branch and are released separately when their client lands).
 
 ### Task A1: Declare the seven capability atom interfaces
 
@@ -65,7 +65,7 @@ Branch: `feat/capability-atoms`, created from `main` (NOT from `feat/atc-unittes
 
 ```bash
 cd /home/okyslytsia/prj/mcp-abap-adt-interfaces
-git checkout main && git pull
+git checkout master && git pull
 git checkout -b feat/capability-atoms
 ```
 

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -529,6 +529,17 @@ import type { ICapabilityContext, ILockStrategy } from './types';
  * and returned unchanged. See the spec's IAdtLockable obligations — idempotent
  * unlock is a TARGET, not implemented here, and is left to the per-endpoint
  * probe + adaptation rule of the full-migration plan.
+ *
+ * DELIBERATELY byte-identical to the current handlers, including the failure
+ * path: if `acquire`/`release` throws, the session is left as-is (stateful) and
+ * the error propagates — exactly as today. In the current architecture,
+ * failure cleanup is the OPERATION CHAIN's job (its create/update catch blocks
+ * call setSessionType('stateless')), NOT lock()/unlock()'s. Adding a
+ * try/finally here would change behaviour and move that responsibility, so the
+ * atom-level "restore stateless on failure" contract is deferred to the
+ * behavioural-conformance work (same bucket as activate/check error
+ * unification), where the chain interaction is reconciled rather than
+ * double-cleaned.
  */
 export class LockCapability<TConfig, TReadResult>
   implements IAdtLockable<TConfig, TReadResult>
@@ -965,7 +976,7 @@ git commit -m "refactor(serviceDefinition): compose LockCapability + VersionsCap
 
 **Interfaces:**
 - Consumes: the three converted handlers (constructed with a fake connection).
-- Produces: a table-driven test asserting the shared behavioural obligations hold identically across the three, plus a verified-unchanged public surface.
+- Produces: a table-driven test asserting the shared behavioural obligations hold identically across the three — specifically the older-BASIS ordering (stateful precedes the LOCK/UNLOCK request, stateless follows the UNLOCK) — plus a verified-unchanged public surface. The failure-path contract is deliberately NOT tested here (it is deferred; see LockCapability's docstring).
 
 - [ ] **Step 1: Write the conformance test**
 
@@ -976,17 +987,27 @@ import { AdtClass } from '../../../../core/class/AdtClass';
 import { AdtDomain } from '../../../../core/domain/AdtDomain';
 import { AdtServiceDefinition } from '../../../../core/serviceDefinition/AdtServiceDefinition';
 
+/**
+ * Records session toggles AND requests in ONE ordered trace, so the test can
+ * assert the older-BASIS ordering (stateful must precede the UNLOCK request,
+ * stateless must follow it) rather than only the final session state.
+ */
 function recordingConnection() {
-  const sessions: string[] = [];
+  const trace: string[] = [];
   return {
-    sessions,
-    setSessionType: (t: string) => sessions.push(t),
-    makeAdtRequest: async () => ({
-      status: 200,
-      headers: {},
-      // minimal LOCK response shape the low-level parsers accept
-      data: `<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE></DATA></asx:values></asx:abap>`,
-    }),
+    trace,
+    setSessionType: (t: string) => trace.push(`session:${t}`),
+    makeAdtRequest: async (req: any) => {
+      const url: string = req?.url ?? '';
+      const action = /_action=(\w+)/.exec(url)?.[1] ?? 'GET';
+      trace.push(`request:${action}`);
+      return {
+        status: 200,
+        headers: {},
+        // minimal LOCK response shape the low-level parsers accept
+        data: `<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE></DATA></asx:values></asx:abap>`,
+      };
+    },
   } as any;
 }
 
@@ -1003,18 +1024,28 @@ const cases = [
 ];
 
 describe('LockCapability conformance across handlers', () => {
-  it.each(cases)('$name: lock leaves session stateful', async ({ make, cfg }) => {
+  it.each(cases)('$name: lock sets stateful before the LOCK request', async ({ make, cfg }) => {
     const conn = recordingConnection();
     const handler = make(conn);
     await handler.lock(cfg);
-    expect(conn.sessions[conn.sessions.length - 1]).toBe('stateful');
+    const iSession = conn.trace.indexOf('session:stateful');
+    const iRequest = conn.trace.findIndex((e: string) => e.startsWith('request:'));
+    expect(iSession).toBeGreaterThanOrEqual(0);
+    expect(iRequest).toBeGreaterThan(iSession); // stateful BEFORE the request
+    // and the session is left stateful (the lock is held).
+    expect(conn.trace.filter((e: string) => e.startsWith('session:')).pop()).toBe('session:stateful');
   });
 
-  it.each(cases)('$name: unlock restores stateless', async ({ make, cfg }) => {
+  it.each(cases)('$name: unlock is stateful → UNLOCK → stateless, in order', async ({ make, cfg }) => {
     const conn = recordingConnection();
     const handler = make(conn);
     await handler.unlock(cfg, 'H1');
-    expect(conn.sessions[conn.sessions.length - 1]).toBe('stateless');
+    const iStateful = conn.trace.indexOf('session:stateful');
+    const iUnlock = conn.trace.indexOf('request:UNLOCK');
+    const iStateless = conn.trace.indexOf('session:stateless');
+    expect(iStateful).toBeGreaterThanOrEqual(0);
+    expect(iUnlock).toBeGreaterThan(iStateful); // stateful BEFORE unlock (older BASIS)
+    expect(iStateless).toBeGreaterThan(iUnlock); // stateless AFTER unlock
   });
 });
 ```
@@ -1143,6 +1174,7 @@ Report to the user: PR opened, ready for review + merge + tag + GitHub release; 
 
 - The remaining 32 handlers — a separate migration plan, using the classification (fits-strategy vs bespoke) the spec requires; includes `AdtFunctionModule` (composite key), `AdtBehaviorImplementation` (delegates to `AdtClass`), `AdtMessageClassMessage` (double-lock).
 - `ActivateCapability` / `CheckCapability` with error-envelope unification — a deliberate behavioural change; its own plan with conformance tests and a CHANGELOG note naming the changed error shapes.
+- **The atom-level failure-path contract** (lock/unlock restore stateless on a thrown error). Today that cleanup lives in the operation chain's catch blocks, not in lock()/unlock(); this pilot preserves that exactly. Moving it into the capabilities is a deliberate behavioural change that must reconcile with the chain's existing cleanup (to avoid double-restore), so it belongs with the error-unification work, not here.
 - `TransportCapability` extraction.
 - Narrowing `AdtClient.getXxx()` return types (the breaking flip) and deprecating the fat contract.
 - The ATC client + `runSync` + MCP tools, built on this architecture once proven.

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -625,9 +625,7 @@ const strategy: IVersionsStrategy<Cfg> = {
     if (!c.name) throw new Error('name is required');
     return c.name;
   },
-  list: async (_ctx, name) => [
-    { version: '000001', versionTitle: name } as any,
-  ],
+  list: async (_ctx, name) => [{ versionId: '000001', title: name } as any],
   source: async (_ctx, uri) => `source-of:${uri}`,
 };
 
@@ -636,7 +634,7 @@ describe('VersionsCapability', () => {
     const cap = new VersionsCapability<Cfg>(getCtx, strategy);
     const v = await cap.getVersions({ name: 'ZBAR' });
     expect(v).toHaveLength(1);
-    expect(v[0].versionTitle).toBe('ZBAR');
+    expect(v[0].title).toBe('ZBAR');
   });
 
   it('getVersionSource delegates to the strategy', async () => {

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -383,14 +383,23 @@ export interface INormalizedLock {
  * Per-handler strategy for LockCapability. The handler supplies its own
  * endpoint knowledge — there is no centralized lifecycle-URI resolver
  * (buildObjectUri is for group operations only).
+ *
+ * `release` returns the handler's OWN state shape (e.g. `{ unlockResult,
+ * errors: [] }`), not void — the current handlers put the ADT unlock response
+ * into `state.unlockResult`, and dropping it would change observable behaviour.
+ * The capability owns only the session toggling around it.
  */
-export interface ILockStrategy<TConfig> {
+export interface ILockStrategy<TConfig, TReadResult> {
   /** Extract the object name from config, or throw if missing. */
   nameOf(config: Partial<TConfig>): string;
   /** POST _action=LOCK, return the normalized handle. */
   acquire(ctx: ICapabilityContext, name: string): Promise<INormalizedLock>;
-  /** POST _action=UNLOCK with the handle. */
-  release(ctx: ICapabilityContext, name: string, lockHandle: string): Promise<void>;
+  /** POST _action=UNLOCK with the handle; build and return the handler state. */
+  release(
+    ctx: ICapabilityContext,
+    name: string,
+    lockHandle: string,
+  ): Promise<TReadResult>;
 }
 
 /** Per-handler strategy for VersionsCapability. */
@@ -424,7 +433,7 @@ git commit -m "feat(capabilities): strategy types for lock and versions"
 
 **Interfaces:**
 - Consumes: `ICapabilityContext`, `INormalizedLock`, `ILockStrategy` from `./types`.
-- Produces: `class LockCapability<TConfig> implements IAdtLockable<TConfig, TReadResult>` with constructor `(ctx: ICapabilityContext, strategy: ILockStrategy<TConfig>, buildState: () => TReadResult)`. Methods: `lock(config): Promise<string>`, `unlock(config, lockHandle): Promise<TReadResult>`.
+- Produces: `class LockCapability<TConfig, TReadResult> implements IAdtLockable<TConfig, TReadResult>` with constructor `(ctx: ICapabilityContext, strategy: ILockStrategy<TConfig, TReadResult>)`. Methods: `lock(config): Promise<string>`, `unlock(config, lockHandle): Promise<TReadResult>`. The state is built by `strategy.release`, so there is no `buildState` constructor param.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -450,7 +459,9 @@ function fakeCtx(): ICapabilityContext & { calls: string[] } {
   };
 }
 
-const strategy: ILockStrategy<Cfg> = {
+type State = { unlockResult?: string; errors: string[] };
+
+const strategy: ILockStrategy<Cfg, State> = {
   nameOf: (c) => {
     if (!c.name) throw new Error('name is required');
     return c.name;
@@ -461,40 +472,36 @@ const strategy: ILockStrategy<Cfg> = {
   },
   release: async (ctx, name, h) => {
     (ctx as any).calls.push(`release:${name}:${h}`);
+    return { unlockResult: `R:${name}`, errors: [] };
   },
 };
 
 describe('LockCapability', () => {
   it('lock sets stateful, acquires, returns the handle', async () => {
     const ctx = fakeCtx();
-    const cap = new LockCapability<Cfg, { errors: string[] }>(
-      ctx,
-      strategy,
-      () => ({ errors: [] }),
-    );
+    const cap = new LockCapability<Cfg, State>(ctx, strategy);
     const handle = await cap.lock({ name: 'ZFOO' });
     expect(handle).toBe('H1');
     expect(ctx.calls).toEqual(['session:stateful', 'acquire:ZFOO']);
   });
 
-  it('unlock releases then restores stateless', async () => {
+  it('unlock is stateful during release, restores stateless, returns state', async () => {
     const ctx = fakeCtx();
-    const cap = new LockCapability<Cfg, { errors: string[] }>(
-      ctx,
-      strategy,
-      () => ({ errors: [] }),
-    );
-    await cap.unlock({ name: 'ZFOO' }, 'H1');
-    expect(ctx.calls).toEqual(['release:ZFOO:H1', 'session:stateless']);
+    const cap = new LockCapability<Cfg, State>(ctx, strategy);
+    const state = await cap.unlock({ name: 'ZFOO' }, 'H1');
+    // stateful BEFORE the UNLOCK (older BASIS), stateless AFTER.
+    expect(ctx.calls).toEqual([
+      'session:stateful',
+      'release:ZFOO:H1',
+      'session:stateless',
+    ]);
+    // the ADT unlock response is preserved in state.
+    expect(state.unlockResult).toBe('R:ZFOO');
   });
 
   it('lock rethrows a missing name from the strategy', async () => {
     const ctx = fakeCtx();
-    const cap = new LockCapability<Cfg, { errors: string[] }>(
-      ctx,
-      strategy,
-      () => ({ errors: [] }),
-    );
+    const cap = new LockCapability<Cfg, State>(ctx, strategy);
     await expect(cap.lock({})).rejects.toThrow('name is required');
   });
 });
@@ -515,18 +522,20 @@ import type { ICapabilityContext, ILockStrategy } from './types';
 
 /**
  * Shared lock/unlock for handlers whose lock differs only by endpoint and
- * name field. `lock` leaves the session stateful (the caller must unlock);
- * `unlock` restores stateless. See the spec's IAdtLockable obligations —
- * idempotent unlock is a TARGET, not implemented here, and is left to the
- * per-endpoint probe + adaptation rule of the full-migration plan.
+ * name field. `lock` leaves the session stateful (the caller must unlock).
+ * `unlock` runs the release inside a stateful request — older BASIS (#106)
+ * only accepts UNLOCK while stateful — then restores stateless. The handler's
+ * state shape (including the ADT `unlockResult`) is built by `strategy.release`
+ * and returned unchanged. See the spec's IAdtLockable obligations — idempotent
+ * unlock is a TARGET, not implemented here, and is left to the per-endpoint
+ * probe + adaptation rule of the full-migration plan.
  */
 export class LockCapability<TConfig, TReadResult>
   implements IAdtLockable<TConfig, TReadResult>
 {
   constructor(
     private readonly ctx: ICapabilityContext,
-    private readonly strategy: ILockStrategy<TConfig>,
-    private readonly buildState: () => TReadResult,
+    private readonly strategy: ILockStrategy<TConfig, TReadResult>,
   ) {}
 
   async lock(config: Partial<TConfig>): Promise<string> {
@@ -542,9 +551,11 @@ export class LockCapability<TConfig, TReadResult>
     lockHandle: string,
   ): Promise<TReadResult> {
     const name = this.strategy.nameOf(config);
-    await this.strategy.release(this.ctx, name, lockHandle);
+    // UNLOCK must run stateful (older BASIS #106); restore stateless after.
+    this.ctx.connection.setSessionType('stateful');
+    const state = await this.strategy.release(this.ctx, name, lockHandle);
     this.ctx.connection.setSessionType('stateless');
-    return this.buildState();
+    return state;
   }
 }
 ```
@@ -714,10 +725,10 @@ private readonly lockCap = new LockCapability<IClassConfig, IClassState>(
       lockHandle: await lockClass(ctx.connection, name),
     }),
     release: async (ctx, name, handle) => {
-      await unlockClass(ctx.connection, name, handle);
+      const result = await unlockClass(ctx.connection, name, handle);
+      return { unlockResult: result, errors: [] };
     },
   },
-  () => ({ errors: [] }),
 );
 
 private readonly versionsCap = new VersionsCapability<IClassConfig>(
@@ -764,7 +775,12 @@ getVersionSource(contentUri: string): Promise<string> {
 }
 ```
 
-(Confirm the exact current `unlock` body first with `sed -n '/async unlock(/,/^  }/p' src/core/class/AdtClass.ts` and preserve any `untrack` / stateless call semantics — the capability already restores stateless, so remove a duplicate `setSessionType('stateless')` from the handler if present.)
+The current `unlock` body (`src/core/class/AdtClass.ts`) is
+`stateful → unlockClass → stateless → untrack → return { unlockResult, errors: [] }`.
+The capability now owns `stateful → release(builds { unlockResult, errors }) → stateless`,
+so the handler wrapper only adds the `untrack`. The state shape is identical; the
+duplicate `setSessionType('stateless')` and the name-guard now live in the capability
+and its strategy, so remove them from the handler body.
 
 - [ ] **Step 3: Build**
 
@@ -819,14 +835,14 @@ private readonly lockCap = new LockCapability<IDomainConfig, IDomainState>(
       lockHandle: await lockDomain(ctx.connection, name),
     }),
     release: async (ctx, name, handle) => {
-      await unlockDomain(ctx.connection, name, handle);
+      const result = await unlockDomain(ctx.connection, name, handle);
+      return { unlockResult: result, errors: [] };
     },
   },
-  () => ({ errors: [] }),
 );
 ```
 
-(Confirm `lockDomain`/`unlockDomain` signatures first: `sed -n '/export async function lockDomain/,/{/p' src/core/domain/lock.ts` and `.../unlockDomain/.../ src/core/domain/unlock.ts`. If `lockDomain` returns `{ lockHandle }` rather than a bare string, adapt `acquire` to return it directly.)
+(Confirm `lockDomain`/`unlockDomain` signatures first: `grep -n "export async function lockDomain" src/core/domain/lock.ts` and `.../unlockDomain .../ src/core/domain/unlock.ts` — both are `(connection, domainName, [lockHandle])`. If `lockDomain` returns `{ lockHandle }` rather than a bare string, adapt `acquire` to return it directly.)
 
 - [ ] **Step 2: Replace lock/unlock, leave getVersions untouched**
 
@@ -903,10 +919,10 @@ private readonly lockCap = new LockCapability<IServiceDefinitionConfig, IService
       lockHandle: await lockServiceDefinition(ctx.connection, name),
     }),
     release: async (ctx, name, handle) => {
-      await unlockServiceDefinition(ctx.connection, name, handle);
+      const result = await unlockServiceDefinition(ctx.connection, name, handle);
+      return { unlockResult: result, errors: [] };
     },
   },
-  () => ({ errors: [] }),
 );
 
 private readonly versionsCap = new VersionsCapability<IServiceDefinitionConfig>(
@@ -916,7 +932,13 @@ private readonly versionsCap = new VersionsCapability<IServiceDefinitionConfig>(
       if (!c.serviceDefinitionName) throw new Error('serviceDefinitionName is required');
       return c.serviceDefinitionName;
     },
-    list: (ctx, name) => getServiceDefinitionVersions(ctx.connection, name),
+    // NOTE: getServiceDefinitionVersions takes a config, not a bare name —
+    // the strategy re-wraps. (getClassIncludeVersions, by contrast, takes a
+    // name; the two low-level shapes differ and the strategy absorbs that.)
+    list: (ctx, name) =>
+      getServiceDefinitionVersions(ctx.connection, {
+        serviceDefinitionName: name,
+      }),
     source: (ctx, uri) => getServiceDefinitionVersionSource(ctx.connection, uri),
   },
 );

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -1089,7 +1089,7 @@ Then read `/tmp/b8.log`. Expected: 6 passed.
 - [ ] **Step 3: Full unit suite**
 
 Run: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b8-unit.log`
-Then read `/tmp/b8-unit.log`. Expected: all pass (~356).
+Then read `/tmp/b8-unit.log`. Expected: all pass — the prior 348, plus 6 capability tests (Tasks B3+B4), plus 6 conformance tests (2 `it.each` over 3 handlers) = 360. Read the actual total from the log; the point is zero failures, not the exact number.
 
 - [ ] **Step 4: Public surface unchanged**
 

--- a/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
+++ b/docs/superpowers/plans/2026-07-20-capability-interfaces-pilot.md
@@ -1130,22 +1130,26 @@ npm test -- integration/core/class integration/core/domain integration/core/serv
 ```
 Then read `integration-pilot.log` — read the summary block (`Test Suites:` … onward). Expected: the previously-passing tests for these three still pass; any pre-existing skips remain skips. A NEW failure that was passing before the refactor is a regression to investigate before release.
 
-- [ ] **Step 2: Verify the consumer still builds and type-checks against the pilot build**
+- [ ] **Step 2: Consumer verification happens AFTER publish — not via a local tarball**
 
-The consumer (`~/prj/mcp-abap-adt`) pins `@mcp-abap-adt/adt-clients` and exercises the `IAdtObject` surface. To prove transparency without publishing, point it at the local pilot build in a throwaway way (do NOT commit the consumer lockfile change):
+Do NOT `npm pack` the pilot and install it into the consumer. That is the "local
+tarball/file bridge" the project rule forbids — consumer work is blocked until the
+dependency is on npm (see the publish-interfaces-first / no-local-bridge rule). The pilot's
+correctness is already established without the consumer: the empty public-surface diff
+(Task B8) plus the full unit suite proves the `IAdtObject` surface and behaviour are
+unchanged, so the consumer that compiles against the current published adt-clients will
+compile against this one.
 
-```bash
-cd /home/okyslytsia/prj/mcp-abap-adt-clients && npm run build && npm pack
-# produces mcp-abap-adt-adt-clients-<ver>.tgz
-cd /home/okyslytsia/prj/mcp-abap-adt
-npm install --no-save /home/okyslytsia/prj/mcp-abap-adt-clients/mcp-abap-adt-adt-clients-*.tgz
-npm run build 2>&1 | tee /tmp/consumer-build.log
-```
-Then read `/tmp/consumer-build.log`. Expected: the consumer compiles clean against the pilot build — proof the `IAdtObject` surface is transparent. Restore the consumer's dependency afterward: `cd ~/prj/mcp-abap-adt && npm install` (re-pulls the published version; confirm no `"link": true` and no tarball path left in its lockfile).
+Consumer verification, if wanted, is a POST-publish step: once the user has published the
+new adt-clients version to npm, bump `~/prj/mcp-abap-adt`'s `@mcp-abap-adt/adt-clients`
+dependency to it and run its build — resolving from the registry, never a local tarball.
+That is outside this task and this branch.
 
 - [ ] **Step 3: Record the verification outcome**
 
-No commit. Summarize for the user: unit (count), trial integration (pass/skip/fail per suite with the actual numbers from the log), surface diff (empty), consumer build (clean). If anything regressed, STOP and report rather than proceeding to release.
+No commit. Summarize for the user: unit (count), trial integration (pass/skip/fail per suite
+with the actual numbers from the log, if run), and the empty surface diff. If anything
+regressed, STOP and report rather than proceeding to release.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -33,22 +33,30 @@ AdtServiceBinding {}`) declare no method of their own and are dropped to avoid
 double-counting. `*Legacy.ts` subclasses are likewise excluded — they override
 selectively and would double-count their parents.
 
+The generator resolves both delegation and inheritance: a method that calls a private
+helper doing the real work counts as real (not a stub), and a subclass inherits its
+parent's verdict for any method it does not override. All counts below are on the single
+population of 35.
+
 ### What the matrix shows
 
-- `getVersions` / `getVersionSource`: **19 real, 11 refuse** — identical sets, the
+- `create` / `read` / `readMetadata`: **35 real** — every contract class.
+- `update` / `delete`: **33 real, 2 refuse** (Request, UnitTest — both known defects,
+  see below).
+- `getVersions` / `getVersionSource`: **23 real, 12 refuse** — identical sets, the
   sharpest split in the contract.
-- `lock` / `unlock`: **26 real, 4 refuse** — identical sets, a rigid pair.
-- `activate`: 28 real, 5 refuse. `check`: 30 real, 4 refuse. The sets differ, so these
+- `lock` / `unlock`: **30 real, 5 refuse** — identical sets, a rigid pair.
+- `activate`: 29 real, 6 refuse. `check`: 30 real, 5 refuse. The sets differ, so these
   are distinct capabilities rather than one.
-- `readTransport`: 23 real and **7 not implemented — through two different mechanisms**:
-  three refuse outright (MessageClass, MessageClassMessage, Request) and four return a
-  stub (AuthorizationField, FeatureToggle, FunctionInclude, UnitTest). With no way to
-  say "I don't do transports", implementers invented more than one lie. That
+- `readTransport`: 27 real and **8 not implemented — through two different mechanisms**:
+  three refuse outright (MessageClass, MessageClassMessage, Request) and five return a
+  stub (AuthorizationField, FeatureToggle, FunctionInclude, CdsUnitTest, UnitTest). With
+  no way to say "I don't do transports", implementers invented more than one lie. That
   inconsistency is the clearest symptom of the problem.
-- Handlers where the contract is plainly the wrong fit: `AdtUnitTest` and `AdtRequest`
+- Classes where the contract is plainly the wrong fit: `AdtUnitTest` and `AdtRequest`
   refuse seven methods each; `AdtMessageClassMessage` refuses or stubs nine;
-  `AdtPackageLegacy` (excluded from the count as a subclass) throws on all 13 and exists
-  solely to satisfy the type.
+  `AdtPackageLegacy` (a `*Legacy` subclass, outside this population) throws on all 13 and
+  exists solely to satisfy the type.
 
 The cost is paid by consumers: `AdtClient.getUnitTest()` returns a type promising
 `lock()`, and the promise is false. The compiler cannot help, so the failure surfaces
@@ -77,13 +85,13 @@ Two rules govern the decomposition. Both were derived during review, not assumed
 **Rule 1 — split only on evidence.** An atom is divided only when a class exists that
 has one part without the other. Absent such a class, the methods stay together.
 
-This is why `IAdtCrud` is a single atom: `create`, `read`, `readMetadata`, `update`,
-`delete` are implemented by all 30 handlers. The only two apparent exceptions —
-`AdtRequest` and `AdtUnitTest` — are our own defects, not domain limits (see
-"Known defects"). No ADT object has partial CRUD.
+This is why `IAdtCrud` is a single atom: across all 35 contract classes `create`, `read`
+and `readMetadata` are 35/35, and `update` / `delete` refuse in only two — `AdtRequest`
+and `AdtUnitTest`, both our own defects, not domain limits (see "Known defects"). No ADT
+object has partial CRUD.
 
 It is also why `readMetadata` stays inside `IAdtCrud` despite being conceptually a
-header read rather than a CRUD operation: all 30 handlers implement both `read` and
+header read rather than a CRUD operation: all 35 implement both `read` and
 `readMetadata`, so there is nothing to split on. If an object ever reads a header but
 not a body, we divide then, with grounds.
 
@@ -101,15 +109,17 @@ that is cheap to fix. Encoding our gaps as contract is the worse failure.
 seven atoms, with no overlap. The two specialized interfaces that widen `IAdtObject` are
 handled separately — see "Specialized interfaces" below.
 
+Counts are real/refuse/stub over the 35-class population.
+
 | Atom | Methods | Evidence (generated) |
 |---|---|---|
-| `IAdtCrud` | `create`, `read`, `readMetadata`, `update`, `delete` | no object has partial CRUD — see below |
-| `IAdtValidatable` | `validate` | 31 real / 1 refuses / 2 stub |
-| `IAdtCheckable` | `check` | 30 real / 4 refuse |
-| `IAdtActivatable` | `activate` | 28 real / 5 refuse |
-| `IAdtLockable` | `lock`, `unlock` | 26 / 4, **identical sets** |
-| `IAdtVersionable` | `getVersions`, `getVersionSource` | 19 / 11, **identical sets**, verified domain boundary |
-| `IAdtTransportAware` | `readTransport` | 23 real / 3 refuse / 4 stub |
+| `IAdtCrud` | `create`, `read`, `readMetadata`, `update`, `delete` | 35/35 for read-side; no object has partial CRUD — see below |
+| `IAdtValidatable` | `validate` | 31 / 1 / 3 |
+| `IAdtCheckable` | `check` | 30 / 5 / 0 |
+| `IAdtActivatable` | `activate` | 29 / 6 / 0 |
+| `IAdtLockable` | `lock`, `unlock` | 30 / 5, **identical sets** |
+| `IAdtVersionable` | `getVersions`, `getVersionSource` | 23 / 12, **identical sets**, verified domain boundary |
+| `IAdtTransportAware` | `readTransport` | 27 / 3 / 5 |
 
 `validate`, `check` and `activate` are separate atoms because their sets genuinely
 differ: `AdtPackage` implements `check` but not `activate`; `AdtMessageClass` implements
@@ -122,9 +132,8 @@ co-occur perfectly — no handler has one without the other.
 
 These are different things, and conflating them makes the counts irreproducible.
 
-**Observed**, from the generated matrix: `update` has 2 refusals and `delete` has 2 —
-`AdtRequest` and `AdtUnitTest` in both cases. `create` and `read` each have one stub
-(`AdtMessageClassMessage`, `AdtFunctionInclude`).
+**Observed**, from the generated matrix: `create`, `read` and `readMetadata` are 35/35;
+`update` and `delete` each have exactly 2 refusals — `AdtRequest` and `AdtUnitTest`.
 
 **Intended**, after the known defects are fixed: CRUD is universal. Both refusals are
 our own bugs, not ADT limits — a transport request's description can be changed and an
@@ -136,25 +145,32 @@ so explicitly rather than quietly picking whichever number supports the design.
 
 ### The versioning boundary is real
 
-`getVersions` / `getVersionSource` are absent from 11 handlers for a domain reason,
+`getVersions` / `getVersionSource` are refused by 12 of the 35 for a domain reason,
 confirmed with the maintainer: ADT exposes version history at `<sourceUri>/versions`.
 Objects without a source resource — those represented purely as XML — have no such
-endpoint.
+endpoint. (Eleven of the twelve are primary handlers; the twelfth, CdsUnitTest,
+inherits the refusal.)
 
 The dividing line is "has `/source/main`", **not** "is DDIC": `Table`, `Structure` and
 `TableType` have versions; `Domain`, `DataElement` and `Package` do not.
 
-- **With versions (19):** AccessControl, AppendStructure, BehaviorDefinition,
+Over the full population of 35, the split is **23 with / 12 without**, generated by
+`scripts/capability-matrix.mjs --csv`:
+
+- **With versions (23):** AccessControl, AppendStructure, BehaviorDefinition,
   BehaviorImplementation, Class, DdicTableType, Ddl, Enhancement, FunctionInclude,
   FunctionModule, Interface, MetadataExtension, Program, ScalarFunction,
-  ScalarFunctionImplementation, ServiceDefinition, Structure, Table, Transformation.
-- **Without (11):** AuthorizationField, DataElement, Domain, FeatureToggle,
+  ScalarFunctionImplementation, ServiceDefinition, Structure, Table, Transformation, and
+  the four class-include handlers (LocalDefinitions, LocalMacros, LocalTestClass,
+  LocalTypes — they delegate to `getIncludeVersions` on the parent class, which the
+  generator resolves as real work).
+- **Without (12):** AuthorizationField, DataElement, Domain, FeatureToggle,
   FunctionGroup, MessageClass, MessageClassMessage, Package, Request, ServiceBinding,
-  UnitTest.
+  UnitTest, and CdsUnitTest (which inherits `AdtUnitTest`'s refusal).
 
-Both lists are generated by `scripts/capability-matrix.mjs --csv` and sum to 30. The
-four class-include handlers are excluded: they delegate to `getIncludeVersions` on the
-parent class rather than implementing the contract method themselves.
+Stripped of the four inheriting class-includes and the one inheriting CdsUnitTest, the
+underlying domain boundary among the primary handlers is 19 source-backed to 11 not —
+the same line, viewed on the smaller population.
 
 ## Composition
 
@@ -309,8 +325,12 @@ type _PartitionIsExact<C, R> = [
 type _Check = _PartitionIsExact<IClassConfig, IClassState>;
 ```
 
-The final instantiation is not decoration: an uninstantiated generic type alias is never
-evaluated, so without it the assertion would silently pass no matter what.
+Keep the final instantiation. A generic type alias is only fully checked at the
+argument types it is instantiated with, so instantiating `_PartitionIsExact` at a
+concrete config/state pair guarantees the `Assert` constraints are actually evaluated
+rather than left to depend on where and whether the alias is referenced. It is cheap
+insurance; the implementation step must confirm the assertion fails when a method is
+removed, which is the real proof that it checks anything.
 
 **This proof covers `IAdtObject` only.** It cannot validate
 `IAdtFeatureToggleControl` or the service-binding atoms, because `AllAtoms` is compared
@@ -346,8 +366,9 @@ Each is a separate decision, taken once the atoms have settled:
 
 1. **Redefine `IAdtObject` as the intersection of its atoms.** Safe once the proof
    above passes, but pointless before consumers exist.
-2. **Narrow `AdtClient.getXxx()` return types** for the 11 handlers without versions,
-   so `getDomain()` no longer promises `getVersions()`. This is a **breaking change**
+2. **Narrow `AdtClient.getXxx()` return types** for the handlers without versions (the
+   12 listed above), so `getDomain()` no longer promises `getVersions()`. This is a
+   **breaking change**
    for adt-clients — code calling `client.getDomain().getVersions()` compiles today and
    throws at runtime; afterwards it fails to compile. That converts a runtime error
    into a compile error, which is the point, but it warrants a major bump and a

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -1,0 +1,239 @@
+# Capability interfaces — design
+
+**Date:** 2026-07-20
+**Status:** approved for planning
+**Repos:** `@mcp-abap-adt/interfaces` (step 1), `@mcp-abap-adt/adt-clients` (later steps)
+
+## Problem
+
+`IAdtObject<TConfig, TReadResult>` declares 13 methods that every object handler must
+provide. Most handlers cannot provide all of them, so they lie — and they lie
+inconsistently.
+
+A survey of all 30 primary handlers in `src/core/*/Adt*.ts` established:
+
+- Only `create`, `read`, `readMetadata` are implemented by every handler.
+- `getVersions` / `getVersionSource` throw in 11 of 30.
+- `activate`, `check`, `lock`, `unlock` throw in 4–5.
+- `readTransport` is unimplemented in 6 handlers **via three different mechanisms**:
+  three throw, three return a fabricated error state, one returns an empty
+  `{errors: []}`. With no way to say "I don't do transports", implementers invented
+  three different lies. That inconsistency is the clearest symptom of the problem.
+- Four handlers are 0–4 of 13: `AdtPackageLegacy` (0/13 — every method throws, the
+  class exists solely to satisfy the type), `AdtUnitTest` (3/13), `AdtRequest` (3/13),
+  `AdtMessageClassMessage` (4/13).
+
+The cost is paid by consumers: `AdtClient.getUnitTest()` returns a type promising
+`lock()`, and the promise is false. The compiler cannot help, so the failure surfaces
+at runtime against a live SAP system.
+
+## Goal and non-goal
+
+**Goal: contract honesty.** A handler should declare only what it does, and
+`AdtClient.getXxx()` should return a type that does not lie.
+
+**Explicit non-goal for now: parameter polymorphism.** An exhaustive search found
+**no production code that accepts `IAdtObject` as a parameter or holds a collection of
+them** — only the test harness `BaseTester` (`src/__tests__/helpers/BaseTester.ts:88`),
+which already uses just 7 of the 13 methods. Group activation
+(`src/core/shared/groupActivation.ts:138`) operates on `IObjectReference[]`, not on
+handlers, so it would not consume a capability interface either.
+
+Narrow capability interfaces do enable such call sites later, and TypeScript's
+structural typing makes them compose without ceremony. But that is a future benefit,
+not present justification. Claiming otherwise would overstate the case.
+
+## Design rules
+
+Two rules govern the decomposition. Both were derived during review, not assumed.
+
+**Rule 1 — split only on evidence.** An atom is divided only when a class exists that
+has one part without the other. Absent such a class, the methods stay together.
+
+This is why `IAdtCrud` is a single atom: `create`, `read`, `readMetadata`, `update`,
+`delete` are implemented by all 30 handlers. The only two apparent exceptions —
+`AdtRequest` and `AdtUnitTest` — are our own defects, not domain limits (see
+"Known defects"). No ADT object has partial CRUD.
+
+It is also why `readMetadata` stays inside `IAdtCrud` despite being conceptually a
+header read rather than a CRUD operation: all 30 handlers implement both `read` and
+`readMetadata`, so there is nothing to split on. If an object ever reads a header but
+not a body, we divide then, with grounds.
+
+**Rule 2 — exclude only on verified domain limits.** A class is left out of a
+capability only when the limitation is confirmed to be ADT's, not ours. When unsure,
+the class stays in and the throwing stub is treated as a bug.
+
+The asymmetry is deliberate. A wrong exclusion enters the type system and is read by
+the next developer as truth about SAP; a redundant method that throws is a visible bug
+that is cheap to fix. Encoding our gaps as contract is the worse failure.
+
+## The partition
+
+Every method of every "big" interface belongs to **exactly one** atom. Nine atoms
+cover 20 methods with no overlap.
+
+| Atom | Methods | Evidence |
+|---|---|---|
+| `IAdtCrud` | `create`, `read`, `readMetadata`, `update`, `delete` | 30/30 — universal; no partial-CRUD object exists |
+| `IAdtValidatable` | `validate` | 27/30 |
+| `IAdtCheckable` | `check` | 26/30 |
+| `IAdtActivatable` | `activate` | 25/30 |
+| `IAdtLockable` | `lock`, `unlock` | rigid pair — 0 handlers have one without the other |
+| `IAdtVersionable` | `getVersions`, `getVersionSource` | 19 vs 11, verified domain boundary |
+| `IAdtTransportAware` | `readTransport` | 24/30 |
+| `IAdtFeatureToggleControl` | `switchOn`, `switchOff`, `getRuntimeState`, `checkState`, `readSource` | single implementer |
+| `IAdtServiceBindingOps` | `validateServiceBinding`, `updateServiceBinding` | single implementer |
+
+`validate`, `check` and `activate` are separate atoms because their sets genuinely
+differ: `AdtPackage` implements `check` but not `activate`; `AdtMessageClass`
+implements `validate` but neither `check` nor `activate`.
+
+`IAdtLockable` and `IAdtVersionable` are each one atom because their member methods
+co-occur perfectly across all 30 handlers.
+
+### The versioning boundary is real
+
+`getVersions` / `getVersionSource` are absent from 11 handlers for a domain reason,
+confirmed with the maintainer: ADT exposes version history at `<sourceUri>/versions`.
+Objects without a source resource — those represented purely as XML — have no such
+endpoint.
+
+The dividing line is "has `/source/main`", **not** "is DDIC": `Table`, `Structure` and
+`TableType` have versions; `Domain`, `DataElement` and `Package` do not.
+
+- **With versions (19):** Class, Interface, Program, Ddl, Table, Structure, TableType,
+  Enhancement, MetadataExtension, BehaviorDefinition, BehaviorImplementation,
+  AccessControl, AppendStructure, ScalarFunction, ScalarFunctionImplementation,
+  ServiceDefinition, Transformation, FunctionInclude.
+- **Without (11):** Domain, DataElement, Package, FunctionGroup, AuthorizationField,
+  FeatureToggle, MessageClass, MessageClassMessage, Request, Service, UnitTest.
+
+## Composition
+
+Composite interfaces are intersections of atoms. They define no methods of their own —
+that is what keeps the partition a partition.
+
+```ts
+export type IAdtCrudObject<TConfig, TReadResult = TConfig> =
+  & IAdtCrud<TConfig, TReadResult>
+  & IAdtValidatable<TConfig, TReadResult>
+  & IAdtCheckable<TConfig, TReadResult>
+  & IAdtActivatable<TConfig, TReadResult>
+  & IAdtLockable<TConfig, TReadResult>
+  & IAdtTransportAware<TConfig, TReadResult>;
+```
+
+A handler that also has version history composes further:
+
+```ts
+type ISourceObject<C, R> = IAdtCrudObject<C, R> & IAdtVersionable<C>;
+```
+
+## Correctness proof
+
+The partition must be provably exact, not exact by inspection. A compile-time
+assertion checks assignability in **both** directions between `IAdtObject` and the
+intersection of its ten constituent atoms:
+
+```ts
+type Assert<T extends true> = T;
+
+type AllAtoms<C, R> =
+  & IAdtCrud<C, R> & IAdtValidatable<C, R> & IAdtCheckable<C, R>
+  & IAdtActivatable<C, R> & IAdtLockable<C, R> & IAdtVersionable<C>
+  & IAdtTransportAware<C, R>;
+
+type _PartitionIsExact = [
+  Assert<IAdtObject<C, R> extends AllAtoms<C, R> ? true : false>,
+  Assert<AllAtoms<C, R> extends IAdtObject<C, R> ? true : false>,
+];
+```
+
+A dropped method, a mistyped parameter or a missing generic argument fails the build.
+
+Both directions are required: one alone would permit the intersection to be a strict
+superset or subset. The assertion must itself be verified by temporarily removing a
+method and confirming the build fails — the same discipline used for the ATC
+vocabulary guard, where an `Extract`-based check turned out to degrade silently
+instead of erroring.
+
+## Scope of step 1
+
+Step 1 is **purely additive**. The atoms are declared as a parallel branch in
+`@mcp-abap-adt/interfaces`.
+
+Explicitly NOT in step 1:
+
+- `IAdtObject` is not redefined as an intersection. It stays byte-for-byte as it is.
+- No handler class is modified.
+- No `AdtClient.getXxx()` return type is narrowed.
+- No composite is applied to any existing declaration.
+
+Version: **minor** (11.2.0), shipping alongside the ATC contract types already on
+`feat/atc-unittest-types`. Nothing breaks; consumers may adopt atoms when they choose.
+
+## Later steps, deliberately deferred
+
+Each is a separate decision, taken once the atoms have settled:
+
+1. **Redefine `IAdtObject` as the intersection of its atoms.** Safe once the proof
+   above passes, but pointless before consumers exist.
+2. **Narrow `AdtClient.getXxx()` return types** for the 11 handlers without versions,
+   so `getDomain()` no longer promises `getVersions()`. This is a **breaking change**
+   for adt-clients — code calling `client.getDomain().getVersions()` compiles today and
+   throws at runtime; afterwards it fails to compile. That converts a runtime error
+   into a compile error, which is the point, but it warrants a major bump and a
+   CHANGELOG entry naming exactly what breaks.
+3. **Non-CRUD / runtime clients.** A separate survey found the 14 runtime classes are
+   already uniform: identical `(connection, logger)` constructors, stateless, raw
+   `IAdtResponse` returns, no locks, no polling. There is a de-facto convention but no
+   meaningful shared operation set — the honest common denominator is a constructor
+   whose `logger` parameter 13 of 14 implementations never read. No abstraction is
+   proposed for them here.
+4. **`IAdtSearchable` is not proposed.** Seven "find things" operations have seven
+   different input shapes and five different result shapes. `ISearchResult` exists in
+   `IAdtShared.ts:84` and is used by no production code — the one type that would have
+   been the shared search result was declared and abandoned. A search capability would
+   have to be *imposed* by normalizing all seven signatures, and would have zero
+   existing call sites to validate against. That is a design act, not an extraction,
+   and belongs in its own spec if wanted.
+
+## Known defects (not part of this design)
+
+Found while building the matrix. Both are bugs to fix, and under Rule 2 neither
+affects the partition — the classes stay in their capabilities.
+
+1. **`AdtRequest.update()` and `.delete()` throw** with the claim that ADT does not
+   support them (`src/core/transport/AdtRequest.ts:190,203`). A transport request's
+   description can be changed, and an empty request can be deleted. The comment states
+   something about ADT that is not true. Could not be verified on the cloud trial: the
+   user has no transport requests there, so `FIND` returns an empty tree, and discovery
+   declares content types but not methods. Treated as a defect on the maintainer's
+   domain knowledge, flagged as unverified.
+2. **`AdtUnitTest` implements `IAdtObject` with 3 of 13 methods.** It is a test-run
+   executor, not an object; a test class is a variant of a class. The contract is
+   simply the wrong one for it.
+
+Related, from the same surveys but out of scope here:
+
+- `FeedRepository` reaches the same three endpoints as `SystemMessages`,
+  `GatewayErrorLog` and `RuntimeDumps` with the opposite contract — parsed objects
+  instead of raw, silent empty results instead of throwing. Two access paths to one
+  endpoint with opposite semantics; new callers choose arbitrarily.
+- Eight core modules construct `new AdtUtils(connection, noopLogger)` inside their own
+  `read.ts` to call `readObjectMetadata` — an inverted dependency, typed modules
+  reaching back into the facade for what should be their own read logic.
+- `src/utils/managementOperations.ts:43` is a second, duplicate group-activation
+  implementation with a different object shape than
+  `src/core/shared/groupActivation.ts`.
+
+## Testing
+
+The partition proof is a compile-time assertion in the interfaces package; it needs no
+runtime test and is validated by deliberately breaking it once.
+
+Step 1 changes no behaviour, so the adt-clients unit suite (348 tests) and the public
+surface must both be unchanged. The surface is captured across all seven entry points
+with the TypeScript compiler API, as in the 7.5.0 migration — a `diff` of before and
+after must be empty.

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -22,9 +22,16 @@ This matters because earlier drafts of this spec carried hand-copied counts that
 wrong in three separate places — one of them an arithmetic impossibility. Numbers in a
 design document must be derivable, or they will drift from the code they describe.
 
-**Denominator: 37 classes** — the 30 primary handlers plus `AdtServiceBinding`, the four
-class-include handlers and `AdtCdsUnitTest`. `*Legacy.ts` subclasses are excluded: they
-override selectively and would double-count their parents.
+**Denominator: 35 classes** — 29 primary `IAdtObject` handlers, plus `AdtServiceBinding`,
+`AdtCdsUnitTest`, and the four class-include handlers. The generator selects classes by
+their **heritage clause**, not by name: a class is counted only if it implements a
+contract interface (`IAdtObject`, `IFeatureToggleObject`, `IAdtServiceBinding`) or
+extends a handler that does. This deliberately excludes the `AdtService` facade and
+`AdtUtils` — neither claims the contract; `AdtUtils` says so at
+`src/core/shared/AdtUtils.ts:4`. Pure-alias subclasses (`class AdtService extends
+AdtServiceBinding {}`) declare no method of their own and are dropped to avoid
+double-counting. `*Legacy.ts` subclasses are likewise excluded — they override
+selectively and would double-count their parents.
 
 ### What the matrix shows
 
@@ -180,17 +187,21 @@ the "exactly one atom" guarantee applies only to `IAdtObject`'s 13.
 `IAdtFeatureToggleControl` atom would cover them cleanly. Low risk, but no reason to
 rush it into step 1.
 
-`IAdtServiceBinding` adds **twelve**, not two as an earlier draft of this spec claimed:
-`getServiceBindingTypes`, `createServiceBinding`, `readServiceBinding`,
-`updateServiceBinding`, `deleteServiceBinding`, `validateServiceBinding`,
-`checkServiceBinding`, `activateServiceBinding`, `transportCheckServiceBinding`,
-`generateServiceBinding`, `createAndGenerateServiceBinding`, `classifyServiceBinding`.
+`IAdtServiceBinding` adds **sixteen** (an earlier draft undercounted this twice — first
+as two, then as twelve): `getServiceBindingTypes`, `createServiceBinding`,
+`readServiceBinding`, `updateServiceBinding`, `deleteServiceBinding`,
+`validateServiceBinding`, `checkServiceBinding`, `activateServiceBinding`,
+`transportCheckServiceBinding`, `generateServiceBinding`, `createAndGenerateServiceBinding`,
+`classifyServiceBinding`, `getODataV2ServiceBinding`, `getODataV4ServiceBinding`,
+`publishODataV2`, `unpublishODataV2`.
 
-That list is itself a finding worth recording. Eight of the twelve are binding-suffixed
-restatements of operations the base contract already has — create, read, update, delete,
-validate, check, activate, transport-check. `AdtServiceBinding` therefore carries **two
-parallel vocabularies for the same lifecycle**, and separately refuses `lock`, `unlock`
-and both version methods from the base contract.
+That list is itself a finding worth recording. Eight are binding-suffixed restatements of
+operations the base contract already has — create, read, update, delete, validate, check,
+activate, transport-check. The other eight are binding-specific: type discovery,
+generation (two forms), classification, OData service reads (v2/v4), and OData
+publish/unpublish. So `AdtServiceBinding` carries **two parallel vocabularies for the
+shared lifecycle**, plus a genuine binding-only surface — and separately refuses `lock`,
+`unlock` and both version methods from the base contract.
 
 Deciding whether those eight should collapse into the base atoms, or whether the binding
 genuinely needs its own lifecycle vocabulary, requires understanding why the duplication
@@ -204,10 +215,9 @@ An interface constrains behaviour, not only shape. TypeScript checks the second 
 says nothing about the first, so the partition alone does not solve the problem that
 motivated it — it would merely distribute it across seven interfaces instead of one.
 
-The evidence is already in hand. `readTransport` is "unimplemented" in six handlers by
-three different mechanisms — throwing, returning a fabricated error state, and
-returning an empty `{errors: []}`. Every one of those satisfies the structural
-signature. The type system was never going to catch it.
+The evidence is already in hand. `readTransport` is "unimplemented" in seven handlers by
+two different mechanisms — three refuse outright, four return a stub. Every one of those
+satisfies the structural signature. The type system was never going to catch it.
 
 So each atom carries a behavioural contract, and implementations must satisfy both.
 
@@ -231,7 +241,10 @@ Contracts common to every atom:
   non-fatal diagnostics only. An empty `errors` array must mean "nothing went wrong",
   never "this operation does not apply here".
 - **Session type is restored** on both the success and failure paths. Any method that
-  sets `stateful` returns the connection to `stateless` before it finishes or throws.
+  sets `stateful` returns the connection to `stateless` before it finishes or throws —
+  with one deliberate exception, `lock` (see `IAdtLockable` below), whose whole purpose
+  is to leave the session `stateful` for the caller. A `lock` that *fails* still restores
+  `stateless`; only a `lock` that *succeeds* leaves it open.
 
 Atom-specific obligations:
 
@@ -355,8 +368,10 @@ judged coherence by the *current concrete signatures* and concluded no capabilit
 possible. Absence of a shared concrete shape does not imply absence of a shared
 abstraction — that is what interfaces are for.
 
-The shapes do share a core. All five "an object was found" types carry a name, a type,
-and optional `uri` / `packageName` / `description`:
+The shapes do share a core. All five "an object was found" types carry a **name and a
+type**; `uri`, `packageName` and `description` appear in some but not all (the table
+shows which). `IObjectReference` is the thinnest — name, type, and an optional parent —
+which makes name+type the only truly universal pair and the right base:
 
 | Type | Name | Type field | Extras |
 |---|---|---|---|

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -64,8 +64,11 @@ at runtime against a live SAP system.
 
 ## Goal and non-goal
 
-**Goal: contract honesty.** A handler should declare only what it does, and
-`AdtClient.getXxx()` should return a type that does not lie.
+**Goal: contract honesty, realized in both the types and the implementation.** A handler
+should declare only what it does, `AdtClient.getXxx()` should return a type that does not
+lie, and the operation chain should run only the steps a handler actually supports rather
+than calling methods that throw. The atoms are step 1; the composition architecture that
+delivers the second half is described under "Implementation architecture".
 
 **Explicit non-goal for now: parameter polymorphism.** An exhaustive search found
 **no production code that accepts `IAdtObject` as a parameter or holds a collection of
@@ -359,6 +362,88 @@ Explicitly NOT in step 1:
 
 Version: **minor** (11.2.0), shipping alongside the ATC contract types already on
 `feat/atc-unittest-types`. Nothing breaks; consumers may adopt atoms when they choose.
+
+## Implementation architecture (adt-clients)
+
+The atoms are only types. This section is how they are realized in adt-clients, and it is
+the larger half of the work. The end state: each handler is a thin proxy that **composes
+capability implementations** rather than owning bespoke lifecycle code.
+
+### Capability implementations
+
+A capability implementation is a reusable unit that satisfies one atom for *any* object
+type, parameterized by the only things that actually vary. A survey of six representative
+handlers established that variation precisely: the lifecycle methods
+(`lock`, `unlock`, `getVersions`, `getVersionSource`, `readTransport`, and the happy path
+of `activate` / `check`) differ **only by object URI and which config field holds the
+name** — the bodies are otherwise the same, copy-pasted into ~15 near-identical per-type
+files (`lock.ts`, `unlock.ts`, `versions.ts`, `activation.ts`, the transport getter).
+
+So each capability is parameterized by a **URI resolver**, not a bare name field —
+because `AdtEnhancement` is dual-keyed (`type` + `name`) and resolves its URI through
+`getEnhancementUri(type, name)`. The resolver already exists centralized as
+`buildObjectUri(name, typeCode, parentName)` in `src/utils/activationUtils.ts`, mapping
+every type code (`CLAS/OC`, `DOMA/DD`, `SRVD/SRV`, …) to its path.
+
+Extraction therefore **deletes code, not adds it**: a `LockCapability` absorbs the ~15
+`lock.ts`/`unlock.ts` wrapper files; `getVersionSource`, byte-identical today, collapses
+to one function. The forwarding on the handler (`getVersions(c) { return this.#versions... }`)
+replaces a method that was already a one-liner — a wash — while the per-type helper files
+disappear. That is where the win is.
+
+### Handlers become proxies
+
+A handler declares which atoms it has and holds a capability instance for each:
+
+```ts
+class AdtClass implements IAdtObject<IClassConfig, IClassState> {
+  #lock = new LockCapability(this.ctx);
+  #versions = new VersionsCapability(this.ctx);
+  // create/read/update stay per-type: they carry the XML/Accept/URI knowledge
+  lock(c) { return this.#lock.lock(c); }
+  getVersions(c) { return this.#versions.list(c); }
+}
+```
+
+`create`, `read`, `update` stay per-type — that is where the genuine per-object knowledge
+lives (XML bodies, Accept headers). The lifecycle methods delegate.
+
+### The operation chain orchestrates over *present* capabilities
+
+The standard SAP flow is `validate → create → lock → check → update → unlock → activate`,
+but not every object has every step — some have no `activate`, some no `lock`. Today that
+absence is expressed as a method that throws. Under this architecture it is expressed
+structurally: the chain runs a step **only if the handler composes that capability**. A
+handler without `IAdtLockable` skips lock/unlock; one without `IAdtActivatable` skips
+activation. Absence becomes "no step", not "a step that refuses" — which is the whole
+point of the partition, now realized in the orchestration and not just the type.
+
+### Error envelopes: unified on purpose
+
+The survey found `activate` and `check` already share their happy path
+(`activateObjectInSession`, `checkRun`) but wrap errors **differently per handler** — not
+by object type, by inconsistent authoring (elaborate `AdtOperationError` on `AdtClass`,
+bare log-and-rethrow on `AdtDomain`). Moving that into a shared capability **changes the
+observable error shape for some types**. This is intended: it is exactly the behavioural
+contract above, and the payoff is uniform, informative errors instead of whichever
+envelope each method's author happened to write. It is a behavioural change, so it must
+be covered by the conformance tests, and the CHANGELOG must name it.
+
+### ATC is the pilot
+
+ATC is greenfield — no legacy handler to preserve — so it is built on this scheme from
+the start and proves the mechanism (capability implementation + proxy + chain-over-present-
+capabilities) on a small surface before the 35 existing handlers are touched. ATC's own
+operations do not map to the `IAdtObject` atoms, so it pilots the *pattern*, not the atom
+set: it composes its own small ATC capabilities the same way.
+
+### Deprecation path
+
+The migration is non-breaking until the final flip. Existing handlers keep their public
+surface while their internals move to composed capabilities; `IAdtObject` stays intact.
+Only once the new scheme is proven across all handlers do the fat contract and the
+lying return types get marked `@deprecated`, with the narrowed capability-based types
+promoted as the supported API — the breaking flip below.
 
 ## Later steps, deliberately deferred
 

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -371,25 +371,58 @@ capability implementations** rather than owning bespoke lifecycle code.
 
 ### Capability implementations
 
-A capability implementation is a reusable unit that satisfies one atom for *any* object
-type, parameterized by the only things that actually vary. A survey of six representative
-handlers established that variation precisely: the lifecycle methods
+A capability implementation is a reusable unit that satisfies one atom for object types
+that share its shape, parameterized by the things that vary. A survey of six
+representative handlers established that for the majority of types the lifecycle methods
 (`lock`, `unlock`, `getVersions`, `getVersionSource`, `readTransport`, and the happy path
-of `activate` / `check`) differ **only by object URI and which config field holds the
+of `activate` / `check`) differ **only by endpoint and which config field holds the
 name** — the bodies are otherwise the same, copy-pasted into ~15 near-identical per-type
 files (`lock.ts`, `unlock.ts`, `versions.ts`, `activation.ts`, the transport getter).
 
-So each capability is parameterized by a **URI resolver**, not a bare name field —
-because `AdtEnhancement` is dual-keyed (`type` + `name`) and resolves its URI through
-`getEnhancementUri(type, name)`. The resolver already exists centralized as
-`buildObjectUri(name, typeCode, parentName)` in `src/utils/activationUtils.ts`, mapping
-every type code (`CLAS/OC`, `DOMA/DD`, `SRVD/SRV`, …) to its path.
+Each capability is parameterized by a **per-capability strategy**, not one global URI
+resolver. This correction matters: there is no single URI per object. Behaviour
+definitions activate at `/sap/bc/adt/ddic/bdef/sources/{name}` but lock, read and
+transport at `/sap/bc/adt/bo/behaviordefinitions/{name}`. So `buildObjectUri` in
+`src/utils/activationUtils.ts` is the **activation** endpoint resolver specifically — it
+is the right input for `ActivateCapability` and wrong for `LockCapability`. Each
+capability's strategy supplies the endpoint *it* needs, the config field(s) it reads, and
+how it normalizes the response. `AdtEnhancement` (dual-keyed `type`+`name`, via
+`getEnhancementUri`) is one reason the strategy cannot be a bare name field; the
+per-endpoint divergence above is another.
 
-Extraction therefore **deletes code, not adds it**: a `LockCapability` absorbs the ~15
-`lock.ts`/`unlock.ts` wrapper files; `getVersionSource`, byte-identical today, collapses
-to one function. The forwarding on the handler (`getVersions(c) { return this.#versions... }`)
-replaces a method that was already a one-liner — a wash — while the per-type helper files
-disappear. That is where the win is.
+**The lock normalization contract.** Lock helpers do not return the same shape today:
+`table/lock.ts` returns a bare `string`, `interface/lock.ts` returns
+`{ lockHandle: string; corrNr?: string }`, and `functionModule/lock.ts` carries a
+`ForUpdate` variant. `LockCapability` must define one normalized result —
+`{ lockHandle: string; corrNr?: string }` — and adapt the bare-string helpers up to it.
+Naming this contract is part of the extraction, not an afterthought.
+
+For the types that fit, extraction **deletes code, not adds it**: `LockCapability`
+absorbs their `lock.ts`/`unlock.ts`; `getVersionSource`, byte-identical across
+Class/Table/ServiceDef today, collapses to one function. The handler forwarding
+(`getVersions(c) { return this.#versions.list(c) }`) replaces a method that was already a
+one-liner — a wash — while the per-type helper files disappear. That is where the win is,
+and the survey put the majority of the 35 in this bucket.
+
+### Handlers that do not fit the simple strategy
+
+Three are genuine exceptions the extraction must plan for, not paper over:
+
+- **`AdtFunctionModule`** — lock/read take a *composite* key (`functionGroupName` +
+  `functionModuleName`), so its endpoint is built from two identifiers, not one
+  (`src/core/functionModule/lock.ts:17`). Its strategy supplies a two-part key; it is
+  still a strategy, just not a single-name one.
+- **`AdtBehaviorImplementation`** — does not lock its own URI at all; it delegates to
+  `this.class.lock({ className })` (`AdtBehaviorImplementation.ts:357`). This is not a
+  problem for the model — it is the model: the handler composes *another handler's*
+  lock capability rather than owning one. It validates the composition approach.
+- **`AdtMessageClassMessage`** — uses two locks and message-specific unlock sequencing
+  (`src/core/messageClass/AdtMessageClassMessage.ts`). It either gets a bespoke lock
+  strategy or keeps its own implementation and simply does not compose the shared
+  `LockCapability`. The atom lets it opt out cleanly.
+
+The extraction plan must classify all 35 into fits-the-strategy vs needs-bespoke before
+promising a deletion count, so the estimate is grounded rather than optimistic.
 
 ### Handlers become proxies
 

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -130,6 +130,75 @@ A handler that also has version history composes further:
 type ISourceObject<C, R> = IAdtCrudObject<C, R> & IAdtVersionable<C>;
 ```
 
+## The behavioural contract
+
+An interface constrains behaviour, not only shape. TypeScript checks the second and
+says nothing about the first, so the partition alone does not solve the problem that
+motivated it — it would merely distribute it across nine interfaces instead of one.
+
+The evidence is already in hand. `readTransport` is "unimplemented" in six handlers by
+three different mechanisms — throwing, returning a fabricated error state, and
+returning an empty `{errors: []}`. Every one of those satisfies the structural
+signature. The type system was never going to catch it.
+
+So each atom carries a behavioural contract, and implementations must satisfy both.
+
+### The rule that makes the split worth doing
+
+**"Not supported" ceases to be a behaviour.** A handler that cannot do something does
+not implement the atom. It must not throw `UNSUPPORTED_OPERATION`, must not return a
+fabricated error state, and must not return an empty stub.
+
+This is the whole point of the partition: `AdtDomain` will not implement
+`IAdtVersionable`, so the question of what its `getVersions` should return disappears
+rather than being answered three ways.
+
+### Per-atom obligations
+
+Contracts common to every atom:
+
+- **Failure is a thrown error**, using `AdtObjectErrorCodes`. Operations do not signal
+  failure by returning a state that happens to contain errors.
+- **The returned state accumulates results**, and `state.errors` records
+  non-fatal diagnostics only. An empty `errors` array must mean "nothing went wrong",
+  never "this operation does not apply here".
+- **Session type is restored** on both the success and failure paths. Any method that
+  sets `stateful` returns the connection to `stateless` before it finishes or throws.
+
+Atom-specific obligations:
+
+- `IAdtCrud` — `read` returns `undefined` for a genuinely absent object; it does not
+  throw for absence. Note the trial-verified caveat that ADT source endpoints answer
+  `200` with an empty body rather than `404`, so absence is determined by content, not
+  status. `create` is not idempotent and must not silently succeed on an existing
+  object.
+- `IAdtLockable` — `lock` returns a handle and leaves the session `stateful`; the
+  caller owns the obligation to `unlock`. `unlock` is idempotent and tolerates an
+  already-released handle. A failure between the two must still restore the session.
+- `IAdtActivatable` — activation of an already-active object is a no-op, not an error.
+- `IAdtVersionable` — implemented only by objects with a source resource. `getVersions`
+  returns an empty array for an object with no history; it does not throw.
+- `IAdtCheckable` / `IAdtValidatable` — a check that *finds problems* has succeeded;
+  problems are reported in the result, not raised as errors. Only a failure of the
+  check mechanism itself throws.
+- `IAdtTransportAware` — implemented only by objects that participate in transports.
+
+### How this is enforced
+
+The compiler cannot verify any of the above, so enforcement is by documentation and
+test:
+
+- Each atom's declaration carries the contract in its docblock, next to the signature,
+  where an implementer will actually read it.
+- The behavioural expectations that can be exercised without a live system belong in
+  the unit suite as shared conformance tests, parameterised over handlers — the same
+  table-driven approach already used for `postUpdateReadinessRead` and
+  `updateNoActivateReadsInactive`.
+
+Writing the contract down is not a guarantee. It is, however, the difference between a
+convention a reviewer can point at and one that has to be inferred from whichever
+handler was read first.
+
 ## Correctness proof
 
 The partition must be provably exact, not exact by inspection. A compile-time
@@ -191,13 +260,96 @@ Each is a separate decision, taken once the atoms have settled:
    meaningful shared operation set — the honest common denominator is a constructor
    whose `logger` parameter 13 of 14 implementations never read. No abstraction is
    proposed for them here.
-4. **`IAdtSearchable` is not proposed.** Seven "find things" operations have seven
-   different input shapes and five different result shapes. `ISearchResult` exists in
-   `IAdtShared.ts:84` and is used by no production code — the one type that would have
-   been the shared search result was declared and abandoned. A search capability would
-   have to be *imposed* by normalizing all seven signatures, and would have zero
-   existing call sites to validate against. That is a design act, not an extraction,
-   and belongs in its own spec if wanted.
+4. **`IAdtSearchable` — viable, but its own spec.** See "Search capability" below.
+
+## Search capability — viable, deferred to its own spec
+
+An earlier draft of this spec claimed no coherent search capability existed. That
+reasoning was wrong and is corrected here, because the mistake is instructive: it
+judged coherence by the *current concrete signatures* and concluded no capability was
+possible. Absence of a shared concrete shape does not imply absence of a shared
+abstraction — that is what interfaces are for.
+
+The shapes do share a core. All five "an object was found" types carry a name, a type,
+and optional `uri` / `packageName` / `description`:
+
+| Type | Name | Type field | Extras |
+|---|---|---|---|
+| `ISearchResult` | `name` | `type` | `description`, `packageName?`, `uri?` |
+| `IWhereUsedReference` | `name` | `type` | `uri`, `isResult`, `usageInformation?` |
+| `IPackageContentItem` | `name` | `adtType` | `isPackage`, `packageName` |
+| `IPackageHierarchyNode` | `name` | `adtType?` | `is_package`, `children?` |
+| `IObjectReference` | `name` | `type` | `parentName?` |
+
+The inconsistency is itself a defect: the object's type is spelled three ways
+(`type`, `adtType`, `adtType?`), and "is this a package" is `isPackage` in one type and
+`is_package` in its sibling — **snake_case and camelCase for the same concept in the
+same file**. A shared base interface removes exactly this.
+
+```ts
+/** Anything the repository can hand back as a located object. */
+export interface IAdtObjectHit {
+  name: string;
+  type: string;
+  uri?: string;
+  packageName?: string;
+  description?: string;
+}
+
+export interface IAdtSearchable<
+  TCriteria extends IAdtSearchCriteria = IAdtSearchCriteria,
+  TResult extends IAdtObjectHit = IAdtObjectHit,
+> {
+  search(criteria: TCriteria): Promise<TResult[]>;
+}
+```
+
+Each existing result type then extends `IAdtObjectHit`. The hierarchy node falls out
+neatly: a tree node is a hit with `children`, not a separate concept.
+
+The generic parameters exist so consumers can bring their own types, constrained by the
+contract package rather than dictated by it — consistent with this library's stance of
+offering options rather than prescribing usage.
+
+### The generic cuts both ways — a caveat to design in from the start
+
+A type parameter behaves differently depending on which side supplies the value, and
+only one direction is sound:
+
+- **Consumer implements the interface** — sound. They produce `MyHit` themselves and
+  the compiler checks it.
+- **Consumer calls our method as `search<MyHit>(...)`** — unsound. We cannot return
+  `MyHit`; we do not know its fields. Such a parameter degrades into a disguised `as`:
+  the type claims `businessArea` while the runtime value has `undefined`.
+
+So library methods must offer an explicit bridge rather than a pass-through type
+parameter:
+
+```ts
+search<T extends IAdtObjectHit = ISearchResult>(
+  criteria: IAdtSearchCriteria,
+  map?: (hit: ISearchResult) => T,
+): Promise<T[]>;
+```
+
+We return our shape; the consumer optionally supplies the transformation and gets
+theirs. Compiler-checked, unlike a bare type argument.
+
+### Why this is a separate spec
+
+The cost is materially different from the atom partition, which is additive and
+risk-free:
+
+1. **Parsers must be written.** Four methods return raw XML today (`searchObjects`,
+   `getWhereUsed`, `getVirtualFoldersContents`, `getAllTypes`). ADT XML parsing is
+   where bugs live — `FeedRepository` already parses so defensively that a malformed
+   feed is indistinguishable from an empty one.
+2. **It is breaking.** Return types change and `is_package` migrates to `isPackage`.
+3. **Still zero call sites.** Nothing in the library consumes a search abstraction, so
+   there is no existing usage to validate the shape against.
+
+Worth doing — it collapses three spellings of one concept into one — but as its own
+scoped piece of work, not folded into the partition.
 
 ## Known defects (not part of this design)
 

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -253,11 +253,18 @@ rather than being answered three ways.
 ### Per-atom obligations
 
 These are **required behaviours the implementation must meet**, not descriptions of what
-every handler does today. Where an obligation is not already backed by the current code,
-it is a target to be secured by a conformance test — and any obligation that depends on
-how SAP responds (idempotency, no-op-on-repeat) must be verified by probing a real system
-before it is relied on, not asserted. The trial-verified caveats below are marked as such;
-the rest are targets.
+every handler does today. Two things must not be confused when reading them:
+
+- **"Current code does otherwise" is not an objection.** These are targets; the point of
+  the refactor is that current behaviour is inconsistent. A contract that only restated
+  what the code already does would justify no work. So a mismatch with today's handlers
+  is expected, and is what the conformance tests will close.
+- **A claim about what *SAP* returns is different** — that is an external fact, and it
+  must be probed, never asserted. Where reaching a target depends on SAP's response
+  (which status means "already released" / "already active"), the target still stands;
+  what needs evidence is the *mechanism* — which status the capability may treat as
+  success. Trial-verified facts below are marked as such; unverified SAP behaviour is
+  flagged as needing a probe.
 
 Contracts common to every atom:
 
@@ -281,18 +288,18 @@ Atom-specific obligations:
   object.
 - `IAdtLockable` — `lock` returns a handle and leaves the session `stateful`; the
   caller owns the obligation to `unlock`. A failure between the two must still restore
-  the session. `unlock` is **best-effort release; repeated- or stale-unlock semantics
-  are endpoint-specific.** This is deliberately weaker than "idempotent": the current
-  helpers POST `_action=UNLOCK` directly and some turn an ADT failure into a thrown
-  error (`src/core/interface/unlock.ts:33`), so no idempotency exists to promise today.
-  If `LockCapability` is to guarantee idempotent unlock, that is an added requirement,
-  not an observation — it must be backed by probing what SAP returns for a repeated or
-  expired handle (per endpoint) and an explicit adaptation rule for which statuses count
-  as already-released success. Until that evidence exists, the contract promises only
-  best-effort release, and a conformance test asserts the weaker guarantee.
-- `IAdtActivatable` — the target is that activating an already-active object is a no-op
-  rather than an error; like the unlock case this depends on what SAP returns and must be
-  confirmed by probing before it is relied on.
+  the session. **Target: `unlock` is idempotent** — releasing an already-released or
+  expired handle succeeds rather than throwing. This is intended *new* behaviour: today
+  the helpers POST `_action=UNLOCK` directly and some turn an ADT failure into a throw
+  (`src/core/interface/unlock.ts:33`). That mismatch is the thing being fixed, not an
+  argument against the target. The one genuine unknown is external — *what SAP returns*
+  for a repeated or expired handle — because that determines whether the capability can
+  distinguish "already released" (swallow as success) from a real error (rethrow). That
+  status must be probed per endpoint before the idempotency rule is finalized; the target
+  stands, the mechanism to reach it is what needs the evidence.
+- `IAdtActivatable` — **target: activating an already-active object is a no-op**, not an
+  error. Same shape as unlock: the goal holds regardless of current behaviour; which SAP
+  status signals "already active" must be probed so the capability can treat it as success.
 - `IAdtVersionable` — implemented only by objects with a source resource. `getVersions`
   returns an empty array for an object with no history; it does not throw.
 - `IAdtCheckable` / `IAdtValidatable` — a check that *finds problems* has succeeded;

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -10,18 +10,38 @@
 provide. Most handlers cannot provide all of them, so they lie — and they lie
 inconsistently.
 
-A survey of all 30 primary handlers in `src/core/*/Adt*.ts` established:
+### How the numbers here were obtained
 
-- Only `create`, `read`, `readMetadata` are implemented by every handler.
-- `getVersions` / `getVersionSource` throw in 11 of 30.
-- `activate`, `check`, `lock`, `unlock` throw in 4–5.
-- `readTransport` is unimplemented in 6 handlers **via three different mechanisms**:
-  three throw, three return a fabricated error state, one returns an empty
-  `{errors: []}`. With no way to say "I don't do transports", implementers invented
-  three different lies. That inconsistency is the clearest symptom of the problem.
-- Four handlers are 0–4 of 13: `AdtPackageLegacy` (0/13 — every method throws, the
-  class exists solely to satisfy the type), `AdtUnitTest` (3/13), `AdtRequest` (3/13),
-  `AdtMessageClassMessage` (4/13).
+Every count below is **generated**, not transcribed. `scripts/capability-matrix.mjs`
+walks the handler classes with the TypeScript compiler API and classifies each contract
+method as *real work*, *refuses* (an unconditional throw or a `throwUnsupported*` call),
+*stub*, or *absent*. Run `node scripts/capability-matrix.mjs` to reproduce; `--csv` for
+the raw matrix.
+
+This matters because earlier drafts of this spec carried hand-copied counts that were
+wrong in three separate places — one of them an arithmetic impossibility. Numbers in a
+design document must be derivable, or they will drift from the code they describe.
+
+**Denominator: 37 classes** — the 30 primary handlers plus `AdtServiceBinding`, the four
+class-include handlers and `AdtCdsUnitTest`. `*Legacy.ts` subclasses are excluded: they
+override selectively and would double-count their parents.
+
+### What the matrix shows
+
+- `getVersions` / `getVersionSource`: **19 real, 11 refuse** — identical sets, the
+  sharpest split in the contract.
+- `lock` / `unlock`: **26 real, 4 refuse** — identical sets, a rigid pair.
+- `activate`: 28 real, 5 refuse. `check`: 30 real, 4 refuse. The sets differ, so these
+  are distinct capabilities rather than one.
+- `readTransport`: 23 real and **7 not implemented — through two different mechanisms**:
+  three refuse outright (MessageClass, MessageClassMessage, Request) and four return a
+  stub (AuthorizationField, FeatureToggle, FunctionInclude, UnitTest). With no way to
+  say "I don't do transports", implementers invented more than one lie. That
+  inconsistency is the clearest symptom of the problem.
+- Handlers where the contract is plainly the wrong fit: `AdtUnitTest` and `AdtRequest`
+  refuse seven methods each; `AdtMessageClassMessage` refuses or stubs nine;
+  `AdtPackageLegacy` (excluded from the count as a subclass) throws on all 13 and exists
+  solely to satisfy the type.
 
 The cost is paid by consumers: `AdtClient.getUnitTest()` returns a type promising
 `lock()`, and the promise is false. The compiler cannot help, so the failure surfaces
@@ -70,27 +90,42 @@ that is cheap to fix. Encoding our gaps as contract is the worse failure.
 
 ## The partition
 
-Every method of every "big" interface belongs to **exactly one** atom. Nine atoms
-cover 20 methods with no overlap.
+**Scope: the 13 methods of `IAdtObject`.** Every one of them belongs to exactly one of
+seven atoms, with no overlap. The two specialized interfaces that widen `IAdtObject` are
+handled separately — see "Specialized interfaces" below.
 
-| Atom | Methods | Evidence |
+| Atom | Methods | Evidence (generated) |
 |---|---|---|
-| `IAdtCrud` | `create`, `read`, `readMetadata`, `update`, `delete` | 30/30 — universal; no partial-CRUD object exists |
-| `IAdtValidatable` | `validate` | 27/30 |
-| `IAdtCheckable` | `check` | 26/30 |
-| `IAdtActivatable` | `activate` | 25/30 |
-| `IAdtLockable` | `lock`, `unlock` | rigid pair — 0 handlers have one without the other |
-| `IAdtVersionable` | `getVersions`, `getVersionSource` | 19 vs 11, verified domain boundary |
-| `IAdtTransportAware` | `readTransport` | 24/30 |
-| `IAdtFeatureToggleControl` | `switchOn`, `switchOff`, `getRuntimeState`, `checkState`, `readSource` | single implementer |
-| `IAdtServiceBindingOps` | `validateServiceBinding`, `updateServiceBinding` | single implementer |
+| `IAdtCrud` | `create`, `read`, `readMetadata`, `update`, `delete` | no object has partial CRUD — see below |
+| `IAdtValidatable` | `validate` | 31 real / 1 refuses / 2 stub |
+| `IAdtCheckable` | `check` | 30 real / 4 refuse |
+| `IAdtActivatable` | `activate` | 28 real / 5 refuse |
+| `IAdtLockable` | `lock`, `unlock` | 26 / 4, **identical sets** |
+| `IAdtVersionable` | `getVersions`, `getVersionSource` | 19 / 11, **identical sets**, verified domain boundary |
+| `IAdtTransportAware` | `readTransport` | 23 real / 3 refuse / 4 stub |
 
 `validate`, `check` and `activate` are separate atoms because their sets genuinely
-differ: `AdtPackage` implements `check` but not `activate`; `AdtMessageClass`
-implements `validate` but neither `check` nor `activate`.
+differ: `AdtPackage` implements `check` but not `activate`; `AdtMessageClass` implements
+`validate` but neither `check` nor `activate`.
 
 `IAdtLockable` and `IAdtVersionable` are each one atom because their member methods
-co-occur perfectly across all 30 handlers.
+co-occur perfectly — no handler has one without the other.
+
+### Observed implementation vs intended capability
+
+These are different things, and conflating them makes the counts irreproducible.
+
+**Observed**, from the generated matrix: `update` has 2 refusals and `delete` has 2 —
+`AdtRequest` and `AdtUnitTest` in both cases. `create` and `read` each have one stub
+(`AdtMessageClassMessage`, `AdtFunctionInclude`).
+
+**Intended**, after the known defects are fixed: CRUD is universal. Both refusals are
+our own bugs, not ADT limits — a transport request's description can be changed and an
+empty request deleted, and `AdtUnitTest` should not implement `IAdtObject` at all (see
+"Known defects"). Under Rule 2 both classes stay inside `IAdtCrud`.
+
+The partition is built on **intended** capability. Where the two diverge, this spec says
+so explicitly rather than quietly picking whichever number supports the design.
 
 ### The versioning boundary is real
 
@@ -102,12 +137,17 @@ endpoint.
 The dividing line is "has `/source/main`", **not** "is DDIC": `Table`, `Structure` and
 `TableType` have versions; `Domain`, `DataElement` and `Package` do not.
 
-- **With versions (19):** Class, Interface, Program, Ddl, Table, Structure, TableType,
-  Enhancement, MetadataExtension, BehaviorDefinition, BehaviorImplementation,
-  AccessControl, AppendStructure, ScalarFunction, ScalarFunctionImplementation,
-  ServiceDefinition, Transformation, FunctionInclude.
-- **Without (11):** Domain, DataElement, Package, FunctionGroup, AuthorizationField,
-  FeatureToggle, MessageClass, MessageClassMessage, Request, Service, UnitTest.
+- **With versions (19):** AccessControl, AppendStructure, BehaviorDefinition,
+  BehaviorImplementation, Class, DdicTableType, Ddl, Enhancement, FunctionInclude,
+  FunctionModule, Interface, MetadataExtension, Program, ScalarFunction,
+  ScalarFunctionImplementation, ServiceDefinition, Structure, Table, Transformation.
+- **Without (11):** AuthorizationField, DataElement, Domain, FeatureToggle,
+  FunctionGroup, MessageClass, MessageClassMessage, Package, Request, ServiceBinding,
+  UnitTest.
+
+Both lists are generated by `scripts/capability-matrix.mjs --csv` and sum to 30. The
+four class-include handlers are excluded: they delegate to `getIncludeVersions` on the
+parent class rather than implementing the contract method themselves.
 
 ## Composition
 
@@ -130,11 +170,39 @@ A handler that also has version history composes further:
 type ISourceObject<C, R> = IAdtCrudObject<C, R> & IAdtVersionable<C>;
 ```
 
+## Specialized interfaces
+
+Two interfaces widen `IAdtObject`. Their methods are **out of scope for step 1**, and
+the "exactly one atom" guarantee applies only to `IAdtObject`'s 13.
+
+`IFeatureToggleObject` adds five: `switchOn`, `switchOff`, `getRuntimeState`,
+`checkState`, `readSource`. One implementer, cohesive, and a single
+`IAdtFeatureToggleControl` atom would cover them cleanly. Low risk, but no reason to
+rush it into step 1.
+
+`IAdtServiceBinding` adds **twelve**, not two as an earlier draft of this spec claimed:
+`getServiceBindingTypes`, `createServiceBinding`, `readServiceBinding`,
+`updateServiceBinding`, `deleteServiceBinding`, `validateServiceBinding`,
+`checkServiceBinding`, `activateServiceBinding`, `transportCheckServiceBinding`,
+`generateServiceBinding`, `createAndGenerateServiceBinding`, `classifyServiceBinding`.
+
+That list is itself a finding worth recording. Eight of the twelve are binding-suffixed
+restatements of operations the base contract already has — create, read, update, delete,
+validate, check, activate, transport-check. `AdtServiceBinding` therefore carries **two
+parallel vocabularies for the same lifecycle**, and separately refuses `lock`, `unlock`
+and both version methods from the base contract.
+
+Deciding whether those eight should collapse into the base atoms, or whether the binding
+genuinely needs its own lifecycle vocabulary, requires understanding why the duplication
+was introduced. That is its own investigation, not a detail of this partition. Until it
+is done, no service-binding atom is proposed — inventing one now would freeze a
+duplication we do not yet understand.
+
 ## The behavioural contract
 
 An interface constrains behaviour, not only shape. TypeScript checks the second and
 says nothing about the first, so the partition alone does not solve the problem that
-motivated it — it would merely distribute it across nine interfaces instead of one.
+motivated it — it would merely distribute it across seven interfaces instead of one.
 
 The evidence is already in hand. `readTransport` is "unimplemented" in six handlers by
 three different mechanisms — throwing, returning a fabricated error state, and
@@ -201,23 +269,40 @@ handler was read first.
 
 ## Correctness proof
 
-The partition must be provably exact, not exact by inspection. A compile-time
-assertion checks assignability in **both** directions between `IAdtObject` and the
-intersection of its ten constituent atoms:
+The partition must be provably exact, not exact by inspection. A compile-time assertion
+checks assignability in **both** directions between `IAdtObject` and the intersection of
+its **seven** constituent atoms. The generic parameters must be bound — an earlier draft
+of this section referenced free `C` / `R` and would not have compiled:
 
 ```ts
 type Assert<T extends true> = T;
 
 type AllAtoms<C, R> =
-  & IAdtCrud<C, R> & IAdtValidatable<C, R> & IAdtCheckable<C, R>
-  & IAdtActivatable<C, R> & IAdtLockable<C, R> & IAdtVersionable<C>
+  & IAdtCrud<C, R>
+  & IAdtValidatable<C, R>
+  & IAdtCheckable<C, R>
+  & IAdtActivatable<C, R>
+  & IAdtLockable<C, R>
+  & IAdtVersionable<C>
   & IAdtTransportAware<C, R>;
 
-type _PartitionIsExact = [
+/** Bound the parameters so the assertion is a closed type expression. */
+type _PartitionIsExact<C, R> = [
   Assert<IAdtObject<C, R> extends AllAtoms<C, R> ? true : false>,
   Assert<AllAtoms<C, R> extends IAdtObject<C, R> ? true : false>,
 ];
+
+/** Instantiate it, or nothing is checked. */
+type _Check = _PartitionIsExact<IClassConfig, IClassState>;
 ```
+
+The final instantiation is not decoration: an uninstantiated generic type alias is never
+evaluated, so without it the assertion would silently pass no matter what.
+
+**This proof covers `IAdtObject` only.** It cannot validate
+`IAdtFeatureToggleControl` or the service-binding atoms, because `AllAtoms` is compared
+against `IAdtObject` alone. Each specialized interface needs its own assertion of the
+same shape, comparing it against the intersection of *its* atoms.
 
 A dropped method, a mistyped parameter or a missing generic argument fails the build.
 

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -562,23 +562,25 @@ judged coherence by the *current concrete signatures* and concluded no capabilit
 possible. Absence of a shared concrete shape does not imply absence of a shared
 abstraction — that is what interfaces are for.
 
-The shapes do share a core. All five "an object was found" types carry a **name and a
-type**; `uri`, `packageName` and `description` appear in some but not all (the table
-shows which). `IObjectReference` is the thinnest — name, type, and an optional parent —
-which makes name+type the only truly universal pair and the right base:
+The shapes do share a core — every one carries a **name** and, in some field, the ADT
+**type code** — but the code is stored under different field names with different declared
+types, which is the whole problem:
 
-| Type | Name | Type field | Extras |
+| Type | Name | Where the ADT type code lives | Extras |
 |---|---|---|---|
-| `ISearchResult` | `name` | `type` | `description`, `packageName?`, `uri?` |
-| `IWhereUsedReference` | `name` | `type` | `uri`, `isResult`, `usageInformation?` |
-| `IPackageContentItem` | `name` | `adtType` | `isPackage`, `packageName` |
-| `IPackageHierarchyNode` | `name` | `adtType?` | `is_package`, `children?` |
-| `IObjectReference` | `name` | `type` | `parentName?` |
+| `ISearchResult` | `name` | `type: string` | `description`, `packageName?`, `uri?` |
+| `IWhereUsedReference` | `name` | `type: string` | `uri`, `isResult`, `usageInformation?` |
+| `IPackageContentItem` | `name` | `adtType: string` (its `type` is an unrelated enum) | `isPackage`, `packageName` |
+| `IPackageHierarchyNode` | `name` | `adtType?: string` (its `type` is an unrelated enum) | `is_package`, `children?` |
+| `IObjectReference` | `name` | `type: string` | `parentName?` |
 
-The inconsistency is itself a defect: the object's type is spelled three ways
-(`type`, `adtType`, `adtType?`), and "is this a package" is `isPackage` in one type and
-`is_package` in its sibling — **snake_case and camelCase for the same concept in the
-same file**. A shared base interface removes exactly this.
+The inconsistency is itself a defect, and worse than a naming slip: the field named
+`type` means a `string` code in three of the types and an unrelated
+`PackageHierarchySupportedType` enum in the other two, where the code is instead in
+`adtType`. On top of that, "is this a package" is `isPackage` in one type and
+`is_package` in its sibling — **snake_case and camelCase for the same concept in the same
+file**. A shared base interface removes exactly this, at the cost of a breaking rename
+(below).
 
 ```ts
 /** Anything the repository can hand back as a located object. */
@@ -598,8 +600,20 @@ export interface IAdtSearchable<
 }
 ```
 
-Each existing result type then extends `IAdtObjectHit`. The hierarchy node falls out
-neatly: a tree node is a hit with `children`, not a separate concept.
+Converging the existing types on `IAdtObjectHit` is a **breaking normalization, not a
+clean `extends`** — and the reason is sharper than a rename. In `IPackageContentItem` and
+`IPackageHierarchyNode` the field literally named `type` is not the ADT type code at all;
+it is an unrelated enum (`PackageHierarchySupportedType`), and the code lives in
+`adtType` (`adtType: string` required on `IPackageContentItem`, `adtType?` on the node).
+The other three carry the code as `type: string`. So `IAdtObjectHit { type: string }`
+cannot simply be extended by the package types — their `type` field has an incompatible
+declared type, and the field that *should* map to `IAdtObjectHit.type` is `adtType`.
+
+Convergence therefore requires renaming `adtType` → `type: string` (and retiring or
+renaming the enum field), plus unifying `isPackage` / `is_package`. That is exactly the
+breaking change the appendix already flags — the point here is only that "extends" was
+the wrong verb: it is a migration, and the search spec must carry it as one. Once done,
+the hierarchy node falls out neatly: a tree node is a hit with `children`.
 
 The generic parameters exist so consumers can bring their own types, constrained by the
 contract package rather than dictated by it — consistent with this library's stance of

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -379,16 +379,33 @@ of `activate` / `check`) differ **only by endpoint and which config field holds 
 name** — the bodies are otherwise the same, copy-pasted into ~15 near-identical per-type
 files (`lock.ts`, `unlock.ts`, `versions.ts`, `activation.ts`, the transport getter).
 
-Each capability is parameterized by a **per-capability strategy**, not one global URI
-resolver. This correction matters: there is no single URI per object. Behaviour
-definitions activate at `/sap/bc/adt/ddic/bdef/sources/{name}` but lock, read and
-transport at `/sap/bc/adt/bo/behaviordefinitions/{name}`. So `buildObjectUri` in
-`src/utils/activationUtils.ts` is the **activation** endpoint resolver specifically — it
-is the right input for `ActivateCapability` and wrong for `LockCapability`. Each
-capability's strategy supplies the endpoint *it* needs, the config field(s) it reads, and
-how it normalizes the response. `AdtEnhancement` (dual-keyed `type`+`name`, via
-`getEnhancementUri`) is one reason the strategy cannot be a bare name field; the
-per-endpoint divergence above is another.
+Each capability is parameterized by a **per-capability strategy**, and there is **no
+existing centralized resolver to build it on** — this is the correction that matters
+most, because two earlier drafts got it wrong.
+
+Two facts from the code:
+
+1. There is no single URI per object. Behaviour definitions *lifecycle* endpoints (lock,
+   read, transport, and the handler's own activation) are all
+   `/sap/bc/adt/bo/behaviordefinitions/{name}` — see
+   `src/core/behaviorDefinition/activation.ts:35`, which **hardcodes** that path.
+2. `buildObjectUri` in `src/utils/activationUtils.ts` is **not** the handler activation
+   resolver. Its only callers are group activation and group deletion
+   (`src/core/shared/groupActivation.ts:149`, `groupDeletion.ts`), where it builds the
+   object-reference URI inside a batch payload. For BDEF it returns
+   `/sap/bc/adt/ddic/bdef/sources/{name}` — a **different** path from the one the BDEF
+   handler actually uses to activate. Building `ActivateCapability` on `buildObjectUri`
+   would route BDEF (and any other type whose group URI differs from its lifecycle URI)
+   to the wrong endpoint.
+
+The consequence: **every per-handler activation today hardcodes its own base path**
+(`/oo/classes/`, `/ddic/domains/`, `/ddic/tables/`, `/programs/programs/`,
+`/oo/interfaces/`, `/bo/behaviordefinitions/`, …). There is no shared map to reuse, so a
+capability's strategy supplies its base path **directly from the handler** — the handler
+already knows it — along with the config field(s) it reads and how it normalizes the
+response. `buildObjectUri` stays where it belongs, in the group operations, and is not a
+dependency of this refactor. `AdtEnhancement` (dual-keyed `type`+`name`, via
+`getEnhancementUri`) is a further reason the strategy cannot be a bare name field.
 
 **The lock normalization contract.** Lock helpers do not return the same shape today:
 `table/lock.ts` returns a bare `string`, `interface/lock.ts` returns

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -53,8 +53,8 @@ population of 35.
   stub (AuthorizationField, FeatureToggle, FunctionInclude, CdsUnitTest, UnitTest). With
   no way to say "I don't do transports", implementers invented more than one lie. That
   inconsistency is the clearest symptom of the problem.
-- Classes where the contract is plainly the wrong fit: `AdtUnitTest` and `AdtRequest`
-  refuse seven methods each; `AdtMessageClassMessage` refuses or stubs nine;
+- Classes where the contract is plainly the wrong fit: `AdtRequest` refuses 9 of 13 and
+  stubs a 10th; `AdtUnitTest` refuses 8 and stubs 2; `AdtMessageClassMessage` refuses 8.
   `AdtPackageLegacy` (a `*Legacy` subclass, outside this population) throws on all 13 and
   exists solely to satisfy the type.
 
@@ -231,8 +231,8 @@ An interface constrains behaviour, not only shape. TypeScript checks the second 
 says nothing about the first, so the partition alone does not solve the problem that
 motivated it — it would merely distribute it across seven interfaces instead of one.
 
-The evidence is already in hand. `readTransport` is "unimplemented" in seven handlers by
-two different mechanisms — three refuse outright, four return a stub. Every one of those
+The evidence is already in hand. `readTransport` is "unimplemented" in eight classes by
+two different mechanisms — three refuse outright, five return a stub. Every one of those
 satisfies the structural signature. The type system was never going to catch it.
 
 So each atom carries a behavioural contract, and implementations must satisfy both.

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -390,22 +390,36 @@ Two facts from the code:
    `/sap/bc/adt/bo/behaviordefinitions/{name}` — see
    `src/core/behaviorDefinition/activation.ts:35`, which **hardcodes** that path.
 2. `buildObjectUri` in `src/utils/activationUtils.ts` is **not** the handler activation
-   resolver. Its only callers are group activation and group deletion
-   (`src/core/shared/groupActivation.ts:149`, `groupDeletion.ts`), where it builds the
-   object-reference URI inside a batch payload. For BDEF it returns
-   `/sap/bc/adt/ddic/bdef/sources/{name}` — a **different** path from the one the BDEF
-   handler actually uses to activate. Building `ActivateCapability` on `buildObjectUri`
-   would route BDEF (and any other type whose group URI differs from its lifecycle URI)
-   to the wrong endpoint.
+   resolver. Its callers are all group operations — `groupActivation.ts:149`,
+   `groupDeletion.ts`, and the legacy `AdtUtilsLegacy.activateObjectsGroup`
+   (`src/core/shared/AdtUtilsLegacy.ts:40`) — where it builds the object-reference URI
+   inside a batch payload. For BDEF it returns `/sap/bc/adt/ddic/bdef/sources/{name}` — a
+   **different** path from the one the BDEF handler actually uses to activate. Building
+   `ActivateCapability` on `buildObjectUri` would route BDEF (and any other type whose
+   group URI differs from its lifecycle URI) to the wrong endpoint.
 
-The consequence: **every per-handler activation today hardcodes its own base path**
-(`/oo/classes/`, `/ddic/domains/`, `/ddic/tables/`, `/programs/programs/`,
-`/oo/interfaces/`, `/bo/behaviordefinitions/`, …). There is no shared map to reuse, so a
-capability's strategy supplies its base path **directly from the handler** — the handler
-already knows it — along with the config field(s) it reads and how it normalizes the
-response. `buildObjectUri` stays where it belongs, in the group operations, and is not a
-dependency of this refactor. `AdtEnhancement` (dual-keyed `type`+`name`, via
-`getEnhancementUri`) is a further reason the strategy cannot be a bare name field.
+The consequence: the **real, self-activating** handlers each hardcode their own base
+path (`/oo/classes/`, `/ddic/domains/`, `/ddic/tables/`, `/programs/programs/`,
+`/oo/interfaces/`, `/bo/behaviordefinitions/`, …) — there is no shared map to reuse, so a
+capability's strategy supplies its base path **directly from the handler**, along with
+the config field(s) it reads and how it normalizes the response.
+
+But not every handler is self-activating, and the extraction must classify them into
+three kinds, not one:
+
+- **Self-activating** (the majority) — hardcode a lifecycle base path; these compose the
+  shared `ActivateCapability` with a base-path strategy.
+- **Delegating** — activate through another handler: `AdtBehaviorImplementation.activate`
+  calls `this.class.activate` (`AdtBehaviorImplementation.ts:591`); the class-include
+  handlers call `super.activate` (`AdtLocalDefinitions.ts:318`). These compose *nothing
+  new* — they reuse the class handler's capability, which is the composition model
+  working as intended.
+- **Refusing** — `AdtPackage.activate` throws (`AdtPackage.ts:559`); such handlers simply
+  do not compose `ActivateCapability` and do not implement `IAdtActivatable`.
+
+`AdtEnhancement` (dual-keyed `type`+`name`, via `getEnhancementUri`) is a further reason
+the strategy cannot be a bare name field. `buildObjectUri` stays in the group operations
+and is not a dependency of this refactor.
 
 **The lock normalization contract.** Lock helpers do not return the same shape today:
 `table/lock.ts` returns a bare `string`, `interface/lock.ts` returns

--- a/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
+++ b/docs/superpowers/specs/2026-07-20-capability-interfaces-design.md
@@ -252,6 +252,13 @@ rather than being answered three ways.
 
 ### Per-atom obligations
 
+These are **required behaviours the implementation must meet**, not descriptions of what
+every handler does today. Where an obligation is not already backed by the current code,
+it is a target to be secured by a conformance test — and any obligation that depends on
+how SAP responds (idempotency, no-op-on-repeat) must be verified by probing a real system
+before it is relied on, not asserted. The trial-verified caveats below are marked as such;
+the rest are targets.
+
 Contracts common to every atom:
 
 - **Failure is a thrown error**, using `AdtObjectErrorCodes`. Operations do not signal
@@ -273,9 +280,19 @@ Atom-specific obligations:
   status. `create` is not idempotent and must not silently succeed on an existing
   object.
 - `IAdtLockable` — `lock` returns a handle and leaves the session `stateful`; the
-  caller owns the obligation to `unlock`. `unlock` is idempotent and tolerates an
-  already-released handle. A failure between the two must still restore the session.
-- `IAdtActivatable` — activation of an already-active object is a no-op, not an error.
+  caller owns the obligation to `unlock`. A failure between the two must still restore
+  the session. `unlock` is **best-effort release; repeated- or stale-unlock semantics
+  are endpoint-specific.** This is deliberately weaker than "idempotent": the current
+  helpers POST `_action=UNLOCK` directly and some turn an ADT failure into a thrown
+  error (`src/core/interface/unlock.ts:33`), so no idempotency exists to promise today.
+  If `LockCapability` is to guarantee idempotent unlock, that is an added requirement,
+  not an observation — it must be backed by probing what SAP returns for a repeated or
+  expired handle (per endpoint) and an explicit adaptation rule for which statuses count
+  as already-released success. Until that evidence exists, the contract promises only
+  best-effort release, and a conformance test asserts the weaker guarantee.
+- `IAdtActivatable` — the target is that activating an already-active object is a no-op
+  rather than an error; like the unlock case this depends on what SAP returns and must be
+  confirmed by probing before it is relied on.
 - `IAdtVersionable` — implemented only by objects with a source resource. `getVersions`
   returns an empty array for an object with no history; it does not throw.
 - `IAdtCheckable` / `IAdtValidatable` — a check that *finds problems* has succeeded;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.5.1",
+  "version": "7.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "7.5.1",
+      "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^11.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.5.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^11.0.0",
+        "@mcp-abap-adt/interfaces": "^11.2.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.0.0.tgz",
-      "integrity": "sha512-T1paoqANLLB0MQQ4pnyodDcrXZfV4A5p4ih71DGtn5gHuO3fA4LDkXwOtNUWo8Bk//CAGsIJCZTajCBjuyC+FA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.2.0.tgz",
+      "integrity": "sha512-/ZQ1XwYnheefhe8FNZwLPjeyP7yjLG+tqB3Tv6pWH90zNovhgwB1mxEO59tzvCB0m43xM416Tech7Tfov0CyUA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^11.0.0",
+    "@mcp-abap-adt/interfaces": "^11.2.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.18.1",
     "fast-xml-parser": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.5.1",
+  "version": "7.6.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/capability-matrix.mjs
+++ b/scripts/capability-matrix.mjs
@@ -90,6 +90,29 @@ for (const file of files) {
     const cls = node.name.text;
     if (!cls.startsWith('Adt')) return;
 
+    // Only classes that actually promise the contract belong in the matrix.
+    // Filtering by heritage (not by name) keeps out facades like AdtService
+    // and utilities like AdtUtils that never claim to implement IAdtObject.
+    // A subclass (e.g. AdtCdsUnitTest extends AdtUnitTest) inherits the
+    // promise, so an `extends Adt*` clause counts too.
+    const CONTRACT_IFACES = new Set([
+      'IAdtObject',
+      'IFeatureToggleObject',
+      'IAdtServiceBinding',
+    ]);
+    const promisesContract = (node.heritageClauses ?? []).some((h) =>
+      h.types.some((t) => {
+        const name = t.expression.getText(sf);
+        if (h.token === ts.SyntaxKind.ImplementsKeyword)
+          return CONTRACT_IFACES.has(name);
+        // extends an Adt* handler => inherits the contract
+        return (
+          h.token === ts.SyntaxKind.ExtendsKeyword && name.startsWith('Adt')
+        );
+      }),
+    );
+    if (!promisesContract) return;
+
     const verdicts = Object.fromEntries(
       CONTRACT_METHODS.map((m) => [m, VERDICT.ABSENT]),
     );
@@ -99,6 +122,11 @@ for (const file of files) {
       if (!CONTRACT_METHODS.includes(name)) continue;
       verdicts[name] = classify(member.body, sf);
     }
+    // A pure alias subclass (e.g. `class AdtService extends AdtServiceBinding {}`)
+    // declares no contract method of its own — every verdict is "absent". Its
+    // behaviour is its parent's, already counted, so drop it to avoid double-counting.
+    if (CONTRACT_METHODS.every((m) => verdicts[m] === VERDICT.ABSENT)) return;
+
     rows.set(cls, { file, verdicts });
   });
 }

--- a/scripts/capability-matrix.mjs
+++ b/scripts/capability-matrix.mjs
@@ -1,0 +1,131 @@
+/**
+ * Derive the capability matrix for IAdtObject implementations.
+ *
+ * Answers, per handler and per contract method: does the implementation do real
+ * work, refuse (throw "not supported"), return a stub, or not declare the method
+ * at all? The spec that consumes this must cite generated output — hand-copied
+ * counts have been wrong three separate times.
+ *
+ * Usage: node scripts/capability-matrix.mjs [--csv]
+ */
+
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+
+const CONTRACT_METHODS = [
+  'validate',
+  'create',
+  'read',
+  'readMetadata',
+  'update',
+  'delete',
+  'activate',
+  'check',
+  'readTransport',
+  'lock',
+  'unlock',
+  'getVersions',
+  'getVersionSource',
+];
+
+/** a = real work, b = refuses, c = stub, d = not declared */
+const VERDICT = { REAL: 'a', REFUSES: 'b', STUB: 'c', ABSENT: 'd' };
+
+function handlerFiles(root) {
+  const out = [];
+  for (const dir of readdirSync(root)) {
+    const d = join(root, dir);
+    if (!statSync(d).isDirectory()) continue;
+    for (const f of readdirSync(d)) {
+      if (!f.startsWith('Adt') || !f.endsWith('.ts')) continue;
+      if (f.endsWith('Legacy.ts')) continue; // subclasses: overrides only
+      out.push(join(d, f));
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Does this body refuse the operation? A refusal is a throw that is NOT inside a
+ * conditional — i.e. the method's whole purpose is to reject. A throw inside an
+ * `if` is ordinary error handling and does not count.
+ */
+function classify(body, sf) {
+  if (!body || !body.statements.length) return VERDICT.STUB;
+
+  for (const stmt of body.statements) {
+    if (ts.isThrowStatement(stmt)) return VERDICT.REFUSES;
+    // `return throwUnsupportedX(...)` and bare calls to a thrower
+    const text = stmt.getText(sf);
+    if (/^\s*(return\s+)?throwUnsupported\w*\s*\(/.test(text))
+      return VERDICT.REFUSES;
+  }
+
+  // Real work = it talks to the connection, or delegates to something that does.
+  const text = body.getText(sf);
+  const doesWork =
+    /\bmakeAdtRequest\b/.test(text) ||
+    /\bawait\s+/.test(text) ||
+    /\bthis\.(connection|class|adtClass|utils)\b/.test(text);
+
+  return doesWork ? VERDICT.REAL : VERDICT.STUB;
+}
+
+const root = 'src/core';
+const files = handlerFiles(root);
+const program = ts.createProgram(files, {
+  allowJs: false,
+  noResolve: true,
+  target: ts.ScriptTarget.ES2020,
+});
+
+const rows = new Map();
+
+for (const file of files) {
+  const sf = program.getSourceFile(file);
+  if (!sf) continue;
+  ts.forEachChild(sf, (node) => {
+    if (!ts.isClassDeclaration(node) || !node.name) return;
+    const cls = node.name.text;
+    if (!cls.startsWith('Adt')) return;
+
+    const verdicts = Object.fromEntries(
+      CONTRACT_METHODS.map((m) => [m, VERDICT.ABSENT]),
+    );
+    for (const member of node.members) {
+      if (!ts.isMethodDeclaration(member) || !member.name) continue;
+      const name = member.name.getText(sf);
+      if (!CONTRACT_METHODS.includes(name)) continue;
+      verdicts[name] = classify(member.body, sf);
+    }
+    rows.set(cls, { file, verdicts });
+  });
+}
+
+const csv = process.argv.includes('--csv');
+
+if (csv) {
+  console.log(['handler', ...CONTRACT_METHODS].join(','));
+  for (const [cls, { verdicts }] of rows)
+    console.log([cls, ...CONTRACT_METHODS.map((m) => verdicts[m])].join(','));
+} else {
+  console.log(`handlers analysed: ${rows.size}\n`);
+  const pad = (s, n) => String(s).padEnd(n);
+  console.log(
+    `${pad('method', 18)}${pad('real', 6)}${pad('refuses', 9)}${pad('stub', 6)}${pad('absent', 8)}`,
+  );
+  for (const m of CONTRACT_METHODS) {
+    const c = { a: 0, b: 0, c: 0, d: 0 };
+    const notReal = [];
+    for (const [cls, { verdicts }] of rows) {
+      c[verdicts[m]]++;
+      if (verdicts[m] === 'b' || verdicts[m] === 'c')
+        notReal.push(`${cls.replace(/^Adt/, '')}:${verdicts[m]}`);
+    }
+    console.log(
+      `${pad(m, 18)}${pad(c.a, 6)}${pad(c.b, 9)}${pad(c.c, 6)}${pad(c.d, 8)}` +
+        (notReal.length ? `  ${notReal.join(' ')}` : ''),
+    );
+  }
+}

--- a/scripts/capability-matrix.mjs
+++ b/scripts/capability-matrix.mjs
@@ -46,30 +46,38 @@ function handlerFiles(root) {
   return out.sort();
 }
 
-/**
- * Does this body refuse the operation? A refusal is a throw that is NOT inside a
- * conditional — i.e. the method's whole purpose is to reject. A throw inside an
- * `if` is ordinary error handling and does not count.
- */
-function classify(body, sf) {
-  if (!body || !body.statements.length) return VERDICT.STUB;
-
+/** A top-level throw / `return throwUnsupported*()` means the method refuses. */
+function refuses(body, sf) {
+  if (!body) return false;
   for (const stmt of body.statements) {
-    if (ts.isThrowStatement(stmt)) return VERDICT.REFUSES;
-    // `return throwUnsupportedX(...)` and bare calls to a thrower
-    const text = stmt.getText(sf);
-    if (/^\s*(return\s+)?throwUnsupported\w*\s*\(/.test(text))
-      return VERDICT.REFUSES;
+    if (ts.isThrowStatement(stmt)) return true;
+    if (/^\s*(return\s+)?throwUnsupported\w*\s*\(/.test(stmt.getText(sf)))
+      return true;
   }
+  return false;
+}
 
-  // Real work = it talks to the connection, or delegates to something that does.
+/**
+ * Does the body itself perform real ADT work — directly? "Directly" means it
+ * awaits, calls makeAdtRequest, or hands `this.connection` to something. It does
+ * NOT include plain `this.method(...)` delegation; that is resolved transitively
+ * by the caller, so that a fabricated stub which merely reads `this.state` is not
+ * mistaken for real work.
+ */
+function worksDirectly(body, sf) {
+  if (!body) return false;
   const text = body.getText(sf);
-  const doesWork =
+  return (
     /\bmakeAdtRequest\b/.test(text) ||
-    /\bawait\s+/.test(text) ||
-    /\bthis\.(connection|class|adtClass|utils)\b/.test(text);
+    /\bawait\b/.test(text) ||
+    /\bthis\.connection\b/.test(text)
+  );
+}
 
-  return doesWork ? VERDICT.REAL : VERDICT.STUB;
+/** The `this.<name>(` methods a body delegates to. */
+function delegatesTo(body, sf) {
+  if (!body) return [];
+  return [...body.getText(sf).matchAll(/\bthis\.(\w+)\s*\(/g)].map((m) => m[1]);
 }
 
 const root = 'src/core';
@@ -80,7 +88,16 @@ const program = ts.createProgram(files, {
   target: ts.ScriptTarget.ES2020,
 });
 
-const rows = new Map();
+const CONTRACT_IFACES = new Set([
+  'IAdtObject',
+  'IFeatureToggleObject',
+  'IAdtServiceBinding',
+]);
+
+// Pass 1: collect every Adt* class with its OWN verdicts and its base class name.
+// We defer the contract test and inheritance resolution to pass 2, because a class
+// may promise the contract only through a base we have not parsed yet.
+const candidates = new Map(); // name -> { file, own, base, implementsContract }
 
 for (const file of files) {
   const sf = program.getSourceFile(file);
@@ -90,45 +107,83 @@ for (const file of files) {
     const cls = node.name.text;
     if (!cls.startsWith('Adt')) return;
 
-    // Only classes that actually promise the contract belong in the matrix.
-    // Filtering by heritage (not by name) keeps out facades like AdtService
-    // and utilities like AdtUtils that never claim to implement IAdtObject.
-    // A subclass (e.g. AdtCdsUnitTest extends AdtUnitTest) inherits the
-    // promise, so an `extends Adt*` clause counts too.
-    const CONTRACT_IFACES = new Set([
-      'IAdtObject',
-      'IFeatureToggleObject',
-      'IAdtServiceBinding',
-    ]);
-    const promisesContract = (node.heritageClauses ?? []).some((h) =>
-      h.types.some((t) => {
+    let base = null;
+    let implementsContract = false;
+    for (const h of node.heritageClauses ?? []) {
+      for (const t of h.types) {
         const name = t.expression.getText(sf);
-        if (h.token === ts.SyntaxKind.ImplementsKeyword)
-          return CONTRACT_IFACES.has(name);
-        // extends an Adt* handler => inherits the contract
-        return (
-          h.token === ts.SyntaxKind.ExtendsKeyword && name.startsWith('Adt')
-        );
-      }),
-    );
-    if (!promisesContract) return;
+        if (h.token === ts.SyntaxKind.ImplementsKeyword) {
+          if (CONTRACT_IFACES.has(name)) implementsContract = true;
+        } else if (h.token === ts.SyntaxKind.ExtendsKeyword) {
+          base = name;
+        }
+      }
+    }
 
-    const verdicts = Object.fromEntries(
-      CONTRACT_METHODS.map((m) => [m, VERDICT.ABSENT]),
-    );
+    // Record every method (not only contract ones), so delegation targets like
+    // `_upsertMessage` / `readSource` can be followed transitively.
+    const methods = new Map(); // name -> { refuses, worksDirectly, delegates }
     for (const member of node.members) {
       if (!ts.isMethodDeclaration(member) || !member.name) continue;
       const name = member.name.getText(sf);
-      if (!CONTRACT_METHODS.includes(name)) continue;
-      verdicts[name] = classify(member.body, sf);
+      methods.set(name, {
+        refuses: refuses(member.body, sf),
+        worksDirectly: worksDirectly(member.body, sf),
+        delegates: delegatesTo(member.body, sf),
+      });
     }
-    // A pure alias subclass (e.g. `class AdtService extends AdtServiceBinding {}`)
-    // declares no contract method of its own — every verdict is "absent". Its
-    // behaviour is its parent's, already counted, so drop it to avoid double-counting.
-    if (CONTRACT_METHODS.every((m) => verdicts[m] === VERDICT.ABSENT)) return;
-
-    rows.set(cls, { file, verdicts });
+    candidates.set(cls, { file, methods, base, implementsContract });
   });
+}
+
+/** Resolve a method to its declaring class along the extends chain. */
+function findMethod(cls, method, seen = new Set()) {
+  const c = candidates.get(cls);
+  if (!c || seen.has(cls)) return null;
+  seen.add(cls);
+  if (c.methods.has(method)) return { cls, info: c.methods.get(method) };
+  return c.base ? findMethod(c.base, method, seen) : null;
+}
+
+/** True if `method` on `cls` does real work directly or via any delegation it reaches. */
+function doesRealWork(cls, method, guard = new Set()) {
+  const key = `${cls}.${method}`;
+  if (guard.has(key)) return false; // cycle
+  guard.add(key);
+  const found = findMethod(cls, method);
+  if (!found) return false;
+  if (found.info.worksDirectly) return true;
+  return found.info.delegates.some((d) => doesRealWork(found.cls, d, guard));
+}
+
+/** Contract verdict for a method: absent / refuses / real / stub. */
+function verdictFor(cls, method) {
+  const found = findMethod(cls, method);
+  if (!found) return VERDICT.ABSENT;
+  if (found.info.refuses) return VERDICT.REFUSES;
+  return doesRealWork(cls, method) ? VERDICT.REAL : VERDICT.STUB;
+}
+
+// Does this class promise the contract — directly, or by extending one that does?
+function promisesContract(name, seen = new Set()) {
+  const c = candidates.get(name);
+  if (!c || seen.has(name)) return false;
+  seen.add(name);
+  return (
+    c.implementsContract || (c.base ? promisesContract(c.base, seen) : false)
+  );
+}
+
+const rows = new Map();
+for (const [cls, c] of candidates) {
+  if (!promisesContract(cls)) continue; // excludes AdtUtils and other non-handlers
+  // A pure-alias subclass declaring no method of its own resolves entirely from
+  // its parent; drop it so it does not double-count the parent it merely renames.
+  if (c.methods.size === 0) continue;
+  const verdicts = Object.fromEntries(
+    CONTRACT_METHODS.map((m) => [m, verdictFor(cls, m)]),
+  );
+  rows.set(cls, { file: c.file, verdicts });
 }
 
 const csv = process.argv.includes('--csv');

--- a/src/__tests__/unit/core/capabilities/conformance.test.ts
+++ b/src/__tests__/unit/core/capabilities/conformance.test.ts
@@ -1,0 +1,85 @@
+import { AdtClass } from '../../../../core/class/AdtClass';
+import { AdtDomain } from '../../../../core/domain/AdtDomain';
+import { AdtServiceDefinition } from '../../../../core/serviceDefinition/AdtServiceDefinition';
+
+/**
+ * Records session toggles AND requests in ONE ordered trace, so the test can
+ * assert the older-BASIS ordering (stateful must precede the UNLOCK request,
+ * stateless must follow it) rather than only the final session state.
+ */
+function recordingConnection() {
+  const trace: string[] = [];
+  return {
+    trace,
+    setSessionType: (t: string) => trace.push(`session:${t}`),
+    makeAdtRequest: async (req: any) => {
+      const url: string = req?.url ?? '';
+      const action = /_action=(\w+)/.exec(url)?.[1] ?? 'GET';
+      trace.push(`request:${action}`);
+      return {
+        status: 200,
+        headers: {},
+        // minimal LOCK response shape the low-level parsers accept
+        data: `<?xml version="1.0"?><asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>H1</LOCK_HANDLE></DATA></asx:values></asx:abap>`,
+      };
+    },
+  } as any;
+}
+
+const noopLogger = { info() {}, warn() {}, error() {}, debug() {} } as any;
+
+const cases = [
+  {
+    name: 'AdtClass',
+    make: (c: any) => new AdtClass(c, noopLogger),
+    cfg: { className: 'ZC' },
+  },
+  {
+    name: 'AdtDomain',
+    make: (c: any) => new AdtDomain(c, noopLogger),
+    cfg: { domainName: 'ZD' },
+  },
+  {
+    name: 'AdtServiceDefinition',
+    make: (c: any) => new AdtServiceDefinition(c, noopLogger),
+    cfg: { serviceDefinitionName: 'ZS' },
+  },
+];
+
+describe('LockCapability conformance across handlers', () => {
+  it.each(cases)('$name: lock sets stateful before the LOCK request', async ({
+    make,
+    cfg,
+  }) => {
+    const conn = recordingConnection();
+    const handler = make(conn);
+    await handler.lock(cfg);
+    const iSession = conn.trace.indexOf('session:stateful');
+    const iRequest = conn.trace.findIndex((e: string) =>
+      e.startsWith('request:'),
+    );
+    expect(iSession).toBeGreaterThanOrEqual(0);
+    expect(iRequest).toBeGreaterThan(iSession); // stateful BEFORE the request
+    // and the session is left stateful (the lock is held).
+    expect(
+      conn.trace.filter((e: string) => e.startsWith('session:')).pop(),
+    ).toBe('session:stateful');
+  });
+
+  it.each(
+    cases,
+  )('$name: unlock is stateful → UNLOCK → stateless, in order', async ({
+    make,
+    cfg,
+  }) => {
+    const conn = recordingConnection();
+    const handler = make(conn);
+    await handler.unlock(cfg, 'H1');
+    const iStateful = conn.trace.indexOf('session:stateful');
+    const iUnlock = conn.trace.indexOf('request:UNLOCK');
+    const iStateless = conn.trace.indexOf('session:stateless');
+    expect(iStateful).toBeGreaterThanOrEqual(0);
+    expect(iUnlock).toBeGreaterThan(iStateful); // stateful BEFORE unlock (older BASIS)
+    expect(iStateless).toBeGreaterThan(iUnlock); // stateless AFTER unlock
+  });
+});

--- a/src/__tests__/unit/core/capabilities/lockCapability.test.ts
+++ b/src/__tests__/unit/core/capabilities/lockCapability.test.ts
@@ -1,0 +1,65 @@
+import { LockCapability } from '../../../../core/shared/capabilities/LockCapability';
+import type {
+  ICapabilityContext,
+  ILockStrategy,
+} from '../../../../core/shared/capabilities/types';
+
+type Cfg = { name?: string };
+
+function fakeCtx(): ICapabilityContext & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    connection: {
+      setSessionType: (t: string) => calls.push(`session:${t}`),
+    } as any,
+    logger: undefined,
+  };
+}
+
+type State = { unlockResult?: string; errors: string[] };
+
+const strategy: ILockStrategy<Cfg, State> = {
+  nameOf: (c) => {
+    if (!c.name) throw new Error('name is required');
+    return c.name;
+  },
+  acquire: async (ctx, name) => {
+    (ctx as any).calls.push(`acquire:${name}`);
+    return { lockHandle: 'H1', corrNr: 'C1' };
+  },
+  release: async (ctx, name, h) => {
+    (ctx as any).calls.push(`release:${name}:${h}`);
+    return { unlockResult: `R:${name}`, errors: [] };
+  },
+};
+
+describe('LockCapability', () => {
+  it('lock sets stateful, acquires, returns the handle', async () => {
+    const ctx = fakeCtx();
+    const cap = new LockCapability<Cfg, State>(() => ctx, strategy);
+    const handle = await cap.lock({ name: 'ZFOO' });
+    expect(handle).toBe('H1');
+    expect(ctx.calls).toEqual(['session:stateful', 'acquire:ZFOO']);
+  });
+
+  it('unlock is stateful during release, restores stateless, returns state', async () => {
+    const ctx = fakeCtx();
+    const cap = new LockCapability<Cfg, State>(() => ctx, strategy);
+    const state = await cap.unlock({ name: 'ZFOO' }, 'H1');
+    // stateful BEFORE the UNLOCK (older BASIS), stateless AFTER.
+    expect(ctx.calls).toEqual([
+      'session:stateful',
+      'release:ZFOO:H1',
+      'session:stateless',
+    ]);
+    // the ADT unlock response is preserved in state.
+    expect(state.unlockResult).toBe('R:ZFOO');
+  });
+
+  it('lock rethrows a missing name from the strategy', async () => {
+    const ctx = fakeCtx();
+    const cap = new LockCapability<Cfg, State>(() => ctx, strategy);
+    await expect(cap.lock({})).rejects.toThrow('name is required');
+  });
+});

--- a/src/__tests__/unit/core/capabilities/versionsCapability.test.ts
+++ b/src/__tests__/unit/core/capabilities/versionsCapability.test.ts
@@ -1,0 +1,40 @@
+import type {
+  ICapabilityContext,
+  IVersionsStrategy,
+} from '../../../../core/shared/capabilities/types';
+import { VersionsCapability } from '../../../../core/shared/capabilities/VersionsCapability';
+
+type Cfg = { name?: string };
+const ctx: ICapabilityContext = { connection: {} as any, logger: undefined };
+const getCtx = () => ctx;
+
+const strategy: IVersionsStrategy<Cfg> = {
+  nameOf: (c) => {
+    if (!c.name) throw new Error('name is required');
+    return c.name;
+  },
+  list: async (_ctx, name) => [{ versionId: '000001', title: name } as any],
+  source: async (_ctx, uri) => `source-of:${uri}`,
+};
+
+describe('VersionsCapability', () => {
+  it('getVersions delegates to the strategy', async () => {
+    const cap = new VersionsCapability<Cfg>(getCtx, strategy);
+    const v = await cap.getVersions({ name: 'ZBAR' });
+    expect(v).toHaveLength(1);
+    expect(v[0].title).toBe('ZBAR');
+  });
+
+  it('getVersionSource delegates to the strategy', async () => {
+    const cap = new VersionsCapability<Cfg>(getCtx, strategy);
+    expect(await cap.getVersionSource('/uri/1')).toBe('source-of:/uri/1');
+  });
+
+  it('getVersions rethrows a missing name', () => {
+    const cap = new VersionsCapability<Cfg>(getCtx, strategy);
+    // getVersions is NOT async (byte-identical to the current handlers, whose
+    // getVersions throws synchronously on a missing name), so nameOf's throw
+    // propagates synchronously — assert a sync throw, not a rejection.
+    expect(() => cap.getVersions({})).toThrow('name is required');
+  });
+});

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -30,6 +30,11 @@ import {
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage, safeStringify } from '../../utils/internalUtils';
+import {
+  type ICapabilityContext,
+  LockCapability,
+  VersionsCapability,
+} from '../shared/capabilities';
 import type { IAdtContentTypes } from '../shared/contentTypes';
 import {
   createLockTracker,
@@ -64,6 +69,44 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
   protected readonly contentTypes?: IAdtContentTypes;
   private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Class';
+
+  // LAZY thunk (not a getter that snapshots): captures `this` but reads
+  // this.connection/this.logger only when invoked, after the constructor has
+  // run — so building the capabilities below as class fields is safe.
+  private readonly capCtx = (): ICapabilityContext => ({
+    connection: this.connection,
+    logger: this.logger,
+  });
+
+  private readonly lockCap = new LockCapability<IClassConfig, IClassState>(
+    this.capCtx,
+    {
+      nameOf: (c) => {
+        if (!c.className) throw new Error('Class name is required');
+        return c.className;
+      },
+      acquire: async (ctx, name) => ({
+        lockHandle: await lockClass(ctx.connection, name),
+      }),
+      release: async (ctx, name, handle) => {
+        const result = await unlockClass(ctx.connection, name, handle);
+        return { unlockResult: result, errors: [] };
+      },
+    },
+  );
+
+  private readonly versionsCap = new VersionsCapability<IClassConfig>(
+    this.capCtx,
+    {
+      nameOf: (c) => {
+        if (!c.className) throw new Error('className is required');
+        return c.className;
+      },
+      list: (ctx, name) =>
+        getClassIncludeVersions(ctx.connection, name, 'main'),
+      source: (ctx, uri) => getClassVersionSource(ctx.connection, uri),
+    },
+  );
 
   constructor(
     connection: IAbapConnection,
@@ -711,18 +754,9 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
    * Lock class
    */
   async lock(config: Partial<IClassConfig>): Promise<string> {
-    if (!config.className) {
-      throw new Error('Class name is required');
-    }
-
-    // Stay stateful while the lock is held — the caller must release it via
-    // unlock(), which restores stateless. On older BASIS (#106) the lock handle
-    // is only valid inside stateful requests, so a stateless write between lock
-    // and unlock fails with 423.
-    this.connection.setSessionType('stateful');
-    const lockHandle = await lockClass(this.connection, config.className);
-    this.lockTracker.track(config.className, lockHandle);
-    return lockHandle;
+    const handle = await this.lockCap.lock(config);
+    this.lockTracker.track(config.className as string, handle);
+    return handle;
   }
 
   /**
@@ -732,21 +766,9 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
     config: Partial<IClassConfig>,
     lockHandle: string,
   ): Promise<IClassState> {
-    if (!config.className) {
-      throw new Error('Class name is required');
-    }
-    this.connection.setSessionType('stateful');
-    const result = await unlockClass(
-      this.connection,
-      config.className,
-      lockHandle,
-    );
-    this.connection.setSessionType('stateless');
-    this.lockTracker.untrack(config.className);
-    return {
-      unlockResult: result,
-      errors: [],
-    };
+    const state = await this.lockCap.unlock(config, lockHandle);
+    this.lockTracker.untrack(config.className as string);
+    return state;
   }
 
   /**
@@ -933,12 +955,11 @@ export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
   }
 
   getVersions(config: Partial<IClassConfig>): Promise<IObjectVersion[]> {
-    if (!config.className) throw new Error('className is required');
-    return getClassIncludeVersions(this.connection, config.className, 'main');
+    return this.versionsCap.getVersions(config);
   }
 
   getVersionSource(contentUri: string): Promise<string> {
-    return getClassVersionSource(this.connection, contentUri);
+    return this.versionsCap.getVersionSource(contentUri);
   }
 
   /** Shared by local-include subclasses to target their own include. */

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -29,6 +29,10 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import {
+  type ICapabilityContext,
+  LockCapability,
+} from '../shared/capabilities';
+import {
   createLockTracker,
   type LockRegistry,
   type LockTracker,
@@ -51,6 +55,31 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
   private readonly systemContext: IAdtSystemContext;
   private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'Domain';
+
+  // LAZY thunk (not a getter that snapshots): captures `this` but reads
+  // this.connection/this.logger only when invoked, after the constructor has
+  // run — so building the capability below as a class field is safe.
+  private readonly capCtx = (): ICapabilityContext => ({
+    connection: this.connection,
+    logger: this.logger,
+  });
+
+  private readonly lockCap = new LockCapability<IDomainConfig, IDomainState>(
+    this.capCtx,
+    {
+      nameOf: (c) => {
+        if (!c.domainName) throw new Error('Domain name is required');
+        return c.domainName;
+      },
+      acquire: async (ctx, name) => ({
+        lockHandle: await lockDomain(ctx.connection, name),
+      }),
+      release: async (ctx, name, handle) => {
+        const result = await unlockDomain(ctx.connection, name, handle);
+        return { unlockResult: result, errors: [] };
+      },
+    },
+  );
 
   constructor(
     connection: IAbapConnection,
@@ -614,14 +643,9 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
    * Lock domain for modification
    */
   async lock(config: Partial<IDomainConfig>): Promise<string> {
-    if (!config.domainName) {
-      throw new Error('Domain name is required');
-    }
-
-    this.connection.setSessionType('stateful');
-    const lockHandle = await lockDomain(this.connection, config.domainName);
-    this.lockTracker.track(config.domainName, lockHandle);
-    return lockHandle;
+    const handle = await this.lockCap.lock(config);
+    this.lockTracker.track(config.domainName as string, handle);
+    return handle;
   }
 
   /**
@@ -631,22 +655,9 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
     config: Partial<IDomainConfig>,
     lockHandle: string,
   ): Promise<IDomainState> {
-    if (!config.domainName) {
-      throw new Error('Domain name is required');
-    }
-
-    this.connection.setSessionType('stateful');
-    const result = await unlockDomain(
-      this.connection,
-      config.domainName,
-      lockHandle,
-    );
-    this.connection.setSessionType('stateless');
-    this.lockTracker.untrack(config.domainName);
-    return {
-      unlockResult: result,
-      errors: [],
-    };
+    const state = await this.lockCap.unlock(config, lockHandle);
+    this.lockTracker.untrack(config.domainName as string);
+    return state;
   }
 
   async getVersions(

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -29,6 +29,11 @@ import type {
 import type { IAdtSystemContext } from '../../clients/AdtClient';
 import { safeErrorMessage } from '../../utils/internalUtils';
 import {
+  type ICapabilityContext,
+  LockCapability,
+  VersionsCapability,
+} from '../shared/capabilities';
+import {
   createLockTracker,
   type LockRegistry,
   type LockTracker,
@@ -64,6 +69,54 @@ export class AdtServiceDefinition
   private readonly systemContext: IAdtSystemContext;
   private readonly lockTracker: LockTracker;
   public readonly objectType: string = 'ServiceDefinition';
+
+  // LAZY thunk (not a getter that snapshots): captures `this` but reads
+  // this.connection/this.logger only when invoked, after the constructor has
+  // run — so building the capabilities below as class fields is safe.
+  private readonly capCtx = (): ICapabilityContext => ({
+    connection: this.connection,
+    logger: this.logger,
+  });
+
+  private readonly lockCap = new LockCapability<
+    IServiceDefinitionConfig,
+    IServiceDefinitionState
+  >(this.capCtx, {
+    nameOf: (c) => {
+      if (!c.serviceDefinitionName)
+        throw new Error('Service definition name is required');
+      return c.serviceDefinitionName;
+    },
+    acquire: async (ctx, name) => ({
+      lockHandle: await lockServiceDefinition(ctx.connection, name),
+    }),
+    release: async (ctx, name, handle) => {
+      const result = await unlockServiceDefinition(
+        ctx.connection,
+        name,
+        handle,
+      );
+      return { unlockResult: result, errors: [] };
+    },
+  });
+
+  private readonly versionsCap =
+    new VersionsCapability<IServiceDefinitionConfig>(this.capCtx, {
+      nameOf: (c) => {
+        if (!c.serviceDefinitionName)
+          throw new Error('serviceDefinitionName is required');
+        return c.serviceDefinitionName;
+      },
+      // NOTE: getServiceDefinitionVersions takes a config, not a bare name —
+      // the strategy re-wraps. (getClassIncludeVersions, by contrast, takes a
+      // name; the two low-level shapes differ and the strategy absorbs that.)
+      list: (ctx, name) =>
+        getServiceDefinitionVersions(ctx.connection, {
+          serviceDefinitionName: name,
+        }),
+      source: (ctx, uri) =>
+        getServiceDefinitionVersionSource(ctx.connection, uri),
+    });
 
   constructor(
     connection: IAbapConnection,
@@ -594,16 +647,8 @@ export class AdtServiceDefinition
    * Lock service definition for modification
    */
   async lock(config: Partial<IServiceDefinitionConfig>): Promise<string> {
-    if (!config.serviceDefinitionName) {
-      throw new Error('Service definition name is required');
-    }
-
-    this.connection.setSessionType('stateful');
-    const lockHandle = await lockServiceDefinition(
-      this.connection,
-      config.serviceDefinitionName,
-    );
-    this.lockTracker.track(config.serviceDefinitionName, lockHandle);
+    const lockHandle = await this.lockCap.lock(config);
+    this.lockTracker.track(config.serviceDefinitionName as string, lockHandle);
     return lockHandle;
   }
 
@@ -614,29 +659,16 @@ export class AdtServiceDefinition
     config: Partial<IServiceDefinitionConfig>,
     lockHandle: string,
   ): Promise<IServiceDefinitionState> {
-    if (!config.serviceDefinitionName) {
-      throw new Error('Service definition name is required');
-    }
-
-    this.connection.setSessionType('stateful');
-    const result = await unlockServiceDefinition(
-      this.connection,
-      config.serviceDefinitionName,
-      lockHandle,
-    );
-    this.connection.setSessionType('stateless');
-    this.lockTracker.untrack(config.serviceDefinitionName);
-    return {
-      unlockResult: result,
-      errors: [],
-    };
+    const state = await this.lockCap.unlock(config, lockHandle);
+    this.lockTracker.untrack(config.serviceDefinitionName as string);
+    return state;
   }
 
   getVersions(config: Partial<IServiceDefinitionConfig>) {
-    return getServiceDefinitionVersions(this.connection, config);
+    return this.versionsCap.getVersions(config);
   }
 
   getVersionSource(contentUri: string) {
-    return getServiceDefinitionVersionSource(this.connection, contentUri);
+    return this.versionsCap.getVersionSource(contentUri);
   }
 }

--- a/src/core/shared/capabilities/LockCapability.ts
+++ b/src/core/shared/capabilities/LockCapability.ts
@@ -1,0 +1,62 @@
+import type { IAdtLockable } from '@mcp-abap-adt/interfaces';
+import type { ICapabilityContext, ILockStrategy } from './types';
+
+/**
+ * Shared lock/unlock for handlers whose lock differs only by endpoint and
+ * name field. `lock` leaves the session stateful (the caller must unlock).
+ * `unlock` runs the release inside a stateful request — older BASIS (#106)
+ * only accepts UNLOCK while stateful — then restores stateless. The handler's
+ * state shape (including the ADT `unlockResult`) is built by `strategy.release`
+ * and returned unchanged. See the spec's IAdtLockable obligations — idempotent
+ * unlock is a TARGET, not implemented here, and is left to the per-endpoint
+ * probe + adaptation rule of the full-migration plan.
+ *
+ * DELIBERATELY byte-identical to the current handlers, including the failure
+ * path: if `acquire`/`release` throws, the session is left as-is (stateful) and
+ * the error propagates — exactly as today. Failure/abandonment handling is
+ * DISTRIBUTED and this capability owns none of it:
+ *   - the consumer largely owns lock/unlock atomicity (it decides when to lock
+ *     and unlock);
+ *   - adt-clients' `LockRegistry.unlockAll()` is a disposal safety net that
+ *     raw-releases abandoned locks — deliberately WITHOUT toggling the session,
+ *     because `unlockAll()` manages the session once for the whole batch;
+ *   - the operation chain's create/update catch blocks also call
+ *     setSessionType('stateless').
+ * Adding a try/finally here would change behaviour and relocate responsibility
+ * across those layers, so the atom-level "restore stateless on failure"
+ * contract is deferred to the behavioural-conformance work (same bucket as
+ * activate/check error unification), where all three layers are reconciled
+ * rather than double-cleaned.
+ */
+export class LockCapability<TConfig, TReadResult>
+  implements IAdtLockable<TConfig, TReadResult>
+{
+  constructor(
+    // LAZY: read at method-call time, so the handler can build this capability
+    // as a class field before its constructor assigns this.connection.
+    private readonly getCtx: () => ICapabilityContext,
+    private readonly strategy: ILockStrategy<TConfig, TReadResult>,
+  ) {}
+
+  async lock(config: Partial<TConfig>): Promise<string> {
+    const ctx = this.getCtx();
+    const name = this.strategy.nameOf(config);
+    // Stay stateful while the lock is held; the caller releases via unlock().
+    ctx.connection.setSessionType('stateful');
+    const { lockHandle } = await this.strategy.acquire(ctx, name);
+    return lockHandle;
+  }
+
+  async unlock(
+    config: Partial<TConfig>,
+    lockHandle: string,
+  ): Promise<TReadResult> {
+    const ctx = this.getCtx();
+    const name = this.strategy.nameOf(config);
+    // UNLOCK must run stateful (older BASIS #106); restore stateless after.
+    ctx.connection.setSessionType('stateful');
+    const state = await this.strategy.release(ctx, name, lockHandle);
+    ctx.connection.setSessionType('stateless');
+    return state;
+  }
+}

--- a/src/core/shared/capabilities/VersionsCapability.ts
+++ b/src/core/shared/capabilities/VersionsCapability.ts
@@ -1,0 +1,24 @@
+import type { IAdtVersionable, IObjectVersion } from '@mcp-abap-adt/interfaces';
+import type { ICapabilityContext, IVersionsStrategy } from './types';
+
+/**
+ * Shared version history for source-backed objects. Types without a
+ * /source/main resource do NOT compose this capability and do not implement
+ * IAdtVersionable — absence is expressed structurally, not by throwing.
+ */
+export class VersionsCapability<TConfig> implements IAdtVersionable<TConfig> {
+  constructor(
+    // LAZY: see LockCapability — read at call time so it can be a class field.
+    private readonly getCtx: () => ICapabilityContext,
+    private readonly strategy: IVersionsStrategy<TConfig>,
+  ) {}
+
+  getVersions(config: Partial<TConfig>): Promise<IObjectVersion[]> {
+    const name = this.strategy.nameOf(config);
+    return this.strategy.list(this.getCtx(), name);
+  }
+
+  getVersionSource(contentUri: string): Promise<string> {
+    return this.strategy.source(this.getCtx(), contentUri);
+  }
+}

--- a/src/core/shared/capabilities/index.ts
+++ b/src/core/shared/capabilities/index.ts
@@ -1,0 +1,3 @@
+export { LockCapability } from './LockCapability';
+export * from './types';
+export { VersionsCapability } from './VersionsCapability';

--- a/src/core/shared/capabilities/types.ts
+++ b/src/core/shared/capabilities/types.ts
@@ -1,0 +1,52 @@
+import type {
+  IAbapConnection,
+  ILogger,
+  IObjectVersion,
+} from '@mcp-abap-adt/interfaces';
+
+/** The connection + logger every capability implementation needs. */
+export interface ICapabilityContext {
+  readonly connection: IAbapConnection;
+  readonly logger?: ILogger;
+}
+
+/**
+ * Normalized lock result. The per-type helpers return different shapes
+ * (bare string vs { lockHandle, corrNr }); the capability normalizes up to
+ * this superset. See the spec's "lock normalization contract".
+ */
+export interface INormalizedLock {
+  lockHandle: string;
+  corrNr?: string;
+}
+
+/**
+ * Per-handler strategy for LockCapability. The handler supplies its own
+ * endpoint knowledge — there is no centralized lifecycle-URI resolver
+ * (buildObjectUri is for group operations only).
+ *
+ * `release` returns the handler's OWN state shape (e.g. `{ unlockResult,
+ * errors: [] }`), not void — the current handlers put the ADT unlock response
+ * into `state.unlockResult`, and dropping it would change observable behaviour.
+ * The capability owns only the session toggling around it.
+ */
+export interface ILockStrategy<TConfig, TReadResult> {
+  /** Extract the object name from config, or throw if missing. */
+  nameOf(config: Partial<TConfig>): string;
+  /** POST _action=LOCK, return the normalized handle. */
+  acquire(ctx: ICapabilityContext, name: string): Promise<INormalizedLock>;
+  /** POST _action=UNLOCK with the handle; build and return the handler state. */
+  release(
+    ctx: ICapabilityContext,
+    name: string,
+    lockHandle: string,
+  ): Promise<TReadResult>;
+}
+
+/** Per-handler strategy for VersionsCapability. */
+export interface IVersionsStrategy<TConfig> {
+  nameOf(config: Partial<TConfig>): string;
+  list(ctx: ICapabilityContext, name: string): Promise<IObjectVersion[]>;
+  /** GET the content URI, return the source text. */
+  source(ctx: ICapabilityContext, contentUri: string): Promise<string>;
+}


### PR DESCRIPTION
Pilots the capability-composition architecture on three handlers. Consumes `@mcp-abap-adt/interfaces@^11.2.0` (the capability atom interfaces). Combined **7.6.0** release — also carries the already-merged 7.5.1 activation fix cumulatively.

## What changed

Two shared capability implementations, parameterized by a per-handler strategy, replace bespoke per-type lock/versions code on three handlers:

- **`LockCapability`** (lock/unlock) — normalizes the lock result, runs `stateful → release → stateless` (older-BASIS #106 needs stateful before UNLOCK), and returns the handler's own `{ unlockResult, errors: [] }` state shape.
- **`VersionsCapability`** (getVersions/getVersionSource) — for source-backed objects only.
- Converted: **`AdtClass`** (both), **`AdtDomain`** (lock only — no `/source/main`, so it composes *no* VersionsCapability; the absence is structural, not a throwing stub), **`AdtServiceDefinition`** (both; its versions strategy re-wraps `{ serviceDefinitionName: name }` since the low-level helper takes a config, not a bare name).

The capabilities take a **lazy** `getCtx` thunk read at call time, so a handler builds them as class fields even though `this.connection` is assigned later in the constructor. The constructor's `createLockTracker` disposal-safety-net thunk (raw release, no session toggle — a separate path from `unlock()`) is **untouched**.

## Why this is safe for consumers

- **Public surface byte-identical** — captured across all seven entry points before and after; empty diff. No `IAdtObject` API change.
- **Behaviour unchanged** — full unit suite (365, including cross-handler lock/unlock ordering conformance) green; each converted method preserves the exact session-toggle order, lock-tracking, and state shape.
- Requires interfaces `^11.2.0` (the additive atoms); that dependency-floor bump is the main reason this is a minor.

## Scope deliberately deferred (future plans)

The remaining 32 handlers, the activate/check error-envelope unification, return-type narrowing (the breaking flip), and the ATC client — each its own plan. Spec: `docs/superpowers/specs/2026-07-20-capability-interfaces-design.md`.

## Verification

- `npm run build:fast` clean; `npm run lint:check` 0 errors (45/25 baseline)
- 365 unit tests pass; public-surface diff empty
- `package-lock.json` resolves interfaces 11.2.0 from the registry, `"link": true` = 0
- Final whole-branch review: READY TO MERGE, 0 Critical/Important

🤖 Generated with [Claude Code](https://claude.com/claude-code)