### PR TITLE
fix(tests): stub logs through an injected logger; deterministic teardown

### DIFF
--- a/src/__tests__/unit/session/adtStubServer.ts
+++ b/src/__tests__/unit/session/adtStubServer.ts
@@ -11,6 +11,7 @@
  */
 
 import { createServer, type Server } from 'node:http';
+import type { ILogger } from '@mcp-abap-adt/interfaces';
 
 export interface StubRequest {
   method: string;
@@ -32,13 +33,19 @@ export interface AdtStub {
   sessionsOpened(): number;
 }
 
-export async function startAdtStub(): Promise<AdtStub> {
+/**
+ * @param logger Optional injected logger for request tracing. Omit it and the
+ *   stub stays silent — diagnostics go through the logger, never to the console,
+ *   so a test run prints nothing unless a caller asked for it.
+ */
+export async function startAdtStub(logger?: ILogger): Promise<AdtStub> {
   const requests: StubRequest[] = [];
   const failures: Array<{ match: string; status: number }> = [];
   let sessionsOpened = 0;
 
   const server: Server = createServer((req, res) => {
     const url = req.url ?? '';
+    logger?.debug('stub request', { method: req.method, url });
     requests.push({
       method: req.method ?? 'GET',
       url,
@@ -94,8 +101,9 @@ export async function startAdtStub(): Promise<AdtStub> {
     matching: (match) => requests.filter((r) => r.url.includes(match)),
     sessionsOpened: () => sessionsOpened,
     close: () =>
-      new Promise<void>((resolve, reject) =>
-        server.close((err) => (err ? reject(err) : resolve())),
-      ),
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+        server.closeAllConnections();
+      }),
   };
 }


### PR DESCRIPTION
Follow-up to #84, one file.

## Injected logger instead of console

The ADT stub carried a `console.error` request trace. Diagnostics belong on an injected `ILogger` — in test helpers as much as in library code. A logger is silent unless the caller asks for output, so a run stays clean and the same helper serves both quiet and verbose use; a `console.*` call cannot be turned off by the caller and pollutes every run (it showed up as a `● Console` block in the jest report).

`startAdtStub(logger?: ILogger)` now traces at debug level. Omitted logger means silence, which is what every current caller wants.

## Deterministic teardown

`close()` also destroys remaining sockets. Measured both ways under `--no-forceExit --detectOpenHandles`: identical timing (~2.2–2.6 s), no open handles either way — Node 19+ already closes idle keep-alive connections inside `server.close()`, and we run Node 25. So this is defensive rather than a fix for an observed leak: it makes teardown deterministic where a socket is active rather than idle, which `forceExit: true` in `jest.config.js` would otherwise mask.

Note the stub is the only lever available here — the connector has no `disconnect()`, and `reset()` drops the axios instance while sockets belong to the global agent. That is fr0ster/mcp-abap-connection#15 seen from the test side.

## Verification

```
74 suites / 379 tests passed
biome check, tsc (src + tests) — clean
no console.* left under src/__tests__/unit/session/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)