### PR TITLE
docs(spec): drop a doubled word in the D1 statement

### DIFF
--- a/docs/superpowers/specs/2026-07-27-session-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-27-session-lifecycle-design.md
@@ -66,7 +66,7 @@ alike:
   after a fresh login form or a fresh JWT the old ABAP session cannot be kept.
 
 The second kind cannot be forbidden. It is made explicit instead: transparent
-transparent while no lock is held, fatal while one is.
+while no lock is held, fatal while one is.
 
 Rejected: throwing on every forced replacement. It would break the automatic
 recovery that read-only consumers rely on today and see no problem with.


### PR DESCRIPTION
Follow-up to #87. One word.

`docs/superpowers/specs/2026-07-27-session-lifecycle-design.md:68` read *"transparent transparent while no lock is held"*. The repetition straddled a line break, which is why it survived every read of that paragraph — and D1 is a normative statement, so the sentence is one people will quote.

Scanned the rest of the spec for the same shape, deliberately allowing a newline between the two words rather than a space:

```python
re.finditer(r'\b([A-Za-z]{3,})\s+\1\b', text)
```

That was the only hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)