### PR TITLE
chore(deps): connection@1.10.1 + session contract tests (no SAP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
-        "@mcp-abap-adt/connection": "^1.8.1",
+        "@mcp-abap-adt/connection": "^1.10.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.3.3",
         "dotenv": "^17.3.1",
@@ -195,14 +195,14 @@
       }
     },
     "node_modules/@mcp-abap-adt/connection": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/connection/-/connection-1.8.1.tgz",
-      "integrity": "sha512-ctTtchVgK0ebOAPB7RdjrryIqktSANm9uFlRNdcuZaj3fPriadYPwR9T7LFmLVmBZx4YFQY/hz5mTl9/FlFD0g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/connection/-/connection-1.10.1.tgz",
+      "integrity": "sha512-/ne1K6MtbjKWuwtctSBUiiv4fAVdie8Ne/jarJd86n+qGk95XbS/9YhnbgxkVlCoH8TKzCIWv4WB2A5kosYY5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^7.0.0",
-        "axios": "^1.13.5",
+        "@mcp-abap-adt/interfaces": "^7.2.0",
+        "axios": "^1.16.0",
         "commander": "^14.0.3",
         "express": "^5.1.0",
         "open": "^11.0.0"
@@ -214,7 +214,8 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@mcp-abap-adt/sap-rfc-lite": "^0.1.0"
+        "@mcp-abap-adt/sap-rfc-lite": "^0.1.0",
+        "kerberos": "^2.1.0"
       }
     },
     "node_modules/@mcp-abap-adt/connection/node_modules/@mcp-abap-adt/interfaces": {
@@ -1405,6 +1406,594 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.2.2.tgz",
+      "integrity": "sha512-42O7+/1Zatsc3MkxaMPpXcIl/ukIrbQaGoArZEAr6GcEi2qhfprOBYOPhj+YvSMJkEkdpTjApUx+2DuWaKwRhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/pump/node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/pump/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/pump/node_modules/once/node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/rc/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/simple-get/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/simple-get/node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/simple-get/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/simple-get/node_modules/once/node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/simple-get/node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/bl/node_modules/buffer/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/bl/node_modules/buffer/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/end-of-stream/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/end-of-stream/node_modules/once/node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/readable-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tar-fs/node_modules/tar-stream/node_modules/readable-stream/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@mcp-abap-adt/connection/node_modules/kerberos/node_modules/prebuild-install/node_modules/tunnel-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@mcp-abap-adt/connection/node_modules/open": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
-    "@mcp-abap-adt/connection": "^1.8.1",
+    "@mcp-abap-adt/connection": "^1.10.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.3.3",
     "dotenv": "^17.3.1",

--- a/src/__tests__/unit/session/adtStubServer.ts
+++ b/src/__tests__/unit/session/adtStubServer.ts
@@ -1,0 +1,101 @@
+/**
+ * Minimal ADT stub over node:http.
+ *
+ * Purpose: run the REAL @mcp-abap-adt/connection against something that records
+ * every byte of every request it emits — including the housekeeping requests the
+ * connector makes on its own (CSRF fetch, retries), which are invisible from
+ * behind IAbapConnection. No SAP system and no credentials involved.
+ *
+ * The stub models just enough ADT: hand out a CSRF token plus a session cookie,
+ * answer everything else with 200, and let a test force a status on any path.
+ */
+
+import { createServer, type Server } from 'node:http';
+
+export interface StubRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  /** True when the request carried the ADT stateful marker. */
+  stateful: boolean;
+}
+
+export interface AdtStub {
+  baseUrl: string;
+  requests: StubRequest[];
+  /** Force a status for the next request whose URL contains `match`. */
+  failNext(match: string, status: number): void;
+  close(): Promise<void>;
+  /** Requests whose URL contains `match`. */
+  matching(match: string): StubRequest[];
+  /** How many distinct sessions the stub has handed out so far. */
+  sessionsOpened(): number;
+}
+
+export async function startAdtStub(): Promise<AdtStub> {
+  const requests: StubRequest[] = [];
+  const failures: Array<{ match: string; status: number }> = [];
+  let sessionsOpened = 0;
+
+  const server: Server = createServer((req, res) => {
+    const url = req.url ?? '';
+    requests.push({
+      method: req.method ?? 'GET',
+      url,
+      headers: req.headers,
+      stateful: req.headers['x-sap-adt-sessiontype'] === 'stateful',
+    });
+
+    const failureIndex = failures.findIndex((f) => url.includes(f.match));
+    if (failureIndex !== -1) {
+      const [failure] = failures.splice(failureIndex, 1);
+      res.writeHead(failure.status, { 'content-type': 'text/html' });
+      // SAP wording matters: the connector only treats a 403 as a token problem
+      // when the body mentions CSRF (shouldRetryCsrf).
+      res.end(
+        failure.status === 403
+          ? '<html><body>CSRF token validation failed</body></html>'
+          : '<html><body>forced</body></html>',
+      );
+      return;
+    }
+
+    // Discovery doubles as the CSRF endpoint and opens a session. Each fetch
+    // opens a DISTINCT one, the way SAP does — that is what makes a silent
+    // re-establishment visible instead of looking like session continuity.
+    if (
+      url.includes('/sap/bc/adt/core/discovery') ||
+      url.includes('/sap/bc/adt/discovery')
+    ) {
+      sessionsOpened += 1;
+      res.writeHead(200, {
+        'content-type': 'application/atomsvc+xml',
+        'x-csrf-token': `STUB-CSRF-TOKEN-${sessionsOpened}`,
+        'set-cookie': `SAP_SESSIONID_STUB_100=STUB-SESSION-${sessionsOpened}; Path=/`,
+      });
+      res.end('<service/>');
+      return;
+    }
+
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('');
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('stub server did not bind to a TCP port');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    failNext: (match, status) => failures.push({ match, status }),
+    matching: (match) => requests.filter((r) => r.url.includes(match)),
+    sessionsOpened: () => sessionsOpened,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}

--- a/src/__tests__/unit/session/connectorSessionContract.test.ts
+++ b/src/__tests__/unit/session/connectorSessionContract.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Connector session contract — verified against the REAL connection package.
+ *
+ * What is established about the wire protocol:
+ *  - `x-sap-adt-sessiontype: stateful` is a per-request instruction ("handle
+ *    this one in a stateful session"). Eclipse sends it on LOCK/UNLOCK only;
+ *    every other call carries just the session cookie, and the lock survives.
+ *  - This connector never sends the header with value `stateless` — outside a
+ *    stateful window it simply omits it, which is wire-identical to an ordinary
+ *    Eclipse call. Omission is therefore NOT what closes a session.
+ *  - Session membership rides on the cookie (`sap-contextid` / SAP_SESSIONID),
+ *    with `sap-adt-connection-id` identifying the conversation.
+ *
+ * What these tests pin: the connector's own housekeeping requests (CSRF fetch,
+ * retry probes) are built by a separate code path that consults neither the
+ * session mode nor the connection id. That path is where a token refetch can
+ * silently start a NEW session — the failure mode worth guarding, distinct
+ * from the header question above.
+ *
+ * Local HTTP stub — no SAP, no credentials:
+ *   MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/session
+ */
+
+import { createAbapConnection } from '@mcp-abap-adt/connection';
+import type { ISapConfig } from '@mcp-abap-adt/interfaces';
+import { type AdtStub, startAdtStub } from './adtStubServer';
+
+const configFor = (baseUrl: string): ISapConfig => ({
+  url: baseUrl,
+  client: '100',
+  authType: 'basic',
+  username: 'STUB',
+  password: 'STUB',
+});
+
+describe('connector session contract (real @mcp-abap-adt/connection)', () => {
+  let stub: AdtStub;
+
+  beforeEach(async () => {
+    stub = await startAdtStub();
+  });
+
+  afterEach(async () => {
+    await stub.close();
+  });
+
+  it('marks ordinary requests stateful once the session is armed', async () => {
+    const conn = createAbapConnection(configFor(stub.baseUrl), null);
+    conn.setSessionType('stateful');
+
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub?_action=LOCK&accessMode=MODIFY',
+      method: 'POST',
+      timeout: 5000,
+      data: null,
+    });
+
+    const lock = stub.matching('_action=LOCK');
+    expect(lock).toHaveLength(1);
+    expect(lock[0].stateful).toBe(true);
+  });
+
+  /**
+   * REGRESSION SHIELD — connection@1.10.1, issue #14.
+   *
+   * The CSRF fetch used to assemble its own headers and omit
+   * `sap-adt-connection-id`, so a fetch triggered while a lock was held reached
+   * the server as a caller unrelated to the conversation that opened the
+   * session. It now carries the id like every other request.
+   *
+   * The session-type marker is deliberately still absent: Eclipse sends
+   * `x-sap-adt-sessiontype` on LOCK/UNLOCK only — not even on the lock-bound
+   * PUT between them — so putting it on a housekeeping GET has no established
+   * benefit. That asymmetry is intended, not an oversight.
+   */
+  it('sends the CSRF fetch inside the conversation, with the connection id', async () => {
+    const conn = createAbapConnection(configFor(stub.baseUrl), null);
+    conn.setSessionType('stateful');
+
+    // A mutation with no cached token forces the connector to fetch one first.
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub?_action=LOCK&accessMode=MODIFY',
+      method: 'POST',
+      timeout: 5000,
+      data: null,
+    });
+
+    const csrfFetches = stub
+      .matching('/discovery')
+      .filter((r) => r.headers['x-csrf-token'] === 'fetch');
+    expect(csrfFetches.length).toBeGreaterThan(0);
+
+    for (const fetch of csrfFetches) {
+      expect(fetch.headers['sap-adt-connection-id']).toBe(conn.getSessionId());
+      expect(fetch.stateful).toBe(false); // intended, see above
+    }
+  });
+
+  it('uses one connection id for the whole connector lifetime, including across reset()', async () => {
+    const conn = createAbapConnection(configFor(stub.baseUrl), null);
+    conn.setSessionType('stateful');
+
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub?_action=LOCK&accessMode=MODIFY',
+      method: 'POST',
+      timeout: 5000,
+      data: null,
+    });
+    // reset() drops the token, cookies and the axios instance — but the
+    // connection id must survive, otherwise every recovery would present the
+    // server with a different conversation.
+    (conn as unknown as { reset: () => void }).reset();
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub',
+      method: 'GET',
+      timeout: 5000,
+    });
+
+    const ids = stub.requests
+      .map((r) => r.headers['sap-adt-connection-id'])
+      .filter(Boolean);
+    expect(ids.length).toBeGreaterThan(1);
+    expect(new Set(ids).size).toBe(1);
+    expect(ids[0]).toBe(conn.getSessionId());
+  });
+
+  /**
+   * FORMAT NOTE (not a proven defect).
+   *
+   * Eclipse's connection id is 32 hex characters with no dashes
+   * (e.g. 26df8f6f97684b94a2d37044db28ea25). The connector already strips the
+   * dashes for `sap-adt-request-id` (`randomUUID().replace(/-/g, '')`) but not
+   * for `sap-adt-connection-id`, so ours goes out in dashed UUID form. Nothing
+   * observed says the server rejects it — this pins the difference so it is a
+   * decision rather than an accident.
+   */
+  it('sends the connection id as a dashed UUID, unlike the dashless Eclipse form', async () => {
+    const conn = createAbapConnection(configFor(stub.baseUrl), null);
+    conn.setSessionType('stateful');
+
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub?_action=LOCK&accessMode=MODIFY',
+      method: 'POST',
+      timeout: 5000,
+      data: null,
+    });
+
+    const locked = stub.matching('_action=LOCK')[0];
+    expect(locked.headers['sap-adt-connection-id']).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    // Eclipse form for comparison: 32 hex chars, no dashes.
+    expect(locked.headers['sap-adt-request-id']).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  /**
+   * DEFECT — lifecycle. A connector should hold its session from connect() and
+   * refuse to work after it is torn down, so that a caller can never operate on
+   * a session it did not open.
+   *
+   * Neither half holds today:
+   *  - `connect()` is optional. A request on a never-connected connector opens
+   *    a session on the fly, so "connected" is not a state the caller controls.
+   *  - There is no `disconnect()` on the HTTP connections at all (only RFC has
+   *    close()). `reset()` tears the session down, and the very next request
+   *    silently opens a NEW one under the SAME connection id — the caller keeps
+   *    believing it holds the lock it acquired in the previous session.
+   */
+  it('opens a session without connect(), and silently opens another after reset()', async () => {
+    const conn = createAbapConnection(configFor(stub.baseUrl), null);
+    conn.setSessionType('stateful');
+
+    // No connect() call anywhere — yet the mutation goes through.
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub?_action=LOCK&accessMode=MODIFY',
+      method: 'POST',
+      timeout: 5000,
+      data: null,
+    });
+    expect(stub.sessionsOpened()).toBe(1);
+    const lockCookie = stub.matching('_action=LOCK')[0].headers.cookie;
+
+    (conn as unknown as { reset: () => void }).reset();
+
+    // A teardown does not stop the connector: the next mutation quietly opens a
+    // second session. Nothing throws, nothing tells the caller.
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub/source/main?lockHandle=LH-1',
+      method: 'PUT',
+      timeout: 5000,
+      data: 'x',
+    });
+    expect(stub.sessionsOpened()).toBe(2);
+
+    const write = stub.matching('/source/main')[0];
+    expect(write.headers.cookie).not.toBe(lockCookie);
+    // Same conversation id, different session — indistinguishable to the caller.
+    expect(write.headers['sap-adt-connection-id']).toBe(conn.getSessionId());
+  });
+
+  it('keeps the mid-window recovery fetch after a 403 inside the conversation', async () => {
+    const conn = createAbapConnection(configFor(stub.baseUrl), null);
+    conn.setSessionType('stateful');
+
+    // Arm the session and cache a token.
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub?_action=LOCK&accessMode=MODIFY',
+      method: 'POST',
+      timeout: 5000,
+      data: null,
+    });
+    const beforeRetry = stub.requests.length;
+
+    // A CSRF rejection on the in-window write sends the connector back for a
+    // fresh token. That recovery request is the one most likely to land while a
+    // lock is held, so it must present the same conversation id.
+    stub.failNext('/source/main', 403);
+    await conn.makeAdtRequest({
+      url: '/sap/bc/adt/ddic/domains/zstub/source/main?lockHandle=LH-1',
+      method: 'PUT',
+      timeout: 5000,
+      data: 'x',
+    });
+
+    const duringRecovery = stub.requests.slice(beforeRetry);
+    const recoveryFetches = duringRecovery.filter(
+      (r) => r.headers['x-csrf-token'] === 'fetch',
+    );
+    expect(recoveryFetches.length).toBeGreaterThan(0);
+    expect(
+      recoveryFetches.every(
+        (r) => r.headers['sap-adt-connection-id'] === conn.getSessionId(),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/unit/session/sessionInvariants.test.ts
+++ b/src/__tests__/unit/session/sessionInvariants.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Client-side session invariants — no SAP system involved.
+ *
+ * A stateful ADT session is killed by what WE send, before SAP is even
+ * consulted: a request that leaves without the stateful marker while a lock is
+ * held. These tests pin that behaviour on the real handler chains, so a change
+ * in either adt-clients or the connector shows up as a red test rather than as
+ * an "object is locked and inactive" incident on a live system.
+ *
+ * Run without SAP credentials:
+ *   MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/session
+ */
+
+import { AdtClass } from '../../../core/class/AdtClass';
+import { AdtDomain } from '../../../core/domain/AdtDomain';
+import { LockRegistry } from '../../../core/shared/LockRegistry';
+import { noopLogger } from '../../../utils/noopLogger';
+import { createSessionRecorder } from './sessionRecorder';
+
+const SOURCE = 'CLASS zcl_a DEFINITION PUBLIC. ENDCLASS.';
+
+describe('session invariants — single handler', () => {
+  /**
+   * DELIBERATE DIVERGENCE FROM ECLIPSE.
+   *
+   * Eclipse sends `x-sap-adt-sessiontype: stateful` on LOCK and UNLOCK only —
+   * not even on the lock-bound PUT in between. We mark the whole window because
+   * of commit 50c9310 (#38, refs mcp-abap-adt#106): on older kernels (BASIS
+   * 7.55) a stateless lock-bound write failed with 423 "not locked (invalid
+   * lock handle)", while newer kernels (758/816) tolerated it.
+   *
+   * So this is compatibility, not protocol ignorance. Narrowing the window to
+   * Eclipse's form would reintroduce #38 on 7.55-class systems — do it only
+   * with evidence from that kernel class, not from a modern one.
+   */
+  it('issues every request of the update chain inside the lock window as stateful', async () => {
+    const rec = createSessionRecorder();
+    const cls = new AdtClass(rec.conn, noopLogger);
+
+    await cls.update({ className: 'ZCL_A', sourceCode: SOURCE });
+
+    const window = rec.lockWindow();
+    expect(window.length).toBeGreaterThan(1);
+    expect(window[0].url).toContain('_action=LOCK');
+    expect(window[window.length - 1].url).toContain('_action=UNLOCK');
+
+    const stateless = window.filter((c) => c.mode !== 'stateful');
+    expect(
+      stateless.map((c) => `${c.method} ${c.url} [${c.mode}]`),
+    ).toStrictEqual([]);
+  });
+
+  it('leaves the session stateless once the chain has unlocked', async () => {
+    const rec = createSessionRecorder();
+    const cls = new AdtClass(rec.conn, noopLogger);
+
+    await cls.update({ className: 'ZCL_A', sourceCode: SOURCE });
+
+    expect(rec.mode).toBe('stateless');
+  });
+
+  it('reads (GET) inside the lock window — the surface where a 401 or a timeout costs the lock', async () => {
+    const rec = createSessionRecorder();
+    const cls = new AdtClass(rec.conn, noopLogger);
+
+    await cls.update({ className: 'ZCL_A', sourceCode: SOURCE });
+
+    // A GET between UPDATE and UNLOCK is what turns a transient auth error or a
+    // per-request timeout into a lost lock: the connector reacts by re-fetching
+    // a CSRF token (a request without the stateful marker) or by tearing down
+    // the socket. Both happen while the lock is still held.
+    const getsInWindow = rec
+      .lockWindow()
+      .filter((c) => c.method === 'GET' && !c.url.includes('_action='));
+    expect(getsInWindow.length).toBeGreaterThan(0);
+  });
+});
+
+describe('session invariants — domain (the shape seen in the E19 incident)', () => {
+  /**
+   * The E19 "Session not found" log shows create 201 → LOCK 200 → GET 400: a
+   * GET immediately after LOCK, with no write in between. That GET is ours —
+   * updateDomain is a read-modify-write (`src/core/domain/update.ts:4`), so it
+   * reads the current XML while the lock is already held. This test pins that
+   * shape: it is the first request of the lock window that can hit a session
+   * which SAP has already dropped, and it is the exact request that failed.
+   */
+  it('emits the lock window as LOCK → GET → PUT → GET → UNLOCK, every request stateful', async () => {
+    const rec = createSessionRecorder();
+    const domain = new AdtDomain(rec.conn, noopLogger);
+
+    await domain.update({
+      domainName: 'ZOK_D_CS_553',
+      packageName: '$TMP',
+      description: 'probe',
+      datatype: 'CHAR',
+      length: 10,
+    });
+
+    const window = rec.lockWindow();
+    expect(window.map((c) => c.method)).toStrictEqual([
+      'POST', // LOCK
+      'GET', // read-modify-write: read current XML, lock already held
+      'PUT', // write the patched XML
+      'GET', // read-back with long polling
+      'POST', // UNLOCK
+    ]);
+    expect(window.every((c) => c.mode === 'stateful')).toBe(true);
+
+    // The read-modify-write GET sits directly behind LOCK, before any write.
+    // That is the request that returned 400 "Session not found" on E19 — the
+    // first place a session dropped between LOCK and the next call shows up.
+    expect(window[0].url).toContain('_action=LOCK');
+    expect(window[1].method).toBe('GET');
+  });
+
+  /**
+   * DEFECT CHARACTERISATION.
+   *
+   * A GET straight after LOCK is normal ADT behaviour — Eclipse does it too,
+   * but Eclipse reads the INACTIVE version. Ours asks for no version at all
+   * (`getDomain` builds the URL without a `version` parameter, and
+   * `AdtDomain.read` ignores its `_version` argument outright), so the
+   * read-modify-write patches whatever the ACTIVE version holds. After a create
+   * that left the object inactive, that reads the wrong source for the patch.
+   *
+   * Compare with the class chain, which does pass `version=inactive`.
+   */
+  it('reads no version at all after LOCK, where Eclipse reads the inactive one', async () => {
+    const rec = createSessionRecorder();
+    const domain = new AdtDomain(rec.conn, noopLogger);
+
+    await domain.update({
+      domainName: 'ZOK_D_CS_553',
+      packageName: '$TMP',
+      description: 'probe',
+      datatype: 'CHAR',
+      length: 10,
+    });
+
+    const readModifyWriteGet = rec.lockWindow()[1];
+    expect(readModifyWriteGet.method).toBe('GET');
+    expect(readModifyWriteGet.url).not.toContain('version=');
+  });
+});
+
+describe('session invariants — two handlers on one connection', () => {
+  /**
+   * DEFECT CHARACTERISATION (not desired behaviour).
+   *
+   * Handlers created from one AdtClient share a single IAbapConnection and a
+   * single session mode. A chain that finishes on handler B unconditionally
+   * restores 'stateless' — it has no way to know handler A still holds a lock.
+   * The next write for A therefore leaves the client without the stateful
+   * marker, which is exactly the 423 / "session does not exist" scenario.
+   *
+   * When this is fixed (lock-aware session control), flip the expectations:
+   * the PUT below must go out 'stateful' and rec.mode must stay 'stateful'
+   * while registry.pending is non-empty.
+   */
+  it('a chain finishing on handler B resets the session while handler A holds a lock', async () => {
+    const rec = createSessionRecorder();
+    const registry = new LockRegistry(rec.conn);
+    const clsA = new AdtClass(
+      rec.conn,
+      noopLogger,
+      undefined,
+      undefined,
+      registry,
+    );
+    const clsB = new AdtClass(
+      rec.conn,
+      noopLogger,
+      undefined,
+      undefined,
+      registry,
+    );
+
+    const handleA = await clsA.lock({ className: 'ZCL_A' });
+    expect(rec.mode).toBe('stateful');
+    expect(registry.pending).toStrictEqual(['Class/ZCL_A']);
+
+    await clsB.update({ className: 'ZCL_B', sourceCode: SOURCE });
+
+    // A's lock is still held...
+    expect(registry.pending).toStrictEqual(['Class/ZCL_A']);
+    // ...but B's chain has already put the shared session back to stateless.
+    expect(rec.mode).toBe('stateless');
+
+    const before = rec.calls.length;
+    await clsA.update(
+      { className: 'ZCL_A', sourceCode: SOURCE },
+      { lockHandle: handleA },
+    );
+
+    const writeForA = rec.calls
+      .slice(before)
+      .find((c) => c.method === 'PUT' && c.url.includes('zcl_a'));
+    expect(writeForA).toBeDefined();
+    // The defect, machine-checked: a write for a locked object left the client
+    // without the stateful marker.
+    expect(writeForA?.mode).toBe('stateless');
+  });
+
+  it('unlockAll releases the whole batch inside one stateful window', async () => {
+    const rec = createSessionRecorder();
+    const registry = new LockRegistry(rec.conn);
+    const clsA = new AdtClass(
+      rec.conn,
+      noopLogger,
+      undefined,
+      undefined,
+      registry,
+    );
+    const clsB = new AdtClass(
+      rec.conn,
+      noopLogger,
+      undefined,
+      undefined,
+      registry,
+    );
+
+    await clsA.lock({ className: 'ZCL_A' });
+    await clsB.lock({ className: 'ZCL_B' });
+
+    const before = rec.calls.length;
+    const failures = await registry.unlockAll();
+
+    expect(failures).toStrictEqual([]);
+    const unlocks = rec.calls
+      .slice(before)
+      .filter((c) => c.url.includes('_action=UNLOCK'));
+    expect(unlocks).toHaveLength(2);
+    expect(unlocks.every((c) => c.mode === 'stateful')).toBe(true);
+    expect(rec.mode).toBe('stateless');
+    expect(registry.pending).toStrictEqual([]);
+  });
+});

--- a/src/__tests__/unit/session/sessionRecorder.ts
+++ b/src/__tests__/unit/session/sessionRecorder.ts
@@ -1,0 +1,108 @@
+/**
+ * Session-mode recorder: a fake IAbapConnection that records, for every ADT
+ * request, which session mode was active when that request went out.
+ *
+ * Why this exists: a stateful ADT session dies when a request leaves the client
+ * without the stateful marker (or when the session identity is swapped under
+ * our feet). Both are client-side facts — they are decided by our chain code
+ * before any byte reaches SAP, so they can be proven without a SAP system.
+ *
+ * The recorder deliberately does NOT model SAP semantics (it never rejects a
+ * lock handle). It only answers: in which session mode did each request leave?
+ */
+
+import type { IAbapConnection, IAdtResponse } from '@mcp-abap-adt/interfaces';
+
+export type SessionMode = 'stateful' | 'stateless';
+
+export interface RecordedCall {
+  /** 0-based position in the request sequence. */
+  index: number;
+  method: string;
+  url: string;
+  /** Session mode active at the moment the request was issued. */
+  mode: SessionMode;
+}
+
+export interface SessionRecorder {
+  conn: IAbapConnection;
+  calls: RecordedCall[];
+  /** Session mode currently set on the connection. */
+  readonly mode: SessionMode;
+  /** Requests carrying `_action=LOCK` … `_action=UNLOCK`, both inclusive. */
+  lockWindow(): RecordedCall[];
+  urls(): string[];
+}
+
+const lockXml = (handle: string): string =>
+  `<asx:abap xmlns:asx="http://www.sap.com/abapxml"><asx:values><DATA><LOCK_HANDLE>${handle}</LOCK_HANDLE></DATA></asx:values></asx:abap>`;
+
+/** Empty report — parseCheckRunResponse reads it as "no errors". */
+const CHECKRUN_OK =
+  '<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun"/>';
+
+const ok = (data: unknown): IAdtResponse =>
+  ({ data, status: 200, statusText: 'OK', headers: {} }) as IAdtResponse;
+
+/**
+ * @param respond Optional override consulted before the default responses;
+ *   return undefined to fall through. Use it to inject errors at a chosen step.
+ * @param lockHandle Handle handed out by LOCK requests.
+ */
+export function createSessionRecorder(
+  respond?: (options: {
+    url: string;
+    method: string;
+    index: number;
+  }) => IAdtResponse | undefined,
+  lockHandle = 'LH-1',
+): SessionRecorder {
+  let mode: SessionMode = 'stateless';
+  const calls: RecordedCall[] = [];
+
+  const conn = {
+    connect: async () => undefined,
+    getBaseUrl: async () => 'http://stub.invalid',
+    getSessionId: () => 'STUB-SESSION',
+    setSessionType: (type: SessionMode) => {
+      mode = type;
+    },
+    // Loose shape on purpose: the fake mirrors what handlers actually pass.
+    makeAdtRequest: async (options: any): Promise<IAdtResponse> => {
+      const url = String(options.url);
+      const method = String(options.method ?? 'GET').toUpperCase();
+      const index = calls.length;
+      calls.push({ index, method, url, mode });
+
+      const override = respond?.({ url, method, index });
+      if (override) {
+        return override;
+      }
+
+      if (url.includes('_action=LOCK')) {
+        return ok(lockXml(lockHandle));
+      }
+      if (url.includes('/checkruns')) {
+        return ok(CHECKRUN_OK);
+      }
+      return ok('');
+    },
+  } as unknown as IAbapConnection;
+
+  return {
+    conn,
+    calls,
+    get mode() {
+      return mode;
+    },
+    urls: () => calls.map((c) => `${c.method} ${c.url}`),
+    lockWindow() {
+      const start = calls.findIndex((c) => c.url.includes('_action=LOCK'));
+      if (start === -1) {
+        return [];
+      }
+      const end = calls.findIndex((c) => c.url.includes('_action=UNLOCK'));
+      return calls.slice(start, end === -1 ? calls.length : end + 1);
+    },
+  };
+}


### PR DESCRIPTION
Realigns with `@mcp-abap-adt/connection@1.10.1` (fr0ster/mcp-abap-connection#14) and adds a session-invariant harness that runs without SAP or credentials.

## Why

Chasing an orphaned edit-lock incident ("object created, INACTIVE and locked") showed that the session story was untestable: nothing recorded which session mode our chains emit, and the connector's own housekeeping requests were invisible from behind `IAbapConnection`. Two things came out of it — a fix in the connector, and this harness so neither side can regress silently.

Dependency note: the lock file was pinned to `1.8.1` while `package.json` already allowed `1.10.x`, so this repo and any freshly-installing environment were running different connector code. That drift is now gone.

## What the harness pins

`MCP_ENV_PATH=/tmp/nonexistent-env npx jest src/__tests__/unit/session`

**Our chains** (`sessionRecorder.ts`, `sessionInvariants.test.ts`) — records the session mode active at every request:

- the whole lock window goes out stateful. This is a deliberate divergence from Eclipse, which marks LOCK/UNLOCK only, not even the lock-bound PUT: see 50c9310 (#38) — on BASIS 7.55 a stateless lock-bound write returned 423, while 758/816 tolerated it. The test says so, so nobody narrows the window from modern-kernel evidence alone.
- domain update is `LOCK → GET → PUT → GET → UNLOCK`, with the read-modify-write GET sitting directly behind LOCK (`src/core/domain/update.ts:4`). That is the request that failed with 400 "Session not found" in the field.
- `unlockAll()` releases a whole batch inside one stateful window.

**The connector** (`adtStubServer.ts`, `connectorSessionContract.test.ts`) — a local HTTP stub records every inbound request and drives the real connection package:

- shields the #14 fix: the CSRF fetch now carries `sap-adt-connection-id`;
- documents that `x-sap-adt-sessiontype` stays absent from housekeeping GETs on purpose (Eclipse omits it too);
- pins that one connection id serves the connector's whole lifetime, including across `reset()`.

## Known defects, characterised not asserted

Two tests pin today's behaviour and name the expectation to flip once fixed:

1. a chain finishing on one handler restores `stateless` on the shared connection while another handler still holds a lock — the next write for the locked object leaves without the stateful marker;
2. the connector works without `connect()` and, after `reset()`, silently opens a **new** session under the same connection id — a caller mid-lock cannot tell (fr0ster/mcp-abap-connection#15, BREAKING, needs an interfaces release first).

## Verification

```
74 suites / 379 tests passed
biome check, tsc (src + tests), build — clean
installed connector: 1.10.1, no "link": true in package-lock.json
```

No library code changed; `package.json` version untouched (dev-dependency only, nothing published changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)