### PR TITLE
release(8.0.0): honest capability types (BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package are documented here.  
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the package follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-07-22
+
+### Changed (BREAKING)
+- **Handlers now declare their honest capability set.** Each object handler `implements` only the capability atom interfaces it genuinely supports (e.g. `AdtDomain` implements everything except `IAdtVersionable`, since it has no `/source/main`), instead of the fat `IAdtObject`. Correspondingly, `AdtClient.getXxx()` — and, by inference, `AdtClientBatch.getXxx()` — return types are **narrowed** to that honest set.
+- **Consequence:** calling a capability a handler does not have is now a **compile error** instead of a runtime throw. For example `client.getDomain().getVersions(...)` no longer type-checks. This **only** breaks code that referenced methods which always threw at runtime (`ADT_UNSUPPORTED_OPERATION`); no working code is affected. Requires `@mcp-abap-adt/interfaces ^11.3.0` (the capability composites).
+- The removed-from-contract methods remain on the classes at runtime, marked `@deprecated`, and will be deleted in a later major.
+
+### Deferred (still return the wide type this release)
+- `getFeatureToggle`, `getServiceBinding` (implement widening interfaces `IFeatureToggleObject` / `IAdtServiceBinding` that extend `IAdtObject`), and `getRequest`, `getUnitTest`, `getCdsUnitTest` (wrong-contract / test-runner — `AdtRequest.update`/`delete` are known defects to fix first). These will be narrowed in a follow-up.
+
 ## [7.6.0] - 2026-07-21
 
 ### Changed

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -1,0 +1,404 @@
+# Capability Type-Honesty Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every handler declare its **honest** capability set — `implements` only the atom interfaces it truly supports — retire the fat `IAdtObject` from all handlers (kept `@deprecated`), and narrow each `AdtClient.getXxx()` return type to that honest set, so calling a capability a handler lacks (e.g. `getDomain().getVersions()`) becomes a **compile error** instead of a runtime throw.
+
+**Architecture:** The class bodies barely change — the substantive change is in the composition layer. In `@mcp-abap-adt/interfaces` we deprecate `IAdtObject` and add named composite types for the recurring capability profiles. In `adt-clients` each handler swaps `implements IAdtObject<C,S>` for its honest composite (named or inline intersection of atoms), and `AdtClient.getXxx()` return types narrow to match. Throwing stubs for unsupported capabilities stay in place (`@deprecated`, removed in a later release) — the narrowed return type is what enforces the compile error.
+
+**Tech Stack:** TypeScript (strict, CommonJS), Biome, ts-jest, the TypeScript compiler API for the surface snapshot and `scripts/capability-matrix.mjs` for the honest-profile classification.
+
+## Global Constraints
+
+- All repository artifacts in English; communication with the user in the user's language.
+- Never change `package.json` version without explicit request; the user chooses CHANGELOG versions.
+- After a version change, run `npm install --package-lock-only` and commit the lockfile in the same commit.
+- Dependencies resolve from the npm registry only; after every `npm install`, `package-lock.json` must have zero `"link": true`.
+- The user runs `npm publish`, never the agent. The agent merges PRs, tags, GitHub-releases.
+- Publish the interfaces dependency to npm FIRST; Phase B is blocked until the new interfaces version is on npm.
+- Tests: never pipe through grep/tail/head — save the full log with `tee`, then read it.
+- Unit tests without SAP: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand`.
+- Biome: 0 errors; warning/info baseline 45/25 in adt-clients — do not increase.
+- **This is a BREAKING change for adt-clients → major (8.0.0).** It only breaks consumer code that referenced capabilities a handler never supported (methods that always threw at runtime). No working code breaks. Coordinate with the consumer (`~/prj/mcp-abap-adt`): after publish, bump its dep and confirm it compiles.
+
+**Repos:** interfaces `~/prj/mcp-abap-adt-interfaces` (default branch **master**); adt-clients `~/prj/mcp-abap-adt-clients` (branch **main**); consumer `~/prj/mcp-abap-adt`.
+
+## The honest-profile classification (generated)
+
+From `node scripts/capability-matrix.mjs`, each handler's honest atom set. Two profiles recur enough to be **named composites**; the rest are **inline intersections**.
+
+**Named composite `IAdtSourceObject<C,S>`** = all seven atoms (`IAdtCrud & IAdtValidatable & IAdtCheckable & IAdtActivatable & IAdtLockable & IAdtVersionable & IAdtTransportAware`). **22 handlers:** AccessControl, AppendStructure, BehaviorDefinition, BehaviorImplementation, Class, DdicTableType, Ddl, Enhancement, FunctionModule, Interface, LocalDefinitions, LocalMacros, LocalTestClass, LocalTypes, MetadataExtension, Program, ScalarFunction, ScalarFunctionImplementation, ServiceDefinition, Structure, Table, Transformation.
+
+**Named composite `IAdtNonVersionedObject<C,S>`** = the six atoms without `IAdtVersionable`. **3 handlers:** DataElement, Domain, FunctionGroup.
+
+**Inline-intersection handlers** (distinct profiles, declared inline):
+
+| Handler | Honest composite (inline) | Missing vs full |
+|---|---|---|
+| FunctionInclude | Crud & Validatable & Checkable & Activatable & Lockable & Versionable | TransportAware |
+| AuthorizationField, FeatureToggle | Crud & Validatable & Checkable & Activatable & Lockable | Versionable, TransportAware |
+| Package | Crud & Validatable & Checkable & Lockable & TransportAware | Activatable, Versionable |
+| MessageClass | Crud & Validatable & Lockable | Checkable, Activatable, Versionable, TransportAware |
+| MessageClassMessage | Crud | everything else |
+
+**Special / deferred (NOT in this migration):**
+- **ServiceBinding** — implements the widening `IAdtServiceBinding` (its own interface), not plain `IAdtObject`. Its honest atoms are Crud & Validatable & Checkable & Activatable & TransportAware (no Lockable/Versionable), but the widening interface needs its own reconciliation. **Deferred** to a follow-up.
+- **Request (`AdtRequest`)** — matrix shows no complete atom; but its `update`/`delete` throws are DEFECTS, not domain limits: transport-request `update` = change the description, `delete` = only for empty requests (see memory `reference_transport_request_update_delete`). Honest profile requires fixing those first. **Deferred.**
+- **UnitTest (`AdtUnitTest`)** and **CdsUnitTest** (extends it) — a test runner, wrong contract entirely. **Deferred.**
+
+The 33 in-scope handlers are the 22 full + 3 non-versioned + 6 inline + MessageClass + MessageClassMessage.
+
+---
+
+## File Structure
+
+**Phase A — interfaces:**
+- Modify `src/adt/IAdtObject.ts` — add `@deprecated` to `IAdtObject`.
+- Create `src/adt/IAdtComposites.ts` — `IAdtSourceObject`, `IAdtNonVersionedObject`, plus a compile-time proof that `IAdtSourceObject` ≡ `IAdtObject`.
+- Modify `src/index.ts` — export the two composites.
+
+**Phase B — adt-clients:**
+- Modify each in-scope `src/core/<type>/Adt<Type>.ts` — swap the `implements` clause (class body otherwise unchanged; throwing stubs stay, marked `@deprecated`).
+- Modify `src/clients/AdtClient.ts` — narrow each in-scope `getXxx()` return type.
+- Modify `src/clients/AdtClientLegacy.ts` if it re-declares any narrowed return type.
+
+---
+
+# PHASE A — interfaces (minor, e.g. 11.3.0)
+
+Branch `feat/capability-composites` off **master**.
+
+### Task A1: Deprecate IAdtObject + add the named composites with a proof
+
+**Files:**
+- Modify: `~/prj/mcp-abap-adt-interfaces/src/adt/IAdtObject.ts`
+- Create: `~/prj/mcp-abap-adt-interfaces/src/adt/IAdtComposites.ts`
+
+**Interfaces:**
+- Consumes: the seven atoms from `IAdtCapabilities.ts` (shipped in 11.2.0), `IAdtObject`, `IClassConfig`/`IClassState`.
+- Produces: `IAdtSourceObject<TConfig, TReadResult>`, `IAdtNonVersionedObject<TConfig, TReadResult>`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd ~/prj/mcp-abap-adt-interfaces && git checkout master && git pull && git checkout -b feat/capability-composites
+```
+
+- [ ] **Step 2: Deprecate `IAdtObject`**
+
+In `src/adt/IAdtObject.ts`, add a JSDoc `@deprecated` tag to the `IAdtObject` interface declaration (do NOT change its members):
+
+```ts
+/**
+ * @deprecated Since 11.3.0. Handlers now declare their honest capability set
+ * (see IAdtComposites and the capability atoms). `IAdtObject` remains as the
+ * full-capability composite for backward compatibility and will be removed in a
+ * later major. New code should depend on the specific capability it needs.
+ */
+export interface IAdtObject<TConfig, TReadResult = TConfig> {
+  // ... members unchanged ...
+```
+
+- [ ] **Step 3: Create the composites + proof**
+
+Create `src/adt/IAdtComposites.ts`:
+
+```ts
+/**
+ * Named capability composites for the recurring handler profiles. A handler
+ * implements the composite that matches the capabilities it genuinely supports;
+ * the fat IAdtObject is deprecated in favour of these.
+ */
+import type {
+  IAdtActivatable,
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
+  IAdtTransportAware,
+  IAdtValidatable,
+  IAdtVersionable,
+} from './IAdtCapabilities';
+import type { IAdtObject } from './IAdtObject';
+import type { IClassConfig, IClassState } from './IAdtClass';
+
+/** Full capability set — source-backed objects (has /source/main → versions). */
+export type IAdtSourceObject<TConfig, TReadResult = TConfig> = IAdtCrud<
+  TConfig,
+  TReadResult
+> &
+  IAdtValidatable<TConfig, TReadResult> &
+  IAdtCheckable<TConfig, TReadResult> &
+  IAdtActivatable<TConfig, TReadResult> &
+  IAdtLockable<TConfig, TReadResult> &
+  IAdtVersionable<TConfig> &
+  IAdtTransportAware<TConfig, TReadResult>;
+
+/** Objects with no source resource — everything except version history. */
+export type IAdtNonVersionedObject<TConfig, TReadResult = TConfig> = IAdtCrud<
+  TConfig,
+  TReadResult
+> &
+  IAdtValidatable<TConfig, TReadResult> &
+  IAdtCheckable<TConfig, TReadResult> &
+  IAdtActivatable<TConfig, TReadResult> &
+  IAdtLockable<TConfig, TReadResult> &
+  IAdtTransportAware<TConfig, TReadResult>;
+
+/** Assertion helper: instantiating with `false` is a compile error. */
+type Assert<T extends true> = T;
+
+/**
+ * IAdtSourceObject must be structurally identical to the (deprecated) IAdtObject
+ * — both directions — so switching a full handler from one to the other is a
+ * no-op. Instantiated at a concrete pair, or nothing is checked.
+ */
+type _SourceEqualsObject<C, R> = [
+  Assert<IAdtSourceObject<C, R> extends IAdtObject<C, R> ? true : false>,
+  Assert<IAdtObject<C, R> extends IAdtSourceObject<C, R> ? true : false>,
+];
+type _Check = _SourceEqualsObject<IClassConfig, IClassState>;
+```
+
+- [ ] **Step 4: Build — expect clean**
+
+Run: `cd ~/prj/mcp-abap-adt-interfaces && npm run build`
+Expected: exit 0.
+
+- [ ] **Step 5: Verify the proof bites — temporarily break it**
+
+Remove `IAdtVersionable<TConfig> &` from `IAdtSourceObject`, run `npm run build`.
+Expected: FAIL with `TS2344` on `_SourceEqualsObject` — without `IAdtVersionable`, the source composite no longer has all of `IAdtObject`'s methods, so `IAdtSourceObject extends IAdtObject` becomes `false` (the first assertion fails).
+Restore the line, rebuild — exit 0. No commit of the broken state.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/adt/IAdtObject.ts src/adt/IAdtComposites.ts
+git commit -m "feat(composites): deprecate IAdtObject; add IAdtSourceObject/IAdtNonVersionedObject"
+```
+
+---
+
+### Task A2: Barrel export, version, changelog, PR
+
+**Files:**
+- Modify: `~/prj/mcp-abap-adt-interfaces/src/index.ts`, `package.json`, `CHANGELOG.md`
+
+- [ ] **Step 1: Export the composites**
+
+In `src/index.ts`, add (alphabetical position):
+
+```ts
+export type {
+  IAdtNonVersionedObject,
+  IAdtSourceObject,
+} from './adt/IAdtComposites';
+```
+
+- [ ] **Step 2: Build + verify exports**
+
+```bash
+npm run build
+node -e "const ts=require('typescript');const p=ts.createProgram(['dist/index.d.ts'],{});const s=p.getTypeChecker().getSymbolAtLocation(p.getSourceFile('dist/index.d.ts'));const n=p.getTypeChecker().getExportsOfModule(s).map(x=>x.getName());const want=['IAdtSourceObject','IAdtNonVersionedObject'];console.log(want.every(w=>n.includes(w))?'both composites exported':'MISSING: '+want.filter(w=>!n.includes(w)));"
+```
+Expected: `both composites exported`.
+
+- [ ] **Step 3: Version 11.3.0 + lockfile**
+
+```bash
+npm version 11.3.0 --no-git-tag-version && npm install --package-lock-only
+grep -c '"link": true' package-lock.json
+```
+Expected: version 11.3.0; link:true count 0.
+
+- [ ] **Step 4: CHANGELOG**
+
+Prepend under the top heading:
+
+```markdown
+## [11.3.0] - 2026-07-21
+
+### Added
+- **Named capability composites** `IAdtSourceObject` (full capability set) and
+  `IAdtNonVersionedObject` (all but version history), for handlers to declare
+  their honest capability profile instead of the fat contract.
+
+### Deprecated
+- **`IAdtObject`.** It remains as the full-capability composite (structurally
+  identical to `IAdtSourceObject`, asserted at compile time) for backward
+  compatibility, and will be removed in a later major. New code should depend on
+  the specific capability atoms or a composite.
+```
+
+- [ ] **Step 5: Commit, push, PR**
+
+```bash
+git add src/index.ts package.json package-lock.json CHANGELOG.md
+git commit -m "release(11.3.0): export capability composites; deprecate IAdtObject"
+git push -u origin feat/capability-composites
+gh pr create --base master --title "release(11.3.0): capability composites + deprecate IAdtObject" --body "Additive: two named composites for the recurring handler profiles, plus an IAdtObject deprecation (kept as the full composite, proven structurally identical). Enables adt-clients handlers to declare honest capability sets."
+```
+
+- [ ] **Step 6: STOP — publish gate.** Report: PR opened, ready for review + merge + tag + **user `npm publish`**. Phase B is blocked until `@mcp-abap-adt/interfaces@11.3.0` is on npm.
+
+---
+
+# PHASE B — adt-clients (major 8.0.0, after 11.3.0 is published)
+
+Branch `feat/capability-type-honesty` off **main**.
+
+### Task B1: Consume 11.3.0 + surface baseline
+
+- [ ] **Step 1:** `git checkout main && git pull && git checkout -b feat/capability-type-honesty`; set `"@mcp-abap-adt/interfaces": "^11.3.0"`; `rm -rf node_modules/@mcp-abap-adt/interfaces && npm install @mcp-abap-adt/interfaces@11.3.0`; confirm `grep -c '"link": true' package-lock.json` = 0.
+- [ ] **Step 2:** `npm run build:fast` — exit 0.
+- [ ] **Step 3:** capture baseline: `node _surface-snapshot.mjs > /tmp/surface-before.txt && wc -l /tmp/surface-before.txt`. (Unlike the pilot, this migration WILL change the surface — the baseline is for the diff in B7 to confirm the change is EXACTLY the expected narrowing.)
+- [ ] **Step 4:** commit `package.json` + `package-lock.json` — `chore: consume @mcp-abap-adt/interfaces ^11.3.0 (pre-migration)`.
+
+---
+
+### Task B2: Switch the 22 full handlers to `IAdtSourceObject`
+
+**Files:** the 22 `src/core/<type>/Adt<Type>.ts` listed under `IAdtSourceObject` above.
+
+**Interfaces:** Consumes `IAdtSourceObject` from `@mcp-abap-adt/interfaces`. Produces handlers whose declared type is `IAdtSourceObject<Config, State>` instead of `IAdtObject<Config, State>` — structurally identical (proven), so this is a no-op refactor for these 22; the build must stay green.
+
+- [ ] **Step 1: For each of the 22 handlers, replace the implements clause.** Worked example (`AdtClass.ts`):
+
+```ts
+// BEFORE
+export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
+// AFTER
+export class AdtClass implements IAdtSourceObject<IClassConfig, IClassState> {
+```
+
+Update the import: replace `IAdtObject` with `IAdtSourceObject` from `@mcp-abap-adt/interfaces` (drop the `IAdtObject` import if now unused). Do NOT touch method bodies. For the 4 class-include handlers that `extends AdtClass`, they inherit — change only if they independently declare `implements IAdtObject` (check each; most just `extends AdtClass`).
+
+- [ ] **Step 2: Build** — `npm run build:fast`, exit 0. Because `IAdtSourceObject ≡ IAdtObject`, all 22 still satisfy their declared type. A failure means a handler was NOT actually full (matrix disagreement) → STOP and report which.
+- [ ] **Step 3: Full unit suite** — `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b2.log`, read it; all pass.
+- [ ] **Step 4: Commit** — `refactor(types): 22 full handlers implement IAdtSourceObject`.
+
+---
+
+### Task B3: Switch the non-versioned + inline-profile handlers
+
+**Files:** DataElement, Domain, FunctionGroup (→ `IAdtNonVersionedObject`); FunctionInclude, AuthorizationField, FeatureToggle, Package, MessageClass, MessageClassMessage (→ inline intersections per the table above).
+
+**Interfaces:** Consumes `IAdtNonVersionedObject` + the seven atoms (for inline intersections). Produces handlers whose declared type omits the capabilities they lack — so their throwing stubs are no longer part of the declared contract.
+
+- [ ] **Step 1: Non-versioned trio.** For `AdtDataElement`, `AdtDomain`, `AdtFunctionGroup`: replace `implements IAdtObject<C,S>` with `implements IAdtNonVersionedObject<C,S>`. Mark the (now-not-declared) `getVersions`/`getVersionSource` throwing stubs `@deprecated`:
+
+```ts
+/** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
+getVersions(config: Partial<IDomainConfig>): Promise<IObjectVersion[]> {
+  return throwUnsupportedVersions('domain');
+}
+```
+
+- [ ] **Step 2: Inline-profile handlers.** For each, replace the implements clause with the inline intersection from the table, importing the needed atoms. Example (`AdtPackage.ts`):
+
+```ts
+import type {
+  IAdtActivatable, // still imported only if referenced elsewhere; else omit
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
+  IAdtTransportAware,
+  IAdtValidatable,
+} from '@mcp-abap-adt/interfaces';
+
+export class AdtPackage
+  implements
+    IAdtCrud<IPackageConfig, IPackageState> &
+      IAdtValidatable<IPackageConfig, IPackageState> &
+      IAdtCheckable<IPackageConfig, IPackageState> &
+      IAdtLockable<IPackageConfig, IPackageState> &
+      IAdtTransportAware<IPackageConfig, IPackageState>
+{
+```
+
+Mark the unsupported-capability stubs (`activate`/`getVersions`/… whichever the profile omits) `@deprecated`. Method bodies unchanged.
+
+- [ ] **Step 3: Build** — `npm run build:fast`, exit 0. Here the build MUST still pass: the class still HAS the extra throwing methods (they just are not in the declared type), which is legal — a class may have more members than its `implements` clause requires.
+- [ ] **Step 4: Full unit suite** — `... | tee /tmp/b3.log`, read it; all pass.
+- [ ] **Step 5: Commit** — `refactor(types): non-full handlers implement their honest capability composite`.
+
+---
+
+### Task B4: Narrow `AdtClient.getXxx()` return types
+
+**Files:** `src/clients/AdtClient.ts` (and `AdtClientLegacy.ts` if it re-declares any of these return types).
+
+**Interfaces:** Consumes the composites + atoms. Produces `AdtClient` factory methods whose declared return type is the handler's honest composite — so `client.getDomain().getVersions()` no longer type-checks.
+
+- [ ] **Step 1: For each in-scope factory method, narrow the return type to match the handler's `implements` clause.** Examples:
+
+```ts
+// full handler — was IAdtObject<...>, now IAdtSourceObject<...>
+getClass(): IAdtSourceObject<IClassConfig, IClassState> { return new AdtClass(...); }
+// non-versioned
+getDomain(): IAdtNonVersionedObject<IDomainConfig, IDomainState> { return new AdtDomain(...); }
+// inline profile
+getPackage(): IAdtCrud<IPackageConfig, IPackageState> & IAdtValidatable<...> & IAdtCheckable<...> & IAdtLockable<...> & IAdtTransportAware<...> { return new AdtPackage(...); }
+```
+
+Leave the deferred ones (`getRequest`, `getUnitTest`, `getCdsUnitTest`, `getServiceBinding`) returning their CURRENT type (`IAdtObject` / `IAdtServiceBinding`) unchanged.
+
+- [ ] **Step 2: Build** — `npm run build:fast`, exit 0.
+- [ ] **Step 3: Add a compile-time guard test** proving the narrowing bites. Create `src/__tests__/unit/clients/returnTypeNarrowing.test.ts`:
+
+```ts
+import { AdtClient } from '../../../clients/AdtClient';
+
+// Type-level only: @ts-expect-error asserts the call is a COMPILE error.
+// If the narrowing regressed, @ts-expect-error itself errors (unused).
+() => {
+  const c = null as unknown as AdtClient;
+  // domain has no version history — these must not type-check:
+  // @ts-expect-error getVersions is not on the narrowed getDomain() type
+  c.getDomain().getVersions({});
+  // @ts-expect-error getVersionSource is not on the narrowed getDomain() type
+  c.getDomain().getVersionSource('');
+  // a full handler still exposes versions (no error expected):
+  c.getClass().getVersions({});
+};
+
+it('return-type narrowing compiles as asserted', () => expect(true).toBe(true));
+```
+
+- [ ] **Step 4: Build + run the guard** — `npm run build:fast` (the `@ts-expect-error` lines are validated at compile time) then `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/clients/returnTypeNarrowing.test.ts --runInBand 2>&1 | tee /tmp/b4.log`, read it; passes.
+- [ ] **Step 5: Commit** — `feat(client)!: narrow getXxx() return types to honest capability composites`.
+
+---
+
+### Task B5: Surface verification + full suite + lint
+
+- [ ] **Step 1: Regenerate the surface** — `npm run build:fast && node _surface-snapshot.mjs > /tmp/surface-after.txt`.
+- [ ] **Step 2: Diff and CONFIRM the change is exactly the expected narrowing** — `diff /tmp/surface-before.txt /tmp/surface-after.txt | tee /tmp/surface-diff.txt`, read it. Expected: the diff shows the composites now referenced and the narrowed return types; it must NOT show any capability method vanishing from a handler that should still expose it, nor any unrelated export appearing/disappearing. If the diff contains anything beyond the intended narrowing, STOP and report.
+- [ ] **Step 3: Full unit suite** — `... | tee /tmp/b5-unit.log`, read it; all pass (prior count + the new narrowing guard).
+- [ ] **Step 4: Lint** — `npm run lint:check 2>&1 | tee /tmp/b5-lint.log`, read it; 0 errors, ≤ 45/25.
+- [ ] **Step 5: Commit** — `test(types): return-type narrowing guard; surface reflects honest capability sets`.
+
+---
+
+### Task B6: Version, changelog, PR
+
+- [ ] **Step 1: Ask the user for the version** — recommend **major 8.0.0** (return-type narrowing is a breaking API change, even though it only breaks always-throwing usage). Wait for confirmation.
+- [ ] **Step 2:** `npm version <chosen> --no-git-tag-version && npm install --package-lock-only`; confirm link:true 0.
+- [ ] **Step 3: CHANGELOG** — a `### Changed` (BREAKING) entry: handlers now declare honest capability sets; `AdtClient.getXxx()` return types narrowed so calling an unsupported capability (e.g. `getDomain().getVersions()`) is now a compile error instead of a runtime throw — this only breaks code that referenced methods that always threw. Deferred: ServiceBinding, Request, UnitTest/CdsUnitTest. Requires interfaces `^11.3.0`.
+- [ ] **Step 4: Commit, PR** — `git push -u origin feat/capability-type-honesty`; `gh pr create --base main --title "release(<chosen>): honest capability types (BREAKING)" --body "..."`. Report: PR ready for the user's external review; then merge + tag + GitHub release; **user publishes**.
+
+---
+
+### Task B7: Consumer coordination (after publish)
+
+- [ ] **Step 1:** After the user publishes `<chosen>` to npm, bump `~/prj/mcp-abap-adt`'s `@mcp-abap-adt/adt-clients` dep to it (from the registry), run its build, read the log. Expected: compiles clean. If the consumer referenced a now-narrowed capability (a call that always threw), it fails to compile HERE — that is the migration surfacing a latent bug; fix the consumer call site or report it. Do NOT use a local tarball; resolve from the registry only.
+
+---
+
+## Out of scope (future work)
+
+- **`AdtRequest`** — fix `update` (change description) and `delete` (empty requests only) per the domain truth, then give it its honest CRUD profile. See memory `reference_transport_request_update_delete`.
+- **`AdtUnitTest` / `AdtCdsUnitTest`** — reconsider the contract (test runner, not an object).
+- **`AdtServiceBinding`** — reconcile the widening `IAdtServiceBinding` with the atom composites.
+- **Removing** the deprecated `IAdtObject` and the throwing stubs — a later major, once consumers have migrated.
+- The activate/check error-envelope unification and further capability-implementation dedup — separate efforts.

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -299,7 +299,7 @@ export class AdtClass implements IAdtSourceObject<IClassConfig, IClassState> {
 
 Update the import: replace `IAdtObject` with `IAdtSourceObject` from `@mcp-abap-adt/interfaces` (drop the `IAdtObject` import if now unused). Do NOT touch method bodies. For the 4 class-include handlers that `extends AdtClass`, they inherit — change only if they independently declare `implements IAdtObject` (check each; most just `extends AdtClass`).
 
-Also update the sibling public alias in `src/core/<type>/index.ts` for each of the 22:
+Also update the sibling public alias in `src/core/<type>/index.ts` — but **only where one already exists**:
 ```ts
 // BEFORE
 export type AdtClassType = IAdtObject<IClassConfig, IClassState>;
@@ -307,6 +307,8 @@ export type AdtClassType = IAdtObject<IClassConfig, IClassState>;
 export type AdtClassType = IAdtSourceObject<IClassConfig, IClassState>;
 ```
 (import `IAdtSourceObject`, drop `IAdtObject` if now unused).
+
+**The 4 class-include handlers (LocalDefinitions, LocalMacros, LocalTestClass, LocalTypes) have NO `Adt*Type` alias** — `src/core/class/index.ts` exports only `AdtClassType`; the includes are exported as classes + config types. Do NOT add new `AdtLocal*Type` aliases — that would add exports and break B5's "export names unchanged" check. So the alias update is for the ~18 standalone full handlers that have one; the 4 includes get their honesty solely from the narrowed `AdtClient`/`AdtClientBatch` return types (and, since they `extends AdtClass`, they inherit its `implements` — change their own `implements` only if a class independently declares `implements IAdtObject`).
 
 - [ ] **Step 2: Build** — `npm run build:fast`, exit 0. Because `IAdtSourceObject ≡ IAdtObject`, all 22 still satisfy their declared type. A failure means a handler was NOT actually full (matrix disagreement) → STOP and report which.
 - [ ] **Step 3: Full unit suite** — `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b2.log`, read it; all pass.

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -31,22 +31,27 @@ From `node scripts/capability-matrix.mjs`, each handler's honest atom set. Two p
 
 **Named composite `IAdtNonVersionedObject<C,S>`** = the six atoms without `IAdtVersionable`. **3 handlers:** DataElement, Domain, FunctionGroup.
 
-**Inline-intersection handlers** (distinct profiles, declared inline):
+**Inline-list handlers** (distinct profiles). NOTE on syntax: a class's `implements`
+clause takes a **comma-separated list** of interfaces, NOT an intersection —
+`implements A & B` is a syntax error (TS1005). Use `implements A<...>, B<...>, ...`.
+(Intersections are only valid in a *type position* — e.g. the `AdtClient` return
+types in Task B4, and the `Adt<Type>Type` aliases, where `A & B` is fine.)
 
-| Handler | Honest composite (inline) | Missing vs full |
+| Handler | Honest capability set (implements A, B, …) | Missing vs full |
 |---|---|---|
-| FunctionInclude | Crud & Validatable & Checkable & Activatable & Lockable & Versionable | TransportAware |
-| AuthorizationField, FeatureToggle | Crud & Validatable & Checkable & Activatable & Lockable | Versionable, TransportAware |
-| Package | Crud & Validatable & Checkable & Lockable & TransportAware | Activatable, Versionable |
-| MessageClass | Crud & Validatable & Lockable | Checkable, Activatable, Versionable, TransportAware |
+| FunctionInclude | Crud, Validatable, Checkable, Activatable, Lockable, Versionable | TransportAware |
+| AuthorizationField | Crud, Validatable, Checkable, Activatable, Lockable | Versionable, TransportAware |
+| Package | Crud, Validatable, Checkable, Lockable, TransportAware | Activatable, Versionable |
+| MessageClass | Crud, Validatable, Lockable | Checkable, Activatable, Versionable, TransportAware |
 | MessageClassMessage | Crud | everything else |
 
-**Special / deferred (NOT in this migration):**
-- **ServiceBinding** — implements the widening `IAdtServiceBinding` (its own interface), not plain `IAdtObject`. Its honest atoms are Crud & Validatable & Checkable & Activatable & TransportAware (no Lockable/Versionable), but the widening interface needs its own reconciliation. **Deferred** to a follow-up.
+**Special / deferred (NOT in this migration) — all implement a widening interface or are wrong-contract:**
+- **ServiceBinding** — implements the widening `IAdtServiceBinding` (which `extends IAdtObject`), not plain `IAdtObject`. Reconciling the widening interface with the atoms is its own work. **Deferred.**
+- **FeatureToggle** — implements `IFeatureToggleObject`, which `extends IAdtObject<IFeatureToggleConfig, IFeatureToggleState>` (verified `node_modules/@mcp-abap-adt/interfaces/.../IAdtFeatureToggle.d.ts:103`). Same situation as ServiceBinding: the widening interface would have to be updated in interfaces to extend the honest atoms instead of `IAdtObject`. **Deferred.**
 - **Request (`AdtRequest`)** — matrix shows no complete atom; but its `update`/`delete` throws are DEFECTS, not domain limits: transport-request `update` = change the description, `delete` = only for empty requests (see memory `reference_transport_request_update_delete`). Honest profile requires fixing those first. **Deferred.**
 - **UnitTest (`AdtUnitTest`)** and **CdsUnitTest** (extends it) — a test runner, wrong contract entirely. **Deferred.**
 
-The 33 in-scope handlers are the 22 full + 3 non-versioned + 6 inline + MessageClass + MessageClassMessage.
+The **30 in-scope handlers** are the 22 full + 3 non-versioned + 5 inline (FunctionInclude, AuthorizationField, Package, MessageClass, MessageClassMessage). FeatureToggle moved to deferred.
 
 ---
 
@@ -59,6 +64,7 @@ The 33 in-scope handlers are the 22 full + 3 non-versioned + 6 inline + MessageC
 
 **Phase B — adt-clients:**
 - Modify each in-scope `src/core/<type>/Adt<Type>.ts` — swap the `implements` clause (class body otherwise unchanged; throwing stubs stay, marked `@deprecated`).
+- Modify each in-scope `src/core/<type>/index.ts` — the public `export type Adt<Type>Type = IAdtObject<IXxxConfig, IXxxState>;` alias must narrow to the same honest composite the handler now implements (consumers can use these aliases directly, so they must not keep exposing unsupported capabilities).
 - Modify `src/clients/AdtClient.ts` — narrow each in-scope `getXxx()` return type.
 - Modify `src/clients/AdtClientLegacy.ts` if it re-declares any narrowed return type.
 
@@ -251,7 +257,17 @@ Branch `feat/capability-type-honesty` off **main**.
 
 - [ ] **Step 1:** `git checkout main && git pull && git checkout -b feat/capability-type-honesty`; set `"@mcp-abap-adt/interfaces": "^11.3.0"`; `rm -rf node_modules/@mcp-abap-adt/interfaces && npm install @mcp-abap-adt/interfaces@11.3.0`; confirm `grep -c '"link": true' package-lock.json` = 0.
 - [ ] **Step 2:** `npm run build:fast` — exit 0.
-- [ ] **Step 3:** capture baseline: `node _surface-snapshot.mjs > /tmp/surface-before.txt && wc -l /tmp/surface-before.txt`. (Unlike the pilot, this migration WILL change the surface — the baseline is for the diff in B7 to confirm the change is EXACTLY the expected narrowing.)
+- [ ] **Step 3:** capture baseline. `_surface-snapshot.mjs` lives in the project root but is **git-excluded** (`.git/info/exclude`) — it will be absent on a fresh checkout. If `test -f _surface-snapshot.mjs` fails, recreate it first:
+
+```js
+import ts from 'typescript';
+const entries=['index','index.core','index.runtime','index.batch','index.ws','index.abapgit','index.executors'];
+const prog=ts.createProgram(entries.map(e=>`dist/${e}.d.ts`),{allowJs:true});
+const ch=prog.getTypeChecker();
+for(const e of entries){const sf=prog.getSourceFile(`dist/${e}.d.ts`);const s=sf&&ch.getSymbolAtLocation(sf);const names=s?ch.getExportsOfModule(s).map(x=>x.getName()).sort():[];console.log(`== ${e} ==`);console.log(names.join('\n'));}
+```
+
+Then: `node _surface-snapshot.mjs > /tmp/surface-before.txt && wc -l /tmp/surface-before.txt`. (Unlike the pilot, this migration WILL change the surface — the baseline is for the diff in B5 to confirm the change is EXACTLY the expected narrowing.)
 - [ ] **Step 4:** commit `package.json` + `package-lock.json` — `chore: consume @mcp-abap-adt/interfaces ^11.3.0 (pre-migration)`.
 
 ---
@@ -273,6 +289,15 @@ export class AdtClass implements IAdtSourceObject<IClassConfig, IClassState> {
 
 Update the import: replace `IAdtObject` with `IAdtSourceObject` from `@mcp-abap-adt/interfaces` (drop the `IAdtObject` import if now unused). Do NOT touch method bodies. For the 4 class-include handlers that `extends AdtClass`, they inherit — change only if they independently declare `implements IAdtObject` (check each; most just `extends AdtClass`).
 
+Also update the sibling public alias in `src/core/<type>/index.ts` for each of the 22:
+```ts
+// BEFORE
+export type AdtClassType = IAdtObject<IClassConfig, IClassState>;
+// AFTER
+export type AdtClassType = IAdtSourceObject<IClassConfig, IClassState>;
+```
+(import `IAdtSourceObject`, drop `IAdtObject` if now unused).
+
 - [ ] **Step 2: Build** — `npm run build:fast`, exit 0. Because `IAdtSourceObject ≡ IAdtObject`, all 22 still satisfy their declared type. A failure means a handler was NOT actually full (matrix disagreement) → STOP and report which.
 - [ ] **Step 3: Full unit suite** — `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit --runInBand 2>&1 | tee /tmp/b2.log`, read it; all pass.
 - [ ] **Step 4: Commit** — `refactor(types): 22 full handlers implement IAdtSourceObject`.
@@ -281,7 +306,7 @@ Update the import: replace `IAdtObject` with `IAdtSourceObject` from `@mcp-abap-
 
 ### Task B3: Switch the non-versioned + inline-profile handlers
 
-**Files:** DataElement, Domain, FunctionGroup (→ `IAdtNonVersionedObject`); FunctionInclude, AuthorizationField, FeatureToggle, Package, MessageClass, MessageClassMessage (→ inline intersections per the table above).
+**Files:** DataElement, Domain, FunctionGroup (→ `IAdtNonVersionedObject`); FunctionInclude, AuthorizationField, Package, MessageClass, MessageClassMessage (→ comma-separated implements per the table above). NOTE: FeatureToggle is NOT here — it is deferred (widening `IFeatureToggleObject`).
 
 **Interfaces:** Consumes `IAdtNonVersionedObject` + the seven atoms (for inline intersections). Produces handlers whose declared type omits the capabilities they lack — so their throwing stubs are no longer part of the declared contract.
 
@@ -294,11 +319,16 @@ getVersions(config: Partial<IDomainConfig>): Promise<IObjectVersion[]> {
 }
 ```
 
-- [ ] **Step 2: Inline-profile handlers.** For each, replace the implements clause with the inline intersection from the table, importing the needed atoms. Example (`AdtPackage.ts`):
+Also update each sibling alias in `src/core/<type>/index.ts`:
+```ts
+// AdtDomain/index.ts — BEFORE / AFTER
+export type AdtDomainType = IAdtNonVersionedObject<IDomainConfig, IDomainState>;
+```
+
+- [ ] **Step 2: Inline-list handlers.** For each (FunctionInclude, AuthorizationField, Package, MessageClass, MessageClassMessage), replace the implements clause with the **comma-separated list** from the table (NOT `&` — that is a syntax error in an `implements` clause). Example (`AdtPackage.ts`):
 
 ```ts
 import type {
-  IAdtActivatable, // still imported only if referenced elsewhere; else omit
   IAdtCheckable,
   IAdtCrud,
   IAdtLockable,
@@ -308,15 +338,27 @@ import type {
 
 export class AdtPackage
   implements
-    IAdtCrud<IPackageConfig, IPackageState> &
-      IAdtValidatable<IPackageConfig, IPackageState> &
-      IAdtCheckable<IPackageConfig, IPackageState> &
-      IAdtLockable<IPackageConfig, IPackageState> &
-      IAdtTransportAware<IPackageConfig, IPackageState>
+    IAdtCrud<IPackageConfig, IPackageState>,
+    IAdtValidatable<IPackageConfig, IPackageState>,
+    IAdtCheckable<IPackageConfig, IPackageState>,
+    IAdtLockable<IPackageConfig, IPackageState>,
+    IAdtTransportAware<IPackageConfig, IPackageState>
 {
 ```
 
 Mark the unsupported-capability stubs (`activate`/`getVersions`/… whichever the profile omits) `@deprecated`. Method bodies unchanged.
+
+Then update the sibling alias in `src/core/<type>/index.ts`. Here a **type position** — so an intersection `&` IS valid (and matches the AdtClient return type in B4):
+```ts
+// AdtPackage/index.ts — BEFORE
+export type AdtPackageType = IAdtObject<IPackageConfig, IPackageState>;
+// AFTER
+export type AdtPackageType = IAdtCrud<IPackageConfig, IPackageState> &
+  IAdtValidatable<IPackageConfig, IPackageState> &
+  IAdtCheckable<IPackageConfig, IPackageState> &
+  IAdtLockable<IPackageConfig, IPackageState> &
+  IAdtTransportAware<IPackageConfig, IPackageState>;
+```
 
 - [ ] **Step 3: Build** — `npm run build:fast`, exit 0. Here the build MUST still pass: the class still HAS the extra throwing methods (they just are not in the declared type), which is legal — a class may have more members than its `implements` clause requires.
 - [ ] **Step 4: Full unit suite** — `... | tee /tmp/b3.log`, read it; all pass.
@@ -341,7 +383,7 @@ getDomain(): IAdtNonVersionedObject<IDomainConfig, IDomainState> { return new Ad
 getPackage(): IAdtCrud<IPackageConfig, IPackageState> & IAdtValidatable<...> & IAdtCheckable<...> & IAdtLockable<...> & IAdtTransportAware<...> { return new AdtPackage(...); }
 ```
 
-Leave the deferred ones (`getRequest`, `getUnitTest`, `getCdsUnitTest`, `getServiceBinding`) returning their CURRENT type (`IAdtObject` / `IAdtServiceBinding`) unchanged.
+Leave the deferred ones (`getRequest`, `getUnitTest`, `getCdsUnitTest`, `getServiceBinding`, `getFeatureToggle`) returning their CURRENT type (`IAdtObject` / `IAdtServiceBinding` / `IFeatureToggleObject`) unchanged.
 
 - [ ] **Step 2: Build** — `npm run build:fast`, exit 0.
 - [ ] **Step 3: Add a compile-time guard test** proving the narrowing bites. Create `src/__tests__/unit/clients/returnTypeNarrowing.test.ts`:

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -360,7 +360,7 @@ export class AdtPackage
 
 Mark the unsupported-capability stubs (`activate`/`getVersions`/… whichever the profile omits) `@deprecated`. Method bodies unchanged.
 
-Then update the sibling alias in `src/core/<type>/index.ts`. Here a **type position** — so an intersection `&` IS valid (and matches the AdtClient return type in B4):
+Then update the sibling alias in `src/core/<type>/index.ts` — **only where one already exists.** A type position, so an intersection `&` IS valid (and matches the AdtClient return type in B4):
 ```ts
 // AdtPackage/index.ts — BEFORE
 export type AdtPackageType = IAdtObject<IPackageConfig, IPackageState>;
@@ -371,6 +371,8 @@ export type AdtPackageType = IAdtCrud<IPackageConfig, IPackageState> &
   IAdtLockable<IPackageConfig, IPackageState> &
   IAdtTransportAware<IPackageConfig, IPackageState>;
 ```
+
+Alias presence among the 5 inline handlers (verified): **Package, MessageClass, MessageClassMessage HAVE** an alias (update it); **FunctionInclude and AuthorizationField have NONE** — do NOT add one (it would add an export and break B5's export-names-unchanged check). Those two get their honesty from the `implements` clause plus the narrowed `AdtClient`/`AdtClientBatch` return types.
 
 - [ ] **Step 3: Build** — `npm run build:fast`, exit 0. Here the build MUST still pass: the class still HAS the extra throwing methods (they just are not in the declared type), which is legal — a class may have more members than its `implements` clause requires.
 - [ ] **Step 4: Full unit suite** — `... | tee /tmp/b3.log`, read it; all pass.

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -64,7 +64,7 @@ The **30 in-scope handlers** are the 22 full + 3 non-versioned + 5 inline (Funct
 
 **Phase B — adt-clients:**
 - Modify each in-scope `src/core/<type>/Adt<Type>.ts` — swap the `implements` clause (class body otherwise unchanged; throwing stubs stay, marked `@deprecated`).
-- Modify each in-scope `src/core/<type>/index.ts` — the public `export type Adt<Type>Type = IAdtObject<IXxxConfig, IXxxState>;` alias must narrow to the same honest composite the handler now implements (consumers can use these aliases directly, so they must not keep exposing unsupported capabilities).
+- Modify `src/core/<type>/index.ts` **where an `export type Adt<Type>Type = IAdtObject<...>` alias already exists** (most standalone handlers; NOT the 4 class-includes, NOT FunctionInclude/AuthorizationField) — narrow it to the same honest composite the handler now implements. Do NOT add new aliases (that changes the export-name surface). Handlers without an alias get their honesty from the class `implements` + the narrowed `AdtClient`/`AdtClientBatch` return types.
 - Modify `src/clients/AdtClient.ts` — narrow each in-scope `getXxx()` return type.
 - Modify `src/clients/AdtClientLegacy.ts` if it re-declares any narrowed return type.
 

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -434,14 +434,15 @@ node _surface-snapshot.mjs > /tmp/surface-after.txt
 find dist -name '*.d.ts' | sort | while read f; do echo "=== $f ==="; cat "$f"; done > /tmp/decl-after.txt
 ```
 - [ ] **Step 2a: Export names unchanged** — `diff /tmp/surface-before.txt /tmp/surface-after.txt`, read it. Expected: **EMPTY** — this migration narrows signatures, it does not add or remove any exported symbol. A non-empty name diff means something was unexpectedly added/removed → STOP and report.
-- [ ] **Step 2b: Declaration surface — exactly the intended narrowing** — `diff /tmp/decl-before.txt /tmp/decl-after.txt | tee /tmp/decl-diff.txt`, read the WHOLE file. This is the load-bearing check: every changed line must be one of
-  - (a) an `AdtClient`/`AdtClientLegacy` `getXxx()` return type changing from `IAdtObject<...>` to the handler's honest composite;
-  - (b) **`dist/batch/AdtClientBatch.d.ts`** `getXxx()` return types changing the same way — `AdtClientBatch.getXxx()` is `return this.innerClient.getXxx()` with **no explicit return type**, so its inferred type follows `AdtClient` and its `.d.ts` narrows automatically (it is a public `./batch` entrypoint, so this IS part of the intended surface change — no code change to AdtClientBatch itself);
-  - (c) an `Adt<Type>Type` alias changing from `IAdtObject<...>` to the honest composite;
-  - (d) an added `IAdtSourceObject`/`IAdtNonVersionedObject`/atom import in a `.d.ts`;
-  - (e) a **handler class declaration's `implements` clause** changing — `.d.ts` emits it, so `dist/core/<type>/Adt<Type>.d.ts` will show `export declare class AdtDomain implements IAdtObject<...>` → `implements IAdtNonVersionedObject<...>` (or the comma-separated atom list for inline handlers). This is the source change from B2/B3 surfacing in the declarations — expected.
+- [ ] **Step 2b: Declaration surface — exactly the intended narrowing** — `diff /tmp/decl-before.txt /tmp/decl-after.txt | tee /tmp/decl-diff.txt`, read the WHOLE file. This is the load-bearing check. Rather than enumerate every file, apply ONE **pattern** — every changed line must be one of:
 
-  There must be **no** change to any handler's own **method signatures** (only the `implements` clause on the class line may change; the members below it stay identical), and **no** `getXxx()` for a deferred handler (getRequest/getUnitTest/getCdsUnitTest/getServiceBinding/getFeatureToggle) changing — in `AdtClient` OR `AdtClientBatch`. Anything else in the diff → STOP and report.
+  1. **A `IAdtObject<C,S>` reference replaced by the honest composite** for that config/state pair — the honest composite being `IAdtSourceObject`, `IAdtNonVersionedObject`, or the inline atom intersection. This is the ONLY substantive change, and it appears in exactly these forms wherever `IAdtObject` was written or inferred:
+     - a handler class line: `declare class AdtX implements IAdtObject<...>` → `implements <composite>` (`.d.ts` emits the `implements` clause);
+     - an `AdtClient`/`AdtClientLegacy`/`AdtClientBatch` `getXxx(): IAdtObject<...>` return type → `<composite>` (AdtClientBatch's is inferred from `innerClient`, so it narrows with no source change);
+     - an `Adt<Type>Type = IAdtObject<...>` alias → `<composite>`.
+  2. **An added `import` of `IAdtSourceObject`/`IAdtNonVersionedObject`/an atom** in a `.d.ts` (and a dropped `IAdtObject` import).
+
+  STOP and report if the diff contains ANYTHING else — in particular: any change to a **member/method signature** (the lines *inside* a class body must be byte-identical; only the class's `implements` line may change), or any narrowing of a **deferred** handler (`getFeatureToggle`/`getServiceBinding`/`getRequest`/`getUnitTest`/`getCdsUnitTest`, and the `AdtRequest`/`AdtUnitTest`/`AdtCdsUnitTest`/`AdtServiceBinding`/`AdtFeatureToggle` class lines + their aliases), which must still read `IAdtObject`/`IAdtServiceBinding`/`IFeatureToggleObject`.
 - [ ] **Step 3: Full unit suite** — `... | tee /tmp/b5-unit.log`, read it; all pass (prior count + the new narrowing guard).
 - [ ] **Step 4: Lint** — `npm run lint:check 2>&1 | tee /tmp/b5-lint.log`, read it; 0 errors, ≤ 45/25.
 - [ ] **Step 5: Commit** — `test(types): return-type narrowing guard; surface reflects honest capability sets`.

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -438,9 +438,10 @@ find dist -name '*.d.ts' | sort | while read f; do echo "=== $f ==="; cat "$f"; 
   - (a) an `AdtClient`/`AdtClientLegacy` `getXxx()` return type changing from `IAdtObject<...>` to the handler's honest composite;
   - (b) **`dist/batch/AdtClientBatch.d.ts`** `getXxx()` return types changing the same way — `AdtClientBatch.getXxx()` is `return this.innerClient.getXxx()` with **no explicit return type**, so its inferred type follows `AdtClient` and its `.d.ts` narrows automatically (it is a public `./batch` entrypoint, so this IS part of the intended surface change — no code change to AdtClientBatch itself);
   - (c) an `Adt<Type>Type` alias changing from `IAdtObject<...>` to the honest composite;
-  - (d) an added `IAdtSourceObject`/`IAdtNonVersionedObject`/atom import in a `.d.ts`.
+  - (d) an added `IAdtSourceObject`/`IAdtNonVersionedObject`/atom import in a `.d.ts`;
+  - (e) a **handler class declaration's `implements` clause** changing — `.d.ts` emits it, so `dist/core/<type>/Adt<Type>.d.ts` will show `export declare class AdtDomain implements IAdtObject<...>` → `implements IAdtNonVersionedObject<...>` (or the comma-separated atom list for inline handlers). This is the source change from B2/B3 surfacing in the declarations — expected.
 
-  There must be **no** change to any handler's own method signatures, and **no** `getXxx()` for a deferred handler (getRequest/getUnitTest/getCdsUnitTest/getServiceBinding/getFeatureToggle) changing — in `AdtClient` OR `AdtClientBatch`. Anything else in the diff → STOP and report.
+  There must be **no** change to any handler's own **method signatures** (only the `implements` clause on the class line may change; the members below it stay identical), and **no** `getXxx()` for a deferred handler (getRequest/getUnitTest/getCdsUnitTest/getServiceBinding/getFeatureToggle) changing — in `AdtClient` OR `AdtClientBatch`. Anything else in the diff → STOP and report.
 - [ ] **Step 3: Full unit suite** — `... | tee /tmp/b5-unit.log`, read it; all pass (prior count + the new narrowing guard).
 - [ ] **Step 4: Lint** — `npm run lint:check 2>&1 | tee /tmp/b5-lint.log`, read it; 0 errors, ≤ 45/25.
 - [ ] **Step 5: Commit** — `test(types): return-type narrowing guard; surface reflects honest capability sets`.

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -267,7 +267,17 @@ const ch=prog.getTypeChecker();
 for(const e of entries){const sf=prog.getSourceFile(`dist/${e}.d.ts`);const s=sf&&ch.getSymbolAtLocation(sf);const names=s?ch.getExportsOfModule(s).map(x=>x.getName()).sort():[];console.log(`== ${e} ==`);console.log(names.join('\n'));}
 ```
 
-Then: `node _surface-snapshot.mjs > /tmp/surface-before.txt && wc -l /tmp/surface-before.txt`. (Unlike the pilot, this migration WILL change the surface — the baseline is for the diff in B5 to confirm the change is EXACTLY the expected narrowing.)
+Capture TWO baselines:
+
+1. **Export-name snapshot** (sanity — nothing should be added/removed): `node _surface-snapshot.mjs > /tmp/surface-before.txt`. This lists exported symbol *names* only.
+2. **Declaration-surface baseline** (the one that matters — this migration changes SIGNATURES, not names, so a name diff would be empty). Concatenate every emitted `.d.ts` with its path so the diff has context:
+
+```bash
+find dist -name '*.d.ts' | sort | while read f; do echo "=== $f ==="; cat "$f"; done > /tmp/decl-before.txt
+wc -l /tmp/surface-before.txt /tmp/decl-before.txt
+```
+
+`/tmp/decl-before.txt` contains the actual `.d.ts` signatures — `AdtClient.getDomain(): IAdtObject<...>`, `AdtDomainType = IAdtObject<...>`, etc. B5 diffs this to prove the return types and aliases narrowed exactly as intended. (`dist/` is gitignored, so we snapshot to `/tmp`, not git.)
 - [ ] **Step 4:** commit `package.json` + `package-lock.json` — `chore: consume @mcp-abap-adt/interfaces ^11.3.0 (pre-migration)`.
 
 ---
@@ -407,15 +417,20 @@ import { AdtClient } from '../../../clients/AdtClient';
 it('return-type narrowing compiles as asserted', () => expect(true).toBe(true));
 ```
 
-- [ ] **Step 4: Build + run the guard** — `npm run build:fast` (the `@ts-expect-error` lines are validated at compile time) then `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/clients/returnTypeNarrowing.test.ts --runInBand 2>&1 | tee /tmp/b4.log`, read it; passes.
+- [ ] **Step 4: Type-check the guard, then run it.** `build:fast` (`tsc -p tsconfig.json`) EXCLUDES `src/__tests__/**`, so it does NOT validate the `@ts-expect-error` lines. Use the test tsconfig: `npm run test:check 2>&1 | tee /tmp/b4-check.log`, read it — exit 0 means every `@ts-expect-error` matched a real error (if the narrowing regressed, an `@ts-expect-error` with no error becomes `TS2578: Unused '@ts-expect-error'` and this fails). Then run it: `MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/clients/returnTypeNarrowing.test.ts --runInBand 2>&1 | tee /tmp/b4.log`, read it; passes.
 - [ ] **Step 5: Commit** — `feat(client)!: narrow getXxx() return types to honest capability composites`.
 
 ---
 
-### Task B5: Surface verification + full suite + lint
+### Task B5: Declaration-surface verification + full suite + lint
 
-- [ ] **Step 1: Regenerate the surface** — `npm run build:fast && node _surface-snapshot.mjs > /tmp/surface-after.txt`.
-- [ ] **Step 2: Diff and CONFIRM the change is exactly the expected narrowing** — `diff /tmp/surface-before.txt /tmp/surface-after.txt | tee /tmp/surface-diff.txt`, read it. Expected: the diff shows the composites now referenced and the narrowed return types; it must NOT show any capability method vanishing from a handler that should still expose it, nor any unrelated export appearing/disappearing. If the diff contains anything beyond the intended narrowing, STOP and report.
+- [ ] **Step 1: Regenerate both surfaces** — `npm run build:fast` then:
+```bash
+node _surface-snapshot.mjs > /tmp/surface-after.txt
+find dist -name '*.d.ts' | sort | while read f; do echo "=== $f ==="; cat "$f"; done > /tmp/decl-after.txt
+```
+- [ ] **Step 2a: Export names unchanged** — `diff /tmp/surface-before.txt /tmp/surface-after.txt`, read it. Expected: **EMPTY** — this migration narrows signatures, it does not add or remove any exported symbol. A non-empty name diff means something was unexpectedly added/removed → STOP and report.
+- [ ] **Step 2b: Declaration surface — exactly the intended narrowing** — `diff /tmp/decl-before.txt /tmp/decl-after.txt | tee /tmp/decl-diff.txt`, read the WHOLE file. This is the load-bearing check: every changed line must be one of (a) an `AdtClient`/`AdtClientLegacy` `getXxx()` return type changing from `IAdtObject<...>` to the handler's honest composite, or (b) an `Adt<Type>Type` alias changing the same way, or (c) an added `IAdtSourceObject`/`IAdtNonVersionedObject`/atom import in a `.d.ts`. There must be **no** change to any handler's own method signatures, and **no** `getXxx()` for a deferred handler (getRequest/getUnitTest/getCdsUnitTest/getServiceBinding/getFeatureToggle) changing. Anything else in the diff → STOP and report.
 - [ ] **Step 3: Full unit suite** — `... | tee /tmp/b5-unit.log`, read it; all pass (prior count + the new narrowing guard).
 - [ ] **Step 4: Lint** — `npm run lint:check 2>&1 | tee /tmp/b5-lint.log`, read it; 0 errors, ≤ 45/25.
 - [ ] **Step 5: Commit** — `test(types): return-type narrowing guard; surface reflects honest capability sets`.

--- a/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
+++ b/docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md
@@ -430,7 +430,13 @@ node _surface-snapshot.mjs > /tmp/surface-after.txt
 find dist -name '*.d.ts' | sort | while read f; do echo "=== $f ==="; cat "$f"; done > /tmp/decl-after.txt
 ```
 - [ ] **Step 2a: Export names unchanged** — `diff /tmp/surface-before.txt /tmp/surface-after.txt`, read it. Expected: **EMPTY** — this migration narrows signatures, it does not add or remove any exported symbol. A non-empty name diff means something was unexpectedly added/removed → STOP and report.
-- [ ] **Step 2b: Declaration surface — exactly the intended narrowing** — `diff /tmp/decl-before.txt /tmp/decl-after.txt | tee /tmp/decl-diff.txt`, read the WHOLE file. This is the load-bearing check: every changed line must be one of (a) an `AdtClient`/`AdtClientLegacy` `getXxx()` return type changing from `IAdtObject<...>` to the handler's honest composite, or (b) an `Adt<Type>Type` alias changing the same way, or (c) an added `IAdtSourceObject`/`IAdtNonVersionedObject`/atom import in a `.d.ts`. There must be **no** change to any handler's own method signatures, and **no** `getXxx()` for a deferred handler (getRequest/getUnitTest/getCdsUnitTest/getServiceBinding/getFeatureToggle) changing. Anything else in the diff → STOP and report.
+- [ ] **Step 2b: Declaration surface — exactly the intended narrowing** — `diff /tmp/decl-before.txt /tmp/decl-after.txt | tee /tmp/decl-diff.txt`, read the WHOLE file. This is the load-bearing check: every changed line must be one of
+  - (a) an `AdtClient`/`AdtClientLegacy` `getXxx()` return type changing from `IAdtObject<...>` to the handler's honest composite;
+  - (b) **`dist/batch/AdtClientBatch.d.ts`** `getXxx()` return types changing the same way — `AdtClientBatch.getXxx()` is `return this.innerClient.getXxx()` with **no explicit return type**, so its inferred type follows `AdtClient` and its `.d.ts` narrows automatically (it is a public `./batch` entrypoint, so this IS part of the intended surface change — no code change to AdtClientBatch itself);
+  - (c) an `Adt<Type>Type` alias changing from `IAdtObject<...>` to the honest composite;
+  - (d) an added `IAdtSourceObject`/`IAdtNonVersionedObject`/atom import in a `.d.ts`.
+
+  There must be **no** change to any handler's own method signatures, and **no** `getXxx()` for a deferred handler (getRequest/getUnitTest/getCdsUnitTest/getServiceBinding/getFeatureToggle) changing — in `AdtClient` OR `AdtClientBatch`. Anything else in the diff → STOP and report.
 - [ ] **Step 3: Full unit suite** — `... | tee /tmp/b5-unit.log`, read it; all pass (prior count + the new narrowing guard).
 - [ ] **Step 4: Lint** — `npm run lint:check 2>&1 | tee /tmp/b5-lint.log`, read it; 0 errors, ≤ 45/25.
 - [ ] **Step 5: Commit** — `test(types): return-type narrowing guard; surface reflects honest capability sets`.
@@ -441,7 +447,7 @@ find dist -name '*.d.ts' | sort | while read f; do echo "=== $f ==="; cat "$f"; 
 
 - [ ] **Step 1: Ask the user for the version** — recommend **major 8.0.0** (return-type narrowing is a breaking API change, even though it only breaks always-throwing usage). Wait for confirmation.
 - [ ] **Step 2:** `npm version <chosen> --no-git-tag-version && npm install --package-lock-only`; confirm link:true 0.
-- [ ] **Step 3: CHANGELOG** — a `### Changed` (BREAKING) entry: handlers now declare honest capability sets; `AdtClient.getXxx()` return types narrowed so calling an unsupported capability (e.g. `getDomain().getVersions()`) is now a compile error instead of a runtime throw — this only breaks code that referenced methods that always threw. Deferred: ServiceBinding, Request, UnitTest/CdsUnitTest. Requires interfaces `^11.3.0`.
+- [ ] **Step 3: CHANGELOG** — a `### Changed` (BREAKING) entry: handlers now declare honest capability sets; `AdtClient.getXxx()` (and, by inference, `AdtClientBatch.getXxx()`) return types narrowed so calling an unsupported capability (e.g. `getDomain().getVersions()`) is now a compile error instead of a runtime throw — this only breaks code that referenced methods that always threw. **Still wide (deferred, unchanged this release): `getFeatureToggle`, `getServiceBinding`, `getRequest`, `getUnitTest`, `getCdsUnitTest`** — these implement widening interfaces or are wrong-contract and will be narrowed in a follow-up. Requires interfaces `^11.3.0`.
 - [ ] **Step 4: Commit, PR** — `git push -u origin feat/capability-type-honesty`; `gh pr create --base main --title "release(<chosen>): honest capability types (BREAKING)" --body "..."`. Report: PR ready for the user's external review; then merge + tag + GitHub release; **user publishes**.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.6.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^11.2.0",
+        "@mcp-abap-adt/interfaces": "^11.3.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -1551,9 +1551,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.2.0.tgz",
-      "integrity": "sha512-/ZQ1XwYnheefhe8FNZwLPjeyP7yjLG+tqB3Tv6pWH90zNovhgwB1mxEO59tzvCB0m43xM416Tech7Tfov0CyUA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-11.3.0.tgz",
+      "integrity": "sha512-4KFONd3n1JE+NdXZkuGw7XdXgj5vwHQPtGmQCNE2fwlbb5zMKmThuKFn/fGikBhk2CKiLYtaNOuad3u3pYQKLA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.6.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "7.6.0",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "7.6.0",
+  "version": "8.0.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^11.2.0",
+    "@mcp-abap-adt/interfaces": "^11.3.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.18.1",
     "fast-xml-parser": "^5.9.3"

--- a/scripts/capability-matrix.mjs
+++ b/scripts/capability-matrix.mjs
@@ -67,10 +67,17 @@ function refuses(body, sf) {
 function worksDirectly(body, sf) {
   if (!body) return false;
   const text = body.getText(sf);
+  // Delegation to a composed member's method — `this.<field>.<method>(...)`,
+  // e.g. `this.versionsCap.getVersions(config)` or `this.class.lock(...)` — is
+  // real work. Exclude `this.logger.*` so a stub that only logs is not counted.
+  const delegatesToMember = [...text.matchAll(/\bthis\.(\w+)\.\w+\s*\(/g)].some(
+    (m) => m[1] !== 'logger',
+  );
   return (
     /\bmakeAdtRequest\b/.test(text) ||
     /\bawait\b/.test(text) ||
-    /\bthis\.connection\b/.test(text)
+    /\bthis\.connection\b/.test(text) ||
+    delegatesToMember
   );
 }
 

--- a/src/__tests__/integration/core/authorizationField/AuthorizationField.test.ts
+++ b/src/__tests__/integration/core/authorizationField/AuthorizationField.test.ts
@@ -13,9 +13,17 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import type {
+  IAbapConnection,
+  IAdtObject,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../../clients/AdtClient';
+import type {
+  IAuthorizationFieldConfig,
+  IAuthorizationFieldState,
+} from '../../../../core/authorizationField';
 import { readAuthorizationField } from '../../../../core/authorizationField/read';
 import { isCloudEnvironment } from '../../../../utils/systemInfo';
 import { BaseTester } from '../../../helpers/BaseTester';
@@ -289,7 +297,13 @@ describe('AuthorizationField (using AdtClient)', () => {
         const config = buildConfig(testCase, resolver);
 
         const tester = new BaseTester(
-          client.getAuthorizationField(),
+          // getAuthorizationField() is narrowed to Crud & Validatable &
+          // Checkable & Activatable & Lockable (no readTransport/
+          // getVersions/getVersionSource); cast through the full interface.
+          client.getAuthorizationField() as unknown as IAdtObject<
+            IAuthorizationFieldConfig,
+            IAuthorizationFieldState
+          >,
           'AuthorizationField',
           'create_authorization_field',
           'adt_authorization_field',

--- a/src/__tests__/integration/core/dataElement/DataElement.test.ts
+++ b/src/__tests__/integration/core/dataElement/DataElement.test.ts
@@ -13,9 +13,17 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import type {
+  IAbapConnection,
+  IAdtObject,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../../clients/AdtClient';
+import type {
+  IDataElementConfig,
+  IDataElementState,
+} from '../../../../core/dataElement';
 import { getDataElement } from '../../../../core/dataElement/read';
 import { isCloudEnvironment } from '../../../../utils/systemInfo';
 import { BaseTester } from '../../../helpers/BaseTester';
@@ -367,7 +375,13 @@ describe('DataElement (using AdtClient)', () => {
 
         // Create BaseTester instance
         const tester = new BaseTester(
-          client.getDataElement(),
+          // getDataElement() is narrowed to IAdtNonVersionedObject (no
+          // getVersions/getVersionSource); BaseTester's generic type still
+          // requires the full interface — cast through it.
+          client.getDataElement() as unknown as IAdtObject<
+            IDataElementConfig,
+            IDataElementState
+          >,
           'DataElement',
           'create_data_element',
           'adt_data_element',
@@ -460,7 +474,12 @@ describe('DataElement (using AdtClient)', () => {
         try {
           // Create BaseTester instance
           const tester = new BaseTester(
-            client.getDataElement(),
+            // getDataElement() is narrowed to IAdtNonVersionedObject (no
+            // getVersions/getVersionSource); cast through the full interface.
+            client.getDataElement() as unknown as IAdtObject<
+              IDataElementConfig,
+              IDataElementState
+            >,
             'DataElement',
             'create_data_element',
             'adt_data_element',

--- a/src/__tests__/integration/core/domain/Domain.test.ts
+++ b/src/__tests__/integration/core/domain/Domain.test.ts
@@ -13,7 +13,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import type {
+  IAbapConnection,
+  IAdtObject,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../../clients/AdtClient';
 import type { IDomainConfig, IDomainState } from '../../../../core/domain';
@@ -85,7 +89,12 @@ describe('Domain (using AdtClient)', () => {
       hasConfig = true;
 
       tester = new BaseTester(
-        client.getDomain(),
+        // getDomain() is narrowed to IAdtNonVersionedObject (no
+        // getVersions/getVersionSource); cast through the full interface.
+        client.getDomain() as unknown as IAdtObject<
+          IDomainConfig,
+          IDomainState
+        >,
         'Domain',
         'create_domain',
         'adt_domain',

--- a/src/__tests__/integration/core/functionGroup/FunctionGroup.test.ts
+++ b/src/__tests__/integration/core/functionGroup/FunctionGroup.test.ts
@@ -13,7 +13,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import type {
+  IAbapConnection,
+  IAdtObject,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../../clients/AdtClient';
 import type {
@@ -88,7 +92,12 @@ describe('FunctionGroup (using AdtClient)', () => {
       hasConfig = true;
 
       tester = new BaseTester(
-        client.getFunctionGroup(),
+        // getFunctionGroup() is narrowed to IAdtNonVersionedObject (no
+        // getVersions/getVersionSource); cast through the full interface.
+        client.getFunctionGroup() as unknown as IAdtObject<
+          IFunctionGroupConfig,
+          IFunctionGroupState
+        >,
         'FunctionGroup',
         'create_function_group',
         'adt_function_group',

--- a/src/__tests__/integration/core/functionInclude/FunctionInclude.test.ts
+++ b/src/__tests__/integration/core/functionInclude/FunctionInclude.test.ts
@@ -13,7 +13,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import type {
+  IAbapConnection,
+  IAdtObject,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../../clients/AdtClient';
 import type {
@@ -80,7 +84,12 @@ describe('FunctionInclude (using AdtClient)', () => {
       hasConfig = true;
 
       tester = new BaseTester<IFunctionIncludeConfig, IFunctionIncludeState>(
-        client.getFunctionInclude(),
+        // getFunctionInclude() is narrowed to its honest capability composite
+        // (no readTransport); cast through the full interface.
+        client.getFunctionInclude() as unknown as IAdtObject<
+          IFunctionIncludeConfig,
+          IFunctionIncludeState
+        >,
         'FunctionInclude',
         'create_function_include',
         'adt_function_include',

--- a/src/__tests__/integration/core/messageClass/messageClass.test.ts
+++ b/src/__tests__/integration/core/messageClass/messageClass.test.ts
@@ -18,7 +18,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import type {
+  IAbapConnection,
+  IAdtObject,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../../clients/AdtClient';
 import type {
@@ -97,7 +101,14 @@ describe('MessageClass (using AdtClient)', () => {
       hasConfig = true;
 
       tester = new BaseTester(
-        client.getMessageClass(),
+        // getMessageClass() is narrowed to Crud & Validatable & Lockable
+        // (no activate/check/readTransport/getVersions); BaseTester's
+        // flowTest still exercises activate/check, which the concrete
+        // handler implements at runtime — cast through the full interface.
+        client.getMessageClass() as unknown as IAdtObject<
+          IMessageClassConfig,
+          IMessageClassState
+        >,
         'MessageClass',
         'create_message_class',
         'adt_message_class',

--- a/src/__tests__/integration/core/package/Package.test.ts
+++ b/src/__tests__/integration/core/package/Package.test.ts
@@ -9,7 +9,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { createAbapConnection } from '@mcp-abap-adt/connection';
-import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
+import type {
+  IAbapConnection,
+  IAdtObject,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../../clients/AdtClient';
 import type { IPackageConfig, IPackageState } from '../../../../core/package';
@@ -90,7 +94,14 @@ describe('Package (using AdtClient)', () => {
       hasConfig = true;
 
       tester = new BaseTester(
-        client.getPackage(),
+        // getPackage() is narrowed to Crud & Validatable & Checkable &
+        // Lockable & TransportAware (no activate/getVersions); BaseTester's
+        // flowTest still exercises activate, which the concrete handler
+        // implements at runtime — cast through the full interface.
+        client.getPackage() as unknown as IAdtObject<
+          IPackageConfig,
+          IPackageState
+        >,
         'Package',
         'create_package',
         'adt_package',

--- a/src/__tests__/unit/clients/returnTypeNarrowing.test.ts
+++ b/src/__tests__/unit/clients/returnTypeNarrowing.test.ts
@@ -1,0 +1,16 @@
+import type { AdtClient } from '../../../clients/AdtClient';
+
+// Type-level only: @ts-expect-error asserts the call is a COMPILE error.
+// If the narrowing regressed, @ts-expect-error itself errors (unused).
+() => {
+  const c = null as unknown as AdtClient;
+  // domain has no version history — these must not type-check:
+  // @ts-expect-error getVersions is not on the narrowed getDomain() type
+  c.getDomain().getVersions({});
+  // @ts-expect-error getVersionSource is not on the narrowed getDomain() type
+  c.getDomain().getVersionSource('');
+  // a full handler still exposes versions (no error expected):
+  c.getClass().getVersions({});
+};
+
+it('return-type narrowing compiles as asserted', () => expect(true).toBe(true));

--- a/src/clients/AdtClient.ts
+++ b/src/clients/AdtClient.ts
@@ -15,7 +15,16 @@
 
 import type {
   IAbapConnection,
+  IAdtActivatable,
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
+  IAdtNonVersionedObject,
   IAdtObject,
+  IAdtSourceObject,
+  IAdtTransportAware,
+  IAdtValidatable,
+  IAdtVersionable,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import {
@@ -239,7 +248,7 @@ export class AdtClient {
    * Get high-level operations for Class objects
    * @returns IAdtObject instance for Class operations
    */
-  getClass(): IAdtObject<IClassConfig, IClassState> {
+  getClass(): IAdtSourceObject<IClassConfig, IClassState> {
     return new AdtClass(
       this.connection,
       this.logger,
@@ -253,7 +262,7 @@ export class AdtClient {
    * Get high-level operations for Program objects
    * @returns IAdtObject instance for Program operations
    */
-  getProgram(): IAdtObject<IProgramConfig, IProgramState> {
+  getProgram(): IAdtSourceObject<IProgramConfig, IProgramState> {
     return new AdtProgram(
       this.connection,
       this.logger,
@@ -267,7 +276,7 @@ export class AdtClient {
    * Get high-level operations for Interface objects
    * @returns IAdtObject instance for Interface operations
    */
-  getInterface(): IAdtObject<IInterfaceConfig, IInterfaceState> {
+  getInterface(): IAdtSourceObject<IInterfaceConfig, IInterfaceState> {
     return new AdtInterface(
       this.connection,
       this.logger,
@@ -281,7 +290,7 @@ export class AdtClient {
    * Get high-level operations for Domain objects
    * @returns IAdtObject instance for Domain operations
    */
-  getDomain(): IAdtObject<IDomainConfig, IDomainState> {
+  getDomain(): IAdtNonVersionedObject<IDomainConfig, IDomainState> {
     return new AdtDomain(
       this.connection,
       this.logger,
@@ -338,7 +347,10 @@ export class AdtClient {
    * Get high-level operations for DataElement objects
    * @returns IAdtObject instance for DataElement operations
    */
-  getDataElement(): IAdtObject<IDataElementConfig, IDataElementState> {
+  getDataElement(): IAdtNonVersionedObject<
+    IDataElementConfig,
+    IDataElementState
+  > {
     return new AdtDataElement(
       this.connection,
       this.logger,
@@ -351,10 +363,14 @@ export class AdtClient {
    * Get high-level operations for AuthorizationField objects
    * @returns IAdtObject instance for AuthorizationField operations
    */
-  getAuthorizationField(): IAdtObject<
+  getAuthorizationField(): IAdtCrud<
     IAuthorizationFieldConfig,
     IAuthorizationFieldState
-  > {
+  > &
+    IAdtValidatable<IAuthorizationFieldConfig, IAuthorizationFieldState> &
+    IAdtCheckable<IAuthorizationFieldConfig, IAuthorizationFieldState> &
+    IAdtActivatable<IAuthorizationFieldConfig, IAuthorizationFieldState> &
+    IAdtLockable<IAuthorizationFieldConfig, IAuthorizationFieldState> {
     return new AdtAuthorizationField(
       this.connection,
       this.logger,
@@ -367,7 +383,7 @@ export class AdtClient {
    * Get high-level operations for Structure objects
    * @returns IAdtObject instance for Structure operations
    */
-  getStructure(): IAdtObject<IStructureConfig, IStructureState> {
+  getStructure(): IAdtSourceObject<IStructureConfig, IStructureState> {
     return new AdtStructure(
       this.connection,
       this.logger,
@@ -380,7 +396,7 @@ export class AdtClient {
    * Get high-level operations for Table objects
    * @returns IAdtObject instance for Table operations
    */
-  getTable(): IAdtObject<ITableConfig, ITableState> {
+  getTable(): IAdtSourceObject<ITableConfig, ITableState> {
     return new AdtTable(
       this.connection,
       this.logger,
@@ -393,7 +409,7 @@ export class AdtClient {
    * Get high-level operations for TableType (DDIC Table Type) objects
    * @returns IAdtObject instance for TableType operations
    */
-  getTableType(): IAdtObject<ITableTypeConfig, ITableTypeState> {
+  getTableType(): IAdtSourceObject<ITableTypeConfig, ITableTypeState> {
     return new AdtDdicTableType(
       this.connection,
       this.logger,
@@ -409,7 +425,7 @@ export class AdtClient {
    * (`/ddic/dsfd/sources/`) have their own clients.
    * @returns IAdtObject instance for DDL source operations
    */
-  getDdl(): IAdtObject<IDdlConfig, IDdlState> {
+  getDdl(): IAdtSourceObject<IDdlConfig, IDdlState> {
     return new AdtDdl(
       this.connection,
       this.logger,
@@ -422,7 +438,10 @@ export class AdtClient {
    * Get high-level operations for FunctionGroup objects
    * @returns IAdtObject instance for FunctionGroup operations
    */
-  getFunctionGroup(): IAdtObject<IFunctionGroupConfig, IFunctionGroupState> {
+  getFunctionGroup(): IAdtNonVersionedObject<
+    IFunctionGroupConfig,
+    IFunctionGroupState
+  > {
     return new AdtFunctionGroup(
       this.connection,
       this.logger,
@@ -436,7 +455,10 @@ export class AdtClient {
    * Get high-level operations for FunctionModule objects
    * @returns IAdtObject instance for FunctionModule operations
    */
-  getFunctionModule(): IAdtObject<IFunctionModuleConfig, IFunctionModuleState> {
+  getFunctionModule(): IAdtSourceObject<
+    IFunctionModuleConfig,
+    IFunctionModuleState
+  > {
     return new AdtFunctionModule(
       this.connection,
       this.logger,
@@ -450,10 +472,15 @@ export class AdtClient {
    * Get high-level operations for FunctionInclude objects
    * @returns IAdtObject instance for FunctionInclude operations
    */
-  getFunctionInclude(): IAdtObject<
+  getFunctionInclude(): IAdtCrud<
     IFunctionIncludeConfig,
     IFunctionIncludeState
-  > {
+  > &
+    IAdtValidatable<IFunctionIncludeConfig, IFunctionIncludeState> &
+    IAdtCheckable<IFunctionIncludeConfig, IFunctionIncludeState> &
+    IAdtActivatable<IFunctionIncludeConfig, IFunctionIncludeState> &
+    IAdtLockable<IFunctionIncludeConfig, IFunctionIncludeState> &
+    IAdtVersionable<IFunctionIncludeConfig> {
     return new AdtFunctionInclude(
       this.connection,
       this.logger,
@@ -467,7 +494,11 @@ export class AdtClient {
    * Get high-level operations for Package objects
    * @returns IAdtObject instance for Package operations
    */
-  getPackage(): IAdtObject<IPackageConfig, IPackageState> {
+  getPackage(): IAdtCrud<IPackageConfig, IPackageState> &
+    IAdtValidatable<IPackageConfig, IPackageState> &
+    IAdtCheckable<IPackageConfig, IPackageState> &
+    IAdtLockable<IPackageConfig, IPackageState> &
+    IAdtTransportAware<IPackageConfig, IPackageState> {
     return new AdtPackage(
       this.connection,
       this.logger,
@@ -480,7 +511,9 @@ export class AdtClient {
    * Get high-level operations for MessageClass (MSAG/N) objects
    * @returns IAdtObject instance for MessageClass operations
    */
-  getMessageClass(): IAdtObject<IMessageClassConfig, IMessageClassState> {
+  getMessageClass(): IAdtCrud<IMessageClassConfig, IMessageClassState> &
+    IAdtValidatable<IMessageClassConfig, IMessageClassState> &
+    IAdtLockable<IMessageClassConfig, IMessageClassState> {
     return new AdtMessageClass(
       this.connection,
       this.logger,
@@ -494,7 +527,7 @@ export class AdtClient {
    * Supports read, create/update (upsert), and delete of individual messages.
    * @returns IAdtObject instance for MessageClassMessage operations
    */
-  getMessageClassMessage(): IAdtObject<
+  getMessageClassMessage(): IAdtCrud<
     IMessageClassMessageConfig,
     IMessageClassMessageState
   > {
@@ -505,7 +538,10 @@ export class AdtClient {
    * Get high-level operations for AccessControl objects
    * @returns IAdtObject instance for AccessControl operations
    */
-  getAccessControl(): IAdtObject<IAccessControlConfig, IAccessControlState> {
+  getAccessControl(): IAdtSourceObject<
+    IAccessControlConfig,
+    IAccessControlState
+  > {
     return new AdtAccessControl(
       this.connection,
       this.logger,
@@ -519,7 +555,10 @@ export class AdtClient {
    * Supports both SimpleTransformation and XSLTProgram types
    * @returns IAdtObject instance for Transformation operations
    */
-  getTransformation(): IAdtObject<ITransformationConfig, ITransformationState> {
+  getTransformation(): IAdtSourceObject<
+    ITransformationConfig,
+    ITransformationState
+  > {
     return new AdtTransformation(
       this.connection,
       this.logger,
@@ -532,7 +571,7 @@ export class AdtClient {
    * Get high-level operations for ServiceDefinition objects
    * @returns IAdtObject instance for ServiceDefinition operations
    */
-  getServiceDefinition(): IAdtObject<
+  getServiceDefinition(): IAdtSourceObject<
     IServiceDefinitionConfig,
     IServiceDefinitionState
   > {
@@ -547,7 +586,10 @@ export class AdtClient {
   /**
    * Get high-level operations for CDS Scalar Function (DSFD/SCF) objects
    */
-  getScalarFunction(): IAdtObject<IScalarFunctionConfig, IScalarFunctionState> {
+  getScalarFunction(): IAdtSourceObject<
+    IScalarFunctionConfig,
+    IScalarFunctionState
+  > {
     return new AdtScalarFunction(
       this.connection,
       this.logger,
@@ -559,7 +601,7 @@ export class AdtClient {
   /**
    * Get high-level operations for Scalar Function Implementation (DSFI/SFI) objects
    */
-  getScalarFunctionImplementation(): IAdtObject<
+  getScalarFunctionImplementation(): IAdtSourceObject<
     IScalarFunctionImplementationConfig,
     IScalarFunctionImplementationState
   > {
@@ -574,7 +616,7 @@ export class AdtClient {
   /**
    * Get high-level operations for Append Structure (TABL/DS) objects
    */
-  getAppendStructure(): IAdtObject<
+  getAppendStructure(): IAdtSourceObject<
     IAppendStructureConfig,
     IAppendStructureState
   > {
@@ -609,7 +651,7 @@ export class AdtClient {
    * Get high-level operations for BehaviorDefinition objects
    * @returns IAdtObject instance for BehaviorDefinition operations
    */
-  getBehaviorDefinition(): IAdtObject<
+  getBehaviorDefinition(): IAdtSourceObject<
     IBehaviorDefinitionConfig,
     IBehaviorDefinitionState
   > {
@@ -625,7 +667,7 @@ export class AdtClient {
    * Get high-level operations for BehaviorImplementation objects
    * @returns IAdtObject instance for BehaviorImplementation operations
    */
-  getBehaviorImplementation(): IAdtObject<
+  getBehaviorImplementation(): IAdtSourceObject<
     IBehaviorImplementationConfig,
     IBehaviorImplementationState
   > {
@@ -640,7 +682,7 @@ export class AdtClient {
    * Get high-level operations for MetadataExtension objects
    * @returns IAdtObject instance for MetadataExtension operations
    */
-  getMetadataExtension(): IAdtObject<
+  getMetadataExtension(): IAdtSourceObject<
     IMetadataExtensionConfig,
     IMetadataExtensionState
   > {
@@ -662,7 +704,7 @@ export class AdtClient {
    * - BAdI Enhancement Spot
    * @returns IAdtObject instance for Enhancement operations
    */
-  getEnhancement(): IAdtObject<IEnhancementConfig, IEnhancementState> {
+  getEnhancement(): IAdtSourceObject<IEnhancementConfig, IEnhancementState> {
     return new AdtEnhancement(
       this.connection,
       this.logger,
@@ -728,7 +770,7 @@ export class AdtClient {
    * Get high-level operations for LocalTestClass objects
    * @returns IAdtObject instance for LocalTestClass operations
    */
-  getLocalTestClass(): IAdtObject<ILocalTestClassConfig, IClassState> {
+  getLocalTestClass(): IAdtSourceObject<ILocalTestClassConfig, IClassState> {
     return new AdtLocalTestClass(
       this.connection,
       this.logger,
@@ -742,7 +784,7 @@ export class AdtClient {
    * Get high-level operations for LocalTypes objects
    * @returns IAdtObject instance for LocalTypes operations
    */
-  getLocalTypes(): IAdtObject<ILocalTypesConfig, IClassState> {
+  getLocalTypes(): IAdtSourceObject<ILocalTypesConfig, IClassState> {
     return new AdtLocalTypes(
       this.connection,
       this.logger,
@@ -756,7 +798,10 @@ export class AdtClient {
    * Get high-level operations for LocalDefinitions objects
    * @returns IAdtObject instance for LocalDefinitions operations
    */
-  getLocalDefinitions(): IAdtObject<ILocalDefinitionsConfig, IClassState> {
+  getLocalDefinitions(): IAdtSourceObject<
+    ILocalDefinitionsConfig,
+    IClassState
+  > {
     return new AdtLocalDefinitions(
       this.connection,
       this.logger,
@@ -770,7 +815,7 @@ export class AdtClient {
    * Get high-level operations for LocalMacros objects
    * @returns IAdtObject instance for LocalMacros operations
    */
-  getLocalMacros(): IAdtObject<ILocalMacrosConfig, IClassState> {
+  getLocalMacros(): IAdtSourceObject<ILocalMacrosConfig, IClassState> {
     return new AdtLocalMacros(
       this.connection,
       this.logger,

--- a/src/clients/AdtClientLegacy.ts
+++ b/src/clients/AdtClientLegacy.ts
@@ -15,7 +15,14 @@
 
 import type {
   IAbapConnection,
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
+  IAdtNonVersionedObject,
   IAdtObject,
+  IAdtSourceObject,
+  IAdtTransportAware,
+  IAdtValidatable,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IClassConfig, IClassState } from '../core/class';
@@ -75,7 +82,7 @@ export class AdtClientLegacy extends AdtClient {
 
   // --- Supported types with legacy overrides ---
 
-  override getProgram(): IAdtObject<IProgramConfig, IProgramState> {
+  override getProgram(): IAdtSourceObject<IProgramConfig, IProgramState> {
     return new AdtProgramLegacy(
       this.connection,
       this.logger,
@@ -84,7 +91,7 @@ export class AdtClientLegacy extends AdtClient {
     );
   }
 
-  override getClass(): IAdtObject<IClassConfig, IClassState> {
+  override getClass(): IAdtSourceObject<IClassConfig, IClassState> {
     return new AdtClassLegacy(
       this.connection,
       this.logger,
@@ -93,7 +100,7 @@ export class AdtClientLegacy extends AdtClient {
     );
   }
 
-  override getInterface(): IAdtObject<IInterfaceConfig, IInterfaceState> {
+  override getInterface(): IAdtSourceObject<IInterfaceConfig, IInterfaceState> {
     return new AdtInterfaceLegacy(
       this.connection,
       this.logger,
@@ -102,7 +109,7 @@ export class AdtClientLegacy extends AdtClient {
     );
   }
 
-  override getFunctionGroup(): IAdtObject<
+  override getFunctionGroup(): IAdtNonVersionedObject<
     IFunctionGroupConfig,
     IFunctionGroupState
   > {
@@ -114,7 +121,7 @@ export class AdtClientLegacy extends AdtClient {
     );
   }
 
-  override getFunctionModule(): IAdtObject<
+  override getFunctionModule(): IAdtSourceObject<
     IFunctionModuleConfig,
     IFunctionModuleState
   > {
@@ -126,7 +133,11 @@ export class AdtClientLegacy extends AdtClient {
     );
   }
 
-  override getPackage(): IAdtObject<IPackageConfig, IPackageState> {
+  override getPackage(): IAdtCrud<IPackageConfig, IPackageState> &
+    IAdtValidatable<IPackageConfig, IPackageState> &
+    IAdtCheckable<IPackageConfig, IPackageState> &
+    IAdtLockable<IPackageConfig, IPackageState> &
+    IAdtTransportAware<IPackageConfig, IPackageState> {
     return new AdtPackageLegacy(
       this.connection,
       this.logger,
@@ -134,7 +145,7 @@ export class AdtClientLegacy extends AdtClient {
     );
   }
 
-  override getDdl(): IAdtObject<IDdlConfig, IDdlState> {
+  override getDdl(): IAdtSourceObject<IDdlConfig, IDdlState> {
     return new AdtDdlLegacy(this.connection, this.logger, this.systemContext);
   }
 

--- a/src/core/accessControl/AdtAccessControl.ts
+++ b/src/core/accessControl/AdtAccessControl.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -53,7 +53,7 @@ import {
   getAccessControlVersions,
 } from './versions';
 export class AdtAccessControl
-  implements IAdtObject<IAccessControlConfig, IAccessControlState>
+  implements IAdtSourceObject<IAccessControlConfig, IAccessControlState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/accessControl/index.ts
+++ b/src/core/accessControl/index.ts
@@ -1,10 +1,10 @@
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IAccessControlConfig, IAccessControlState } from './types';
 
 export { AdtAccessControl } from './AdtAccessControl';
 export * from './types';
 
-export type AdtAccessControlType = IAdtObject<
+export type AdtAccessControlType = IAdtSourceObject<
   IAccessControlConfig,
   IAccessControlState
 >;

--- a/src/core/appendStructure/AdtAppendStructure.ts
+++ b/src/core/appendStructure/AdtAppendStructure.ts
@@ -5,8 +5,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -39,7 +39,7 @@ import {
   getAppendStructureVersions,
 } from './versions';
 export class AdtAppendStructure
-  implements IAdtObject<IAppendStructureConfig, IAppendStructureState>
+  implements IAdtSourceObject<IAppendStructureConfig, IAppendStructureState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/appendStructure/index.ts
+++ b/src/core/appendStructure/index.ts
@@ -1,10 +1,10 @@
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IAppendStructureConfig, IAppendStructureState } from './types';
 
 export { AdtAppendStructure } from './AdtAppendStructure';
 export * from './types';
 
-export type AdtAppendStructureType = IAdtObject<
+export type AdtAppendStructureType = IAdtSourceObject<
   IAppendStructureConfig,
   IAppendStructureState
 >;

--- a/src/core/authorizationField/AdtAuthorizationField.ts
+++ b/src/core/authorizationField/AdtAuthorizationField.ts
@@ -18,8 +18,12 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
+  IAdtActivatable,
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
   IAdtOperationOptions,
+  IAdtValidatable,
   ILogger,
   IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
@@ -50,7 +54,12 @@ import { unlockAuthorizationField } from './unlock';
 import { updateAuthorizationField } from './update';
 import { validateAuthorizationFieldName } from './validation';
 export class AdtAuthorizationField
-  implements IAdtObject<IAuthorizationFieldConfig, IAuthorizationFieldState>
+  implements
+    IAdtCrud<IAuthorizationFieldConfig, IAuthorizationFieldState>,
+    IAdtValidatable<IAuthorizationFieldConfig, IAuthorizationFieldState>,
+    IAdtCheckable<IAuthorizationFieldConfig, IAuthorizationFieldState>,
+    IAdtActivatable<IAuthorizationFieldConfig, IAuthorizationFieldState>,
+    IAdtLockable<IAuthorizationFieldConfig, IAuthorizationFieldState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
@@ -568,6 +577,8 @@ export class AdtAuthorizationField
 
   /**
    * Read transport info — not supported by the APS IAM endpoint yet.
+   *
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
    */
   async readTransport(): Promise<IAuthorizationFieldState> {
     const error = new Error(
@@ -618,12 +629,14 @@ export class AdtAuthorizationField
     return { errors: [] };
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersions(
     _config: Partial<IAuthorizationFieldConfig>,
   ): Promise<IObjectVersion[]> {
     throwUnsupportedVersions('authorization field');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersionSource(_contentUri: string): Promise<string> {
     throwUnsupportedVersions('authorization field');
   }

--- a/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
+++ b/src/core/behaviorDefinition/AdtBehaviorDefinition.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -56,7 +56,8 @@ import {
   getBehaviorDefinitionVersions,
 } from './versions';
 export class AdtBehaviorDefinition
-  implements IAdtObject<IBehaviorDefinitionConfig, IBehaviorDefinitionState>
+  implements
+    IAdtSourceObject<IBehaviorDefinitionConfig, IBehaviorDefinitionState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/behaviorDefinition/index.ts
+++ b/src/core/behaviorDefinition/index.ts
@@ -2,7 +2,7 @@
  * Behavior Definition operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type {
   IBehaviorDefinitionConfig,
   IBehaviorDefinitionState,
@@ -12,7 +12,7 @@ export { AdtBehaviorDefinition } from './AdtBehaviorDefinition';
 export * from './types';
 
 // Type alias for AdtBehaviorDefinition
-export type AdtBehaviorDefinitionType = IAdtObject<
+export type AdtBehaviorDefinitionType = IAdtSourceObject<
   IBehaviorDefinitionConfig,
   IBehaviorDefinitionState
 >;

--- a/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
+++ b/src/core/behaviorImplementation/AdtBehaviorImplementation.ts
@@ -26,8 +26,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import { safeErrorMessage } from '../../utils/internalUtils';
@@ -54,7 +54,10 @@ import {
 } from './versions';
 export class AdtBehaviorImplementation
   implements
-    IAdtObject<IBehaviorImplementationConfig, IBehaviorImplementationState>
+    IAdtSourceObject<
+      IBehaviorImplementationConfig,
+      IBehaviorImplementationState
+    >
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/behaviorImplementation/index.ts
+++ b/src/core/behaviorImplementation/index.ts
@@ -2,7 +2,7 @@
  * Behavior Implementation operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type {
   IBehaviorImplementationConfig,
   IBehaviorImplementationState,
@@ -12,7 +12,7 @@ export { AdtBehaviorImplementation } from './AdtBehaviorImplementation';
 export * from './types';
 
 // Type alias for AdtBehaviorImplementation
-export type AdtBehaviorImplementationType = IAdtObject<
+export type AdtBehaviorImplementationType = IAdtSourceObject<
   IBehaviorImplementationConfig,
   IBehaviorImplementationState
 >;

--- a/src/core/class/AdtClass.ts
+++ b/src/core/class/AdtClass.ts
@@ -23,8 +23,8 @@ import {
   type IAdtResponse as AxiosResponse,
   type HttpError,
   type IAbapConnection,
-  type IAdtObject,
   type IAdtOperationOptions,
+  type IAdtSourceObject,
   type ILogger,
   type IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
@@ -62,7 +62,7 @@ import {
   getClassVersionSource,
 } from './versions';
 
-export class AdtClass implements IAdtObject<IClassConfig, IClassState> {
+export class AdtClass implements IAdtSourceObject<IClassConfig, IClassState> {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;

--- a/src/core/class/index.ts
+++ b/src/core/class/index.ts
@@ -2,14 +2,14 @@
  * Class operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IClassConfig, IClassState } from './types';
 
 export { AdtClass } from './AdtClass';
 export * from './types';
 
 // Type alias for AdtClass
-export type AdtClassType = IAdtObject<IClassConfig, IClassState>;
+export type AdtClassType = IAdtSourceObject<IClassConfig, IClassState>;
 export {
   AdtLocalDefinitions,
   type ILocalDefinitionsConfig,

--- a/src/core/dataElement/AdtDataElement.ts
+++ b/src/core/dataElement/AdtDataElement.ts
@@ -21,7 +21,7 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
+  IAdtNonVersionedObject,
   IAdtOperationOptions,
   ILogger,
   IObjectVersion,
@@ -46,7 +46,7 @@ import { unlockDataElement } from './unlock';
 import { updateDataElement } from './update';
 import { validateDataElementName } from './validation';
 export class AdtDataElement
-  implements IAdtObject<IDataElementConfig, IDataElementState>
+  implements IAdtNonVersionedObject<IDataElementConfig, IDataElementState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
@@ -696,12 +696,14 @@ export class AdtDataElement
     };
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersions(
     _config: Partial<IDataElementConfig>,
   ): Promise<IObjectVersion[]> {
     throwUnsupportedVersions('data element');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersionSource(_contentUri: string): Promise<string> {
     throwUnsupportedVersions('data element');
   }

--- a/src/core/dataElement/index.ts
+++ b/src/core/dataElement/index.ts
@@ -2,14 +2,14 @@
  * DataElement operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtNonVersionedObject } from '@mcp-abap-adt/interfaces';
 import type { IDataElementConfig, IDataElementState } from './types';
 
 export { AdtDataElement } from './AdtDataElement';
 export * from './types';
 
 // Type alias for AdtDataElement
-export type AdtDataElementType = IAdtObject<
+export type AdtDataElementType = IAdtNonVersionedObject<
   IDataElementConfig,
   IDataElementState
 >;

--- a/src/core/ddl/AdtDdl.ts
+++ b/src/core/ddl/AdtDdl.ts
@@ -24,8 +24,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -48,7 +48,7 @@ import { updateDdl } from './update';
 import { validateDdlName } from './validation';
 
 import { getDdlVersionSource, getDdlVersions } from './versions';
-export class AdtDdl implements IAdtObject<IDdlConfig, IDdlState> {
+export class AdtDdl implements IAdtSourceObject<IDdlConfig, IDdlState> {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;

--- a/src/core/ddl/index.ts
+++ b/src/core/ddl/index.ts
@@ -2,11 +2,11 @@
  * View operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IDdlConfig, IDdlState } from './types';
 
 export { AdtDdl } from './AdtDdl';
 export * from './types';
 
 // Type alias for AdtDdl
-export type AdtDdlType = IAdtObject<IDdlConfig, IDdlState>;
+export type AdtDdlType = IAdtSourceObject<IDdlConfig, IDdlState>;

--- a/src/core/domain/AdtDomain.ts
+++ b/src/core/domain/AdtDomain.ts
@@ -21,7 +21,7 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
+  IAdtNonVersionedObject,
   IAdtOperationOptions,
   ILogger,
   IObjectVersion,
@@ -49,7 +49,9 @@ import type { IDomainConfig, IDomainState } from './types';
 import { unlockDomain } from './unlock';
 import { updateDomain } from './update';
 import { validateDomainName } from './validation';
-export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
+export class AdtDomain
+  implements IAdtNonVersionedObject<IDomainConfig, IDomainState>
+{
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;
@@ -660,12 +662,14 @@ export class AdtDomain implements IAdtObject<IDomainConfig, IDomainState> {
     return state;
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersions(
     _config: Partial<IDomainConfig>,
   ): Promise<IObjectVersion[]> {
     throwUnsupportedVersions('domain');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersionSource(_contentUri: string): Promise<string> {
     throwUnsupportedVersions('domain');
   }

--- a/src/core/domain/index.ts
+++ b/src/core/domain/index.ts
@@ -2,11 +2,11 @@
  * Domain operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtNonVersionedObject } from '@mcp-abap-adt/interfaces';
 import type { IDomainConfig, IDomainState } from './types';
 
 export { AdtDomain } from './AdtDomain';
 export * from './types';
 
 // Type alias for AdtDomain
-export type AdtDomainType = IAdtObject<IDomainConfig, IDomainState>;
+export type AdtDomainType = IAdtNonVersionedObject<IDomainConfig, IDomainState>;

--- a/src/core/enhancement/AdtEnhancement.ts
+++ b/src/core/enhancement/AdtEnhancement.ts
@@ -28,8 +28,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -61,7 +61,7 @@ import {
   getEnhancementVersions,
 } from './versions';
 export class AdtEnhancement
-  implements IAdtObject<IEnhancementConfig, IEnhancementState>
+  implements IAdtSourceObject<IEnhancementConfig, IEnhancementState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/functionGroup/AdtFunctionGroup.ts
+++ b/src/core/functionGroup/AdtFunctionGroup.ts
@@ -24,7 +24,7 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
+  IAdtNonVersionedObject,
   IAdtOperationOptions,
   ILogger,
   IObjectVersion,
@@ -49,7 +49,7 @@ import type { IFunctionGroupConfig, IFunctionGroupState } from './types';
 import { updateFunctionGroup } from './update';
 import { validateFunctionGroupName } from './validation';
 export class AdtFunctionGroup
-  implements IAdtObject<IFunctionGroupConfig, IFunctionGroupState>
+  implements IAdtNonVersionedObject<IFunctionGroupConfig, IFunctionGroupState>
 {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
@@ -770,12 +770,14 @@ export class AdtFunctionGroup
     };
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersions(
     _config: Partial<IFunctionGroupConfig>,
   ): Promise<IObjectVersion[]> {
     throwUnsupportedVersions('function group');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersionSource(_contentUri: string): Promise<string> {
     throwUnsupportedVersions('function group');
   }

--- a/src/core/functionGroup/index.ts
+++ b/src/core/functionGroup/index.ts
@@ -2,14 +2,14 @@
  * FunctionGroup operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtNonVersionedObject } from '@mcp-abap-adt/interfaces';
 import type { IFunctionGroupConfig, IFunctionGroupState } from './types';
 
 export { AdtFunctionGroup } from './AdtFunctionGroup';
 export * from './types';
 
 // Type alias for AdtFunctionGroup
-export type AdtFunctionGroupType = IAdtObject<
+export type AdtFunctionGroupType = IAdtNonVersionedObject<
   IFunctionGroupConfig,
   IFunctionGroupState
 >;

--- a/src/core/functionInclude/AdtFunctionInclude.ts
+++ b/src/core/functionInclude/AdtFunctionInclude.ts
@@ -18,8 +18,13 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
+  IAdtActivatable,
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
   IAdtOperationOptions,
+  IAdtValidatable,
+  IAdtVersionable,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -52,7 +57,13 @@ import {
   getFunctionIncludeVersions,
 } from './versions';
 export class AdtFunctionInclude
-  implements IAdtObject<IFunctionIncludeConfig, IFunctionIncludeState>
+  implements
+    IAdtCrud<IFunctionIncludeConfig, IFunctionIncludeState>,
+    IAdtValidatable<IFunctionIncludeConfig, IFunctionIncludeState>,
+    IAdtCheckable<IFunctionIncludeConfig, IFunctionIncludeState>,
+    IAdtActivatable<IFunctionIncludeConfig, IFunctionIncludeState>,
+    IAdtLockable<IFunctionIncludeConfig, IFunctionIncludeState>,
+    IAdtVersionable<IFunctionIncludeConfig>
 {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
@@ -789,6 +800,8 @@ export class AdtFunctionInclude
 
   /**
    * Read transport info — not supported for FUGR/I (transport tracked at group level).
+   *
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
    */
   async readTransport(): Promise<IFunctionIncludeState> {
     const error = new Error(

--- a/src/core/functionModule/AdtFunctionModule.ts
+++ b/src/core/functionModule/AdtFunctionModule.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -50,7 +50,7 @@ import {
   getFunctionModuleVersions,
 } from './versions';
 export class AdtFunctionModule
-  implements IAdtObject<IFunctionModuleConfig, IFunctionModuleState>
+  implements IAdtSourceObject<IFunctionModuleConfig, IFunctionModuleState>
 {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;

--- a/src/core/functionModule/index.ts
+++ b/src/core/functionModule/index.ts
@@ -2,14 +2,14 @@
  * FunctionModule operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IFunctionModuleConfig, IFunctionModuleState } from './types';
 
 export { AdtFunctionModule } from './AdtFunctionModule';
 export * from './types';
 
 // Type alias for AdtFunctionModule
-export type AdtFunctionModuleType = IAdtObject<
+export type AdtFunctionModuleType = IAdtSourceObject<
   IFunctionModuleConfig,
   IFunctionModuleState
 >;

--- a/src/core/interface/AdtInterface.ts
+++ b/src/core/interface/AdtInterface.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -51,7 +51,7 @@ import { validateInterfaceName } from './validation';
 
 import { getInterfaceVersionSource, getInterfaceVersions } from './versions';
 export class AdtInterface
-  implements IAdtObject<IInterfaceConfig, IInterfaceState>
+  implements IAdtSourceObject<IInterfaceConfig, IInterfaceState>
 {
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;

--- a/src/core/interface/index.ts
+++ b/src/core/interface/index.ts
@@ -2,11 +2,14 @@
  * Interface operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IInterfaceConfig, IInterfaceState } from './types';
 
 export { AdtInterface } from './AdtInterface';
 export * from './types';
 
 // Type alias for AdtInterface
-export type AdtInterfaceType = IAdtObject<IInterfaceConfig, IInterfaceState>;
+export type AdtInterfaceType = IAdtSourceObject<
+  IInterfaceConfig,
+  IInterfaceState
+>;

--- a/src/core/messageClass/AdtMessageClass.ts
+++ b/src/core/messageClass/AdtMessageClass.ts
@@ -17,8 +17,10 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
+  IAdtCrud,
+  IAdtLockable,
   IAdtOperationOptions,
+  IAdtValidatable,
   ILogger,
   IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
@@ -43,7 +45,10 @@ import { parseMessageClass } from './xml';
 const VALIDATE_BASE = '/sap/bc/adt/messageclass/validation';
 
 export class AdtMessageClass
-  implements IAdtObject<IMessageClassConfig, IMessageClassState>
+  implements
+    IAdtCrud<IMessageClassConfig, IMessageClassState>,
+    IAdtValidatable<IMessageClassConfig, IMessageClassState>,
+    IAdtLockable<IMessageClassConfig, IMessageClassState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
@@ -284,6 +289,8 @@ export class AdtMessageClass
   /**
    * Read transport request information.
    * Transport endpoint is not confirmed for message classes — always throws.
+   *
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
    */
   async readTransport(
     config: Partial<IMessageClassConfig>,
@@ -327,7 +334,10 @@ export class AdtMessageClass
     return { unlockResult, errors: [] };
   }
 
-  /** Message classes are not activated — always throws. */
+  /**
+   * Message classes are not activated — always throws.
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
+   */
   async activate(
     _config: Partial<IMessageClassConfig>,
   ): Promise<IMessageClassState> {
@@ -337,14 +347,20 @@ export class AdtMessageClass
     );
   }
 
-  /** Syntax check is not applicable to message classes — always throws. */
+  /**
+   * Syntax check is not applicable to message classes — always throws.
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
+   */
   async check(
     _config: Partial<IMessageClassConfig>,
   ): Promise<IMessageClassState> {
     throwUnsupportedOperation('check', `message class ${_config.name ?? ''}`);
   }
 
-  /** Version history is not supported for message classes — always throws. */
+  /**
+   * Version history is not supported for message classes — always throws.
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
+   */
   async getVersions(
     _config: Partial<IMessageClassConfig>,
   ): Promise<IObjectVersion[]> {
@@ -354,7 +370,10 @@ export class AdtMessageClass
     );
   }
 
-  /** Version source retrieval is not supported for message classes — always throws. */
+  /**
+   * Version source retrieval is not supported for message classes — always throws.
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
+   */
   async getVersionSource(_contentUri: string): Promise<string> {
     throwUnsupportedOperation('getVersionSource', 'message class');
   }

--- a/src/core/messageClass/AdtMessageClassMessage.ts
+++ b/src/core/messageClass/AdtMessageClassMessage.ts
@@ -27,7 +27,7 @@
 
 import type {
   IAbapConnection,
-  IAdtObject,
+  IAdtCrud,
   IAdtOperationOptions,
   ILogger,
   IObjectVersion,
@@ -55,7 +55,7 @@ import { buildMessageClassXml, parseMessageClass } from './xml';
 const BASE = '/sap/bc/adt/messageclass';
 
 export class AdtMessageClassMessage
-  implements IAdtObject<IMessageClassMessageConfig, IMessageClassMessageState>
+  implements IAdtCrud<IMessageClassMessageConfig, IMessageClassMessageState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
@@ -371,34 +371,40 @@ export class AdtMessageClassMessage
 
   // ── unsupported operations ─────────────────────────────────────────────────
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async validate(
     _config: Partial<IMessageClassMessageConfig>,
   ): Promise<IMessageClassMessageState> {
     throwUnsupportedOperation('validate', 'message class message');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async activate(
     _config: Partial<IMessageClassMessageConfig>,
   ): Promise<IMessageClassMessageState> {
     throwUnsupportedOperation('activate', 'message class message');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async check(
     _config: Partial<IMessageClassMessageConfig>,
   ): Promise<IMessageClassMessageState> {
     throwUnsupportedOperation('check', 'message class message');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async readTransport(
     _config: Partial<IMessageClassMessageConfig>,
   ): Promise<IMessageClassMessageState> {
     throwUnsupportedOperation('readTransport', 'message class message');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async lock(_config: Partial<IMessageClassMessageConfig>): Promise<string> {
     throwUnsupportedOperation('lock', 'message class message');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async unlock(
     _config: Partial<IMessageClassMessageConfig>,
     _lockHandle: string,
@@ -406,12 +412,14 @@ export class AdtMessageClassMessage
     throwUnsupportedOperation('unlock', 'message class message');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersions(
     _config: Partial<IMessageClassMessageConfig>,
   ): Promise<IObjectVersion[]> {
     throwUnsupportedOperation('getVersions', 'message class message');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersionSource(_contentUri: string): Promise<string> {
     throwUnsupportedOperation('getVersionSource', 'message class message');
   }

--- a/src/core/messageClass/index.ts
+++ b/src/core/messageClass/index.ts
@@ -2,7 +2,11 @@
  * Message class operations - public exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type {
+  IAdtCrud,
+  IAdtLockable,
+  IAdtValidatable,
+} from '@mcp-abap-adt/interfaces';
 import type {
   IMessageClassConfig,
   IMessageClassMessageConfig,
@@ -17,13 +21,15 @@ export type { IParsedMessage, IParsedMessageClass } from './xml';
 export { buildMessageClassXml, parseMessageClass } from './xml';
 
 // Type alias for AdtMessageClass
-export type AdtMessageClassType = IAdtObject<
+export type AdtMessageClassType = IAdtCrud<
   IMessageClassConfig,
   IMessageClassState
->;
+> &
+  IAdtValidatable<IMessageClassConfig, IMessageClassState> &
+  IAdtLockable<IMessageClassConfig, IMessageClassState>;
 
 // Type alias for AdtMessageClassMessage
-export type AdtMessageClassMessageType = IAdtObject<
+export type AdtMessageClassMessageType = IAdtCrud<
   IMessageClassMessageConfig,
   IMessageClassMessageState
 >;

--- a/src/core/metadataExtension/AdtMetadataExtension.ts
+++ b/src/core/metadataExtension/AdtMetadataExtension.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -56,7 +56,7 @@ import {
   getMetadataExtensionVersions,
 } from './versions';
 export class AdtMetadataExtension
-  implements IAdtObject<IMetadataExtensionConfig, IMetadataExtensionState>
+  implements IAdtSourceObject<IMetadataExtensionConfig, IMetadataExtensionState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/metadataExtension/index.ts
+++ b/src/core/metadataExtension/index.ts
@@ -2,7 +2,7 @@
  * Metadata Extension (DDLX) operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type {
   IMetadataExtensionConfig,
   IMetadataExtensionState,
@@ -12,7 +12,7 @@ export { AdtMetadataExtension } from './AdtMetadataExtension';
 export * from './types';
 
 // Type alias for AdtMetadataExtension
-export type AdtMetadataExtensionType = IAdtObject<
+export type AdtMetadataExtensionType = IAdtSourceObject<
   IMetadataExtensionConfig,
   IMetadataExtensionState
 >;

--- a/src/core/package/AdtPackage.ts
+++ b/src/core/package/AdtPackage.ts
@@ -24,8 +24,12 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
   IAdtOperationOptions,
+  IAdtTransportAware,
+  IAdtValidatable,
   ILogger,
   IObjectVersion,
 } from '@mcp-abap-adt/interfaces';
@@ -47,7 +51,14 @@ import type { IPackageConfig, IPackageState } from './types';
 import { unlockPackage } from './unlock';
 import { updatePackage } from './update';
 import { validatePackageBasic } from './validation';
-export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
+export class AdtPackage
+  implements
+    IAdtCrud<IPackageConfig, IPackageState>,
+    IAdtValidatable<IPackageConfig, IPackageState>,
+    IAdtCheckable<IPackageConfig, IPackageState>,
+    IAdtLockable<IPackageConfig, IPackageState>,
+    IAdtTransportAware<IPackageConfig, IPackageState>
+{
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;
@@ -555,6 +566,8 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
   /**
    * Activate package
    * Note: Packages don't have activate operation - this is a stub
+   *
+   * @deprecated Not part of this handler's capability set; throws. Removed in a later major.
    */
   async activate(_config: Partial<IPackageConfig>): Promise<IPackageState> {
     throw new Error(
@@ -625,12 +638,14 @@ export class AdtPackage implements IAdtObject<IPackageConfig, IPackageState> {
     };
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersions(
     _config: Partial<IPackageConfig>,
   ): Promise<IObjectVersion[]> {
     throwUnsupportedVersions('package');
   }
 
+  /** @deprecated Not part of this handler's capability set; throws. Removed in a later major. */
   async getVersionSource(_contentUri: string): Promise<string> {
     throwUnsupportedVersions('package');
   }

--- a/src/core/package/index.ts
+++ b/src/core/package/index.ts
@@ -2,11 +2,21 @@
  * Package operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type {
+  IAdtCheckable,
+  IAdtCrud,
+  IAdtLockable,
+  IAdtTransportAware,
+  IAdtValidatable,
+} from '@mcp-abap-adt/interfaces';
 import type { IPackageConfig, IPackageState } from './types';
 
 export { AdtPackage } from './AdtPackage';
 export * from './types';
 
 // Type alias for AdtPackage
-export type AdtPackageType = IAdtObject<IPackageConfig, IPackageState>;
+export type AdtPackageType = IAdtCrud<IPackageConfig, IPackageState> &
+  IAdtValidatable<IPackageConfig, IPackageState> &
+  IAdtCheckable<IPackageConfig, IPackageState> &
+  IAdtLockable<IPackageConfig, IPackageState> &
+  IAdtTransportAware<IPackageConfig, IPackageState>;

--- a/src/core/program/AdtProgram.ts
+++ b/src/core/program/AdtProgram.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -50,7 +50,9 @@ import { uploadProgramSource } from './update';
 import { validateProgramName } from './validation';
 
 import { getProgramVersionSource, getProgramVersions } from './versions';
-export class AdtProgram implements IAdtObject<IProgramConfig, IProgramState> {
+export class AdtProgram
+  implements IAdtSourceObject<IProgramConfig, IProgramState>
+{
   protected readonly connection: IAbapConnection;
   protected readonly logger?: ILogger;
   protected readonly systemContext: IAdtSystemContext;

--- a/src/core/program/index.ts
+++ b/src/core/program/index.ts
@@ -2,7 +2,7 @@
  * Program operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IProgramConfig, IProgramState } from './types';
 
 export { AdtProgram } from './AdtProgram';
@@ -10,4 +10,4 @@ export { runProgram } from './run';
 export * from './types';
 
 // Type alias for AdtProgram
-export type AdtProgramType = IAdtObject<IProgramConfig, IProgramState>;
+export type AdtProgramType = IAdtSourceObject<IProgramConfig, IProgramState>;

--- a/src/core/scalarFunction/AdtScalarFunction.ts
+++ b/src/core/scalarFunction/AdtScalarFunction.ts
@@ -5,8 +5,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -39,7 +39,7 @@ import {
   getScalarFunctionVersions,
 } from './versions';
 export class AdtScalarFunction
-  implements IAdtObject<IScalarFunctionConfig, IScalarFunctionState>
+  implements IAdtSourceObject<IScalarFunctionConfig, IScalarFunctionState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/scalarFunction/index.ts
+++ b/src/core/scalarFunction/index.ts
@@ -1,10 +1,10 @@
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IScalarFunctionConfig, IScalarFunctionState } from './types';
 
 export { AdtScalarFunction } from './AdtScalarFunction';
 export * from './types';
 
-export type AdtScalarFunctionType = IAdtObject<
+export type AdtScalarFunctionType = IAdtSourceObject<
   IScalarFunctionConfig,
   IScalarFunctionState
 >;

--- a/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
+++ b/src/core/scalarFunctionImplementation/AdtScalarFunctionImplementation.ts
@@ -5,8 +5,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -44,7 +44,7 @@ import {
 } from './versions';
 export class AdtScalarFunctionImplementation
   implements
-    IAdtObject<
+    IAdtSourceObject<
       IScalarFunctionImplementationConfig,
       IScalarFunctionImplementationState
     >

--- a/src/core/scalarFunctionImplementation/index.ts
+++ b/src/core/scalarFunctionImplementation/index.ts
@@ -1,4 +1,4 @@
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type {
   IScalarFunctionImplementationConfig,
   IScalarFunctionImplementationState,
@@ -7,7 +7,7 @@ import type {
 export { AdtScalarFunctionImplementation } from './AdtScalarFunctionImplementation';
 export * from './types';
 
-export type AdtScalarFunctionImplementationType = IAdtObject<
+export type AdtScalarFunctionImplementationType = IAdtSourceObject<
   IScalarFunctionImplementationConfig,
   IScalarFunctionImplementationState
 >;

--- a/src/core/serviceDefinition/AdtServiceDefinition.ts
+++ b/src/core/serviceDefinition/AdtServiceDefinition.ts
@@ -22,8 +22,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -62,7 +62,7 @@ import {
   getServiceDefinitionVersions,
 } from './versions';
 export class AdtServiceDefinition
-  implements IAdtObject<IServiceDefinitionConfig, IServiceDefinitionState>
+  implements IAdtSourceObject<IServiceDefinitionConfig, IServiceDefinitionState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/serviceDefinition/index.ts
+++ b/src/core/serviceDefinition/index.ts
@@ -2,7 +2,7 @@
  * ServiceDefinition operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type {
   IServiceDefinitionConfig,
   IServiceDefinitionState,
@@ -12,7 +12,7 @@ export { AdtServiceDefinition } from './AdtServiceDefinition';
 export * from './types';
 
 // Type alias for AdtServiceDefinition
-export type AdtServiceDefinitionType = IAdtObject<
+export type AdtServiceDefinitionType = IAdtSourceObject<
   IServiceDefinitionConfig,
   IServiceDefinitionState
 >;

--- a/src/core/structure/AdtStructure.ts
+++ b/src/core/structure/AdtStructure.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -50,7 +50,7 @@ import { validateStructureName } from './validation';
 
 import { getStructureVersionSource, getStructureVersions } from './versions';
 export class AdtStructure
-  implements IAdtObject<IStructureConfig, IStructureState>
+  implements IAdtSourceObject<IStructureConfig, IStructureState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/structure/index.ts
+++ b/src/core/structure/index.ts
@@ -2,11 +2,14 @@
  * Structure operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { IStructureConfig, IStructureState } from './types';
 
 export { AdtStructure } from './AdtStructure';
 export * from './types';
 
 // Type alias for AdtStructure
-export type AdtStructureType = IAdtObject<IStructureConfig, IStructureState>;
+export type AdtStructureType = IAdtSourceObject<
+  IStructureConfig,
+  IStructureState
+>;

--- a/src/core/table/AdtTable.ts
+++ b/src/core/table/AdtTable.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -45,7 +45,7 @@ import { updateTable } from './update';
 import { validateTableName } from './validation';
 import { getTableVersionSource, getTableVersions } from './versions';
 
-export class AdtTable implements IAdtObject<ITableConfig, ITableState> {
+export class AdtTable implements IAdtSourceObject<ITableConfig, ITableState> {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;
   private readonly systemContext: IAdtSystemContext;

--- a/src/core/table/index.ts
+++ b/src/core/table/index.ts
@@ -2,11 +2,11 @@
  * Table operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { ITableConfig, ITableState } from './types';
 
 export { AdtTable } from './AdtTable';
 export * from './types';
 
 // Type alias for AdtTable
-export type AdtTableType = IAdtObject<ITableConfig, ITableState>;
+export type AdtTableType = IAdtSourceObject<ITableConfig, ITableState>;

--- a/src/core/tabletype/AdtDdicTableType.ts
+++ b/src/core/tabletype/AdtDdicTableType.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -46,7 +46,7 @@ import { validateTableTypeName } from './validation';
 
 import { getTableTypeVersionSource, getTableTypeVersions } from './versions';
 export class AdtDdicTableType
-  implements IAdtObject<ITableTypeConfig, ITableTypeState>
+  implements IAdtSourceObject<ITableTypeConfig, ITableTypeState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/tabletype/index.ts
+++ b/src/core/tabletype/index.ts
@@ -2,14 +2,14 @@
  * TableType operations - exports
  */
 
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { ITableTypeConfig, ITableTypeState } from './types';
 
 export { AdtDdicTableType } from './AdtDdicTableType';
 export * from './types';
 
 // Type alias for AdtDdicTableType
-export type AdtDdicTableTypeAlias = IAdtObject<
+export type AdtDdicTableTypeAlias = IAdtSourceObject<
   ITableTypeConfig,
   ITableTypeState
 >;

--- a/src/core/transformation/AdtTransformation.ts
+++ b/src/core/transformation/AdtTransformation.ts
@@ -21,8 +21,8 @@
 import type {
   HttpError,
   IAbapConnection,
-  IAdtObject,
   IAdtOperationOptions,
+  IAdtSourceObject,
   ILogger,
 } from '@mcp-abap-adt/interfaces';
 import type { IAdtSystemContext } from '../../clients/AdtClient';
@@ -53,7 +53,7 @@ import {
   getTransformationVersions,
 } from './versions';
 export class AdtTransformation
-  implements IAdtObject<ITransformationConfig, ITransformationState>
+  implements IAdtSourceObject<ITransformationConfig, ITransformationState>
 {
   private readonly connection: IAbapConnection;
   private readonly logger?: ILogger;

--- a/src/core/transformation/index.ts
+++ b/src/core/transformation/index.ts
@@ -1,10 +1,10 @@
-import type { IAdtObject } from '@mcp-abap-adt/interfaces';
+import type { IAdtSourceObject } from '@mcp-abap-adt/interfaces';
 import type { ITransformationConfig, ITransformationState } from './types';
 
 export { AdtTransformation } from './AdtTransformation';
 export * from './types';
 
-export type AdtTransformationType = IAdtObject<
+export type AdtTransformationType = IAdtSourceObject<
   ITransformationConfig,
   ITransformationState
 >;


### PR DESCRIPTION
The type-honesty migration. Every in-scope object handler now `implements` only the capability atom interfaces it genuinely supports, and `AdtClient.getXxx()` (plus `AdtClientBatch` by inference) return types narrow to match — so calling a capability a handler lacks is a **compile error** instead of a runtime throw. Requires `@mcp-abap-adt/interfaces@^11.3.0`.

## The change

- **Handlers declare honest capability sets.** `AdtClass` → `IAdtSourceObject` (all 7 atoms); `AdtDomain` → `IAdtNonVersionedObject` (no versions); `AdtPackage` → `IAdtCrud, IAdtValidatable, IAdtCheckable, IAdtLockable, IAdtTransportAware` (no activate/versions); etc. `implements` uses comma-separated atom lists; return types and `Adt<Type>Type` aliases use `&` intersections.
- **`AdtClient.getXxx()` return types narrowed** to the same honest composite. `client.getDomain().getVersions(...)` no longer type-checks.
- Removed-from-contract methods stay on the classes at runtime, `@deprecated`, deleted in a later major.

## Why this is safe for consumers

The narrowing **only** breaks code that referenced methods which always threw at runtime (`ADT_UNSUPPORTED_OPERATION`) — e.g. `getDomain().getVersions()`. No working consumer code is affected; a latent runtime crash becomes a compile error, which is the point. A compile-time guard test (`returnTypeNarrowing.test.ts`, type-checked by `test:check`) proves the narrowing bites.

## Scope

30 in-scope handlers. **Deferred** (still return the wide type): `getFeatureToggle`, `getServiceBinding` (widening interfaces `IFeatureToggleObject`/`IAdtServiceBinding` that extend `IAdtObject`), and `getRequest`, `getUnitTest`, `getCdsUnitTest` (wrong-contract; `AdtRequest.update`/`delete` are known defects to fix first). See `docs/superpowers/plans/2026-07-21-capability-type-honesty-migration.md`.

## Verification

- `build:fast` clean; `test:check` exit 0 (every `@ts-expect-error` matched a real error); 366 unit tests pass; `lint:check` 0 errors (45/25 baseline).
- Export-name surface unchanged (empty diff); declaration surface changed exactly per the `IAdtObject → composite` pattern (verified across all `.d.ts`).
- `package-lock.json` resolves interfaces 11.3.0 from the registry, `"link": true` = 0.
- Executed subagent-driven: implementer + independent review per task (B1–B5), all clean.

Note: 7 integration-test call sites use `as unknown as IAdtObject<...>` casts to satisfy `BaseTester` (which requires the full contract) — test-only, runtime-safe; narrowing `BaseTester`'s param is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)