### PR TITLE
fix(test): make the table type's row type a shared dependency

### DIFF
--- a/src/__tests__/admin/shared-deps/check.test.ts
+++ b/src/__tests__/admin/shared-deps/check.test.ts
@@ -50,6 +50,7 @@ function getSharedNames(
 
 /** All shared_dependencies sections */
 const ALL_SECTIONS = [
+  'structures',
   'tables',
   'views',
   'access_controls',

--- a/src/__tests__/admin/shared-deps/setup.test.ts
+++ b/src/__tests__/admin/shared-deps/setup.test.ts
@@ -94,8 +94,13 @@ describe('Admin: Setup shared dependencies', () => {
       testsLogger.info('Setting up shared package...');
       await ensureSharedPackage(client, testsLogger);
 
-      // Dependency order: tables → views → access_controls → behavior_definitions → service_definitions → service_bindings → classes → interfaces → function_groups → function_modules → programs
+      // Dependency order: structures → tables → views → access_controls → behavior_definitions → service_definitions → service_bindings → classes → interfaces → function_groups → function_modules → programs
+      //
+      // Structures come first because a table type names one as its row type,
+      // and an inactive or absent row type fails the activation rather than the
+      // create — the failure lands one step later than its cause.
       const typeOrder: Array<{ type: string; label: string }> = [
+        { type: 'structures', label: 'Structures' },
         { type: 'tables', label: 'Tables' },
         { type: 'views', label: 'Views' },
         { type: 'access_controls', label: 'Access controls' },

--- a/src/__tests__/admin/shared-deps/teardown.test.ts
+++ b/src/__tests__/admin/shared-deps/teardown.test.ts
@@ -299,6 +299,33 @@ describe('Admin: Teardown shared dependencies', () => {
         results.push({ type: 'tables', name: item.name, status });
       }
 
+      // 3b. Structures — LAST of the data-dictionary objects, because a table
+      // type names one as its row type. Deleting a structure while something
+      // still points at it is the mirror of creating it too late: the failure
+      // surfaces on the dependent object, not on the one actually at fault.
+      const structures = sharedConfig.structures || [];
+      for (const item of structures) {
+        if (shouldSkip(item, 'structure')) {
+          results.push({
+            type: 'structures',
+            name: item.name,
+            status: 'skipped',
+          });
+          continue;
+        }
+        const status = await safeDelete(
+          `structure ${item.name}`,
+          async () => {
+            await client.getStructure().delete({
+              structureName: item.name,
+              transportRequest,
+            });
+          },
+          testsLogger,
+        );
+        results.push({ type: 'structures', name: item.name, status });
+      }
+
       // 4. Function groups
       const functionGroups = sharedConfig.function_groups || [];
       for (const item of functionGroups) {

--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -104,6 +104,17 @@ shared_dependencies:
   software_component: ""                     # e.g., HOME (leave empty for cloud)
   transport_layer: ""                        # e.g., ZE19 (leave empty for cloud)
 
+  structures:
+    - name: "ZAC_SHR_STRU"
+      description: "Shared structure used as a table type's row type"
+      source: |
+        @EndUserText.label: 'Shared structure for TableType row type'
+        @AbapCatalog.enhancement.category: #NOT_EXTENSIBLE
+        define structure ZAC_SHR_STRU {
+          mandt  : abap.clnt;
+          field1 : abap.int1;
+        }
+
   tables:
     - name: "ZAC_SHR_VTABL"
       description: "Shared table for View and CDS Unit Test"
@@ -961,7 +972,7 @@ create_tabletype:
         # package_name: "ZAC_PKG01"
         # transport_request: ""
         # XML format parameters (for update - rowType added after create)
-        row_type_name: "ZAC_STRU01"  # Structure name (must exist)
+        row_type_name: "ZAC_SHR_STRU"  # → shared_dependencies.structures
         row_type_kind: "dictionaryType"   # Type kind: dictionaryType, predefinedAbapType, etc.
         access_type: "standard"           # standard, sorted, hashed, index
         primary_key_definition: "standard"  # standard, rowType, keyComponents, empty

--- a/src/__tests__/helpers/test-helper.js
+++ b/src/__tests__/helpers/test-helper.js
@@ -2173,7 +2173,10 @@ async function ensureSharedDependency(client, type, name, logger) {
   // Check if the object already exists
   let exists = false;
   try {
-    if (type === 'tables') {
+    if (type === 'structures') {
+      const result = await client.getStructure().read({ structureName: name });
+      exists = !!result;
+    } else if (type === 'tables') {
       const result = await client.getTable().read({ tableName: name });
       // Table read returns { readResult: undefined } on 404 (quirk)
       exists = result?.readResult !== undefined;
@@ -2251,7 +2254,27 @@ async function ensureSharedDependency(client, type, name, logger) {
   // Create the object (high-level create does full chain: validate → create → lock → update → unlock → activate)
   logger?.info?.(`Creating shared ${type} ${name}...`);
   try {
-    if (type === 'tables') {
+    if (type === 'structures') {
+      await client.getStructure().create({
+        structureName: name,
+        packageName,
+        description: depConfig.description || 'Shared test structure',
+        ddlCode: depConfig.source,
+        transportRequest,
+      });
+      if (depConfig.source) {
+        logger?.info?.(`Activating shared structure ${name}...`);
+        await client.getStructure().update(
+          {
+            structureName: name,
+            ddlCode: depConfig.source,
+            transportRequest,
+          },
+          { activateOnUpdate: true, sourceCode: depConfig.source },
+        );
+        logger?.info?.(`Shared structure ${name} activated`);
+      }
+    } else if (type === 'tables') {
       await client.getTable().create({
         tableName: name,
         packageName,


### PR DESCRIPTION
`TableType` failed on the trial cloud — in a combined run **and on its own**.

## What was wrong

```yaml
row_type_name: "ZAC_STRU01"  # Structure name (must exist)
```

It does not exist. `ZAC_STRU01` is the **Structure suite's own workflow object**: created by its flow and deleted by its cleanup. The annotation was untrue by construction, and the failure landed on activation rather than on the missing object:

```
✗ activate FAILED: Activation of ZAC_TTYP01 failed: Activation was cancelled.;
  Row type ZAC_STRU01 is not active or does not exist; TTYP ZAC_TTYP01 was not activated
```

One step after its cause, which is why it reads as "the table type is broken" rather than "its row type is gone".

## What this does

The repository already has the mechanism — this test simply went around it. `shared_dependencies` creates in dependency order and deletes in reverse, and the convention for referencing one is visible on the View case:

```yaml
table_name: "ZAC_SHR_VTABL"    # → shared_dependencies.tables
```

So `structures` becomes a shared category holding `ZAC_SHR_STRU`, and TableType points at it. Five places, because that is what a category costs here:

| file | change |
|---|---|
| `test-config.yaml.template` | the `structures` section; TableType repointed (the real `test-config.yaml` is gitignored and was updated locally) |
| `test-helper.js` | read and create branches, mirroring tables: create, then activate via update |
| `setup.test.ts` | structures **first** — a row type is needed at activation |
| `teardown.test.ts` | structures **after** tables, i.e. the reverse |
| `check.test.ts` | `'structures'` in `ALL_SECTIONS`, or the shared structure reads as an orphan |

The teardown position is worth a second look during review: deleting a structure while something still points at it is the same mistake from the other end, and would again surface on the dependent object rather than on the one at fault.

## Verified where it had to be — the trial cloud

| | before | after |
|---|---|---|
| `tabletype` alone | 1 failed, 1 passed | **2/2**, activation succeeds |
| `structure` + `tabletype`, one run | 1 failed | **4/4** |

The second row is the original failing combination. Structure still creates and deletes its own `ZAC_STRU01`; nothing depends on it any more.

```
384 unit tests · build:fast · test:check · Biome clean
```

## Noted, not fixed here

The same list of types lives in **three** places: `typeOrder` in setup, the block sequence in teardown, and `ALL_SECTIONS` in check. All three are updated in this PR, but the next category will need the same discipline and forgetting one of them is silent — the orphan check would quietly disagree with what setup creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)