### PR TITLE
chore(lint): enforce injected loggers over console (noConsole)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Error handling in chains: automatic unlock + `setSessionType('stateless')` on an
 - All dependencies must resolve from npm registry only. No local links or symlinks (`"link": true`) in `package-lock.json`. Sibling repos exist in parent directory — npm may auto-link them. Always verify after `npm install`.
 - Biome config: single quotes, semicolons always, indent 2 spaces
 - `noExplicitAny: warn` in production code, relaxed in tests
+- **All diagnostic output goes through an injected `ILogger` — never `console.*`.** This holds for test helpers and stubs as much as for library code: a logger stays silent unless the caller asks for output, so runs stay clean and one helper serves both quiet and verbose use, while a `console.*` call cannot be turned off by the caller. Give a helper an optional `logger?: ILogger` parameter and call `logger?.debug('message', { meta })`. Enforced by `noConsole` — `error` in production code, `warn` in tests (existing test occurrences are debt, not a precedent)
 
 ## Testing Notes
 

--- a/biome.json
+++ b/biome.json
@@ -1,62 +1,64 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true
-	},
-	"files": {
-		"includes": ["**", "!!**/dist"]
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "space",
-		"indentWidth": 2
-	},
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"suspicious": {
-				"noExplicitAny": "warn"
-			},
-			"correctness": {
-				"noUnusedVariables": "warn",
-				"noUnusedImports": "warn"
-			}
-		}
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "single",
-			"semicolons": "always"
-		}
-	},
-	"assist": {
-		"enabled": true,
-		"actions": {
-			"source": {
-				"organizeImports": "on"
-			}
-		}
-	},
-	"overrides": [
-		{
-			"includes": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noExplicitAny": "off"
-					},
-					"style": {
-						"noNonNullAssertion": "off"
-					},
-					"correctness": {
-						"noUnusedVariables": "off",
-						"noUnusedImports": "off"
-					}
-				}
-			}
-		}
-	]
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["**", "!!**/dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noConsole": "error"
+      },
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off",
+            "noConsole": "warn"
+          },
+          "style": {
+            "noNonNullAssertion": "off"
+          },
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
The rule was unwritten, so nothing stopped a `console.error` from landing in a test helper (#85), and the existing occurrences in tests read as an accepted pattern to anyone glancing at neighbouring files.

## What

**CLAUDE.md**, under Code Standards: all diagnostic output goes through an injected `ILogger`, never `console.*` — test helpers and stubs included. A logger stays silent unless the caller asks for output, so runs stay clean and one helper serves both quiet and verbose use, while a `console.*` call cannot be turned off by the caller.

**biome.json**:

| scope | severity | findings today |
|---|---|---|
| production code | `error` | **0** — the four `console.log` matches under `src/` are examples inside JSDoc blocks |
| tests | `warn` | 20 across 6 files (`globalSetup.ts`, `test-helper.js`, `csrf.test.ts`, `check.test.ts`, `MasterLanguage.test.ts`, `BatchEndpointScope.test.ts`) |

Warnings keep the existing test debt visible without blocking, and mark it as debt rather than precedent.

## Verification

```
npm run lint:check → 76 warnings, 25 infos, no errors (was 45 warnings)
probe file with console.log under src/utils/ → error, as intended
```

`biome.json` was reindented tabs → spaces by the repo's own pre-commit formatter, which is why the diff is larger than the two added lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)