### PR TITLE
fix(tests): eight integration files silently skipped on cloud and reported green

### DIFF
--- a/src/__tests__/integration/shared/discovery.test.ts
+++ b/src/__tests__/integration/shared/discovery.test.ts
@@ -11,7 +11,7 @@ import { createAbapConnection, type SapConfig } from '@mcp-abap-adt/connection';
 import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { createTestsLogger } from '../../helpers/testLogger';
 import { logTestStep } from '../../helpers/testProgressLogger';
 
@@ -25,63 +25,6 @@ if (fs.existsSync(envPath)) {
 
 const testsLogger: ILogger = createTestsLogger();
 
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
-
 describe('Shared - discovery', () => {
   let connection: IAbapConnection;
   let client: AdtClient;
@@ -92,6 +35,9 @@ describe('Shared - discovery', () => {
     try {
       const config = getConfig();
       connection = createAbapConnection(config, testsLogger);
+      // The connector refuses work on a connection nobody opened; these files
+      // predate that contract and never noticed, because they were skipping.
+      await (connection as any).connect();
       const { client: resolvedClient, isLegacy: legacy } =
         await createTestAdtClient(connection, testsLogger);
       client = resolvedClient;

--- a/src/__tests__/integration/shared/functionGroupIncludesList.test.ts
+++ b/src/__tests__/integration/shared/functionGroupIncludesList.test.ts
@@ -12,7 +12,7 @@ import { createAbapConnection, type SapConfig } from '@mcp-abap-adt/connection';
 import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { createTestsLogger } from '../../helpers/testLogger';
 import { logTestStep } from '../../helpers/testProgressLogger';
 
@@ -29,63 +29,6 @@ if (fs.existsSync(envPath)) {
 
 const testsLogger: ILogger = createTestsLogger();
 
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
-
 describe('Shared - listFunctionGroupIncludes', () => {
   let connection: IAbapConnection;
   let client: AdtClient;
@@ -95,6 +38,9 @@ describe('Shared - listFunctionGroupIncludes', () => {
     try {
       const config = getConfig();
       connection = createAbapConnection(config, testsLogger);
+      // The connector refuses work on a connection nobody opened; these files
+      // predate that contract and never noticed, because they were skipping.
+      await (connection as any).connect();
       const { client: resolvedClient } = await createTestAdtClient(
         connection,
         testsLogger,

--- a/src/__tests__/integration/shared/functionModulesList.test.ts
+++ b/src/__tests__/integration/shared/functionModulesList.test.ts
@@ -12,7 +12,7 @@ import { createAbapConnection, type SapConfig } from '@mcp-abap-adt/connection';
 import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { createTestsLogger } from '../../helpers/testLogger';
 import { logTestStep } from '../../helpers/testProgressLogger';
 
@@ -28,63 +28,6 @@ if (fs.existsSync(envPath)) {
 
 const testsLogger: ILogger = createTestsLogger();
 
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
-
 describe('Shared - listFunctionModules', () => {
   let connection: IAbapConnection;
   let client: AdtClient;
@@ -94,6 +37,9 @@ describe('Shared - listFunctionModules', () => {
     try {
       const config = getConfig();
       connection = createAbapConnection(config, testsLogger);
+      // The connector refuses work on a connection nobody opened; these files
+      // predate that contract and never noticed, because they were skipping.
+      await (connection as any).connect();
       const { client: resolvedClient } = await createTestAdtClient(
         connection,
         testsLogger,

--- a/src/__tests__/integration/shared/readMetadata.test.ts
+++ b/src/__tests__/integration/shared/readMetadata.test.ts
@@ -13,7 +13,7 @@ import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
 import type { AdtObjectType } from '../../../core/shared/types';
 import { isCloudEnvironment } from '../../../utils/systemInfo';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { TestConfigResolver } from '../../helpers/TestConfigResolver';
 import { createTestsLogger } from '../../helpers/testLogger';
 import { logTestSkip, logTestStep } from '../../helpers/testProgressLogger';
@@ -26,64 +26,6 @@ if (fs.existsSync(envPath)) {
 
 const testsLogger = createTestsLogger();
 const { isHttpStatusAllowed } = require('../../helpers/test-helper');
-
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    // Add refresh credentials for auto-refresh (if available)
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
 
 describe('Shared - readMetadata', () => {
   let connection: IAbapConnection;

--- a/src/__tests__/integration/shared/readSource.test.ts
+++ b/src/__tests__/integration/shared/readSource.test.ts
@@ -13,7 +13,7 @@ import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
 import type { AdtSourceObjectType } from '../../../core/shared/types';
 import { isCloudEnvironment } from '../../../utils/systemInfo';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { TestConfigResolver } from '../../helpers/TestConfigResolver';
 import {
   createConnectionLogger,
@@ -33,64 +33,6 @@ if (fs.existsSync(envPath)) {
 const connectionLogger: ILogger = createConnectionLogger();
 // Test execution logs use DEBUG_ADT_TESTS
 const testsLogger: ILogger = createTestsLogger();
-
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    // Add refresh credentials for auto-refresh (if available)
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
 
 describe('Shared - readSource', () => {
   let connection: IAbapConnection;

--- a/src/__tests__/integration/shared/search.test.ts
+++ b/src/__tests__/integration/shared/search.test.ts
@@ -11,7 +11,8 @@ import { createAbapConnection, type SapConfig } from '@mcp-abap-adt/connection';
 import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { parseSearchResults } from '../../../core/shared/search';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { createTestsLogger } from '../../helpers/testLogger';
 import { logTestStep } from '../../helpers/testProgressLogger';
 
@@ -25,64 +26,6 @@ if (fs.existsSync(envPath)) {
 
 const testsLogger: ILogger = createTestsLogger();
 
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    // Add refresh credentials for auto-refresh (if available)
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
-
 describe('Shared - searchObjects', () => {
   let connection: IAbapConnection;
   let client: AdtClient;
@@ -93,6 +36,9 @@ describe('Shared - searchObjects', () => {
     try {
       const config = getConfig();
       connection = createAbapConnection(config, testsLogger);
+      // The connector refuses work on a connection nobody opened; these files
+      // predate that contract and never noticed, because they were skipping.
+      await (connection as any).connect();
       const { client: resolvedClient, isLegacy: legacy } =
         await createTestAdtClient(connection, testsLogger);
       client = resolvedClient;
@@ -136,10 +82,16 @@ describe('Shared - searchObjects', () => {
     testsLogger.info?.('✅ Search completed');
     testsLogger.info?.(`📊 Response size: ${result.data?.length || 0} bytes`);
 
-    // Parse and log number of results
-    const matches = result.data?.match(/<objectReference/g);
-    if (matches) {
-      testsLogger.info?.(`🎯 Found ${matches.length} objects`);
+    // Parse with the shipped parser rather than a regex. The regex here used to
+    // be /<objectReference/, which never matches: SAP prefixes the element,
+    // `<adtcore:objectReference`. The count was only logged, never asserted, so
+    // it silently found nothing for as long as it existed — and read as
+    // evidence that the payload was unprefixed, which it is not.
+    const hits = parseSearchResults(String(result.data ?? ''));
+    testsLogger.info?.(`🎯 Found ${hits.length} objects`);
+    for (const hit of hits) {
+      expect(hit.name).toBeTruthy();
+      expect(hit.type).toBeTruthy();
     }
   }, 15000);
 
@@ -168,10 +120,16 @@ describe('Shared - searchObjects', () => {
     testsLogger.info?.('✅ Search completed');
     testsLogger.info?.(`📊 Response size: ${result.data?.length || 0} bytes`);
 
-    // Parse and log number of results
-    const matches = result.data?.match(/<objectReference/g);
-    if (matches) {
-      testsLogger.info?.(`🎯 Found ${matches.length} tables`);
+    // Parse with the shipped parser rather than a regex. The regex here used to
+    // be /<objectReference/, which never matches: SAP prefixes the element,
+    // `<adtcore:objectReference`. The count was only logged, never asserted, so
+    // it silently found nothing for as long as it existed — and read as
+    // evidence that the payload was unprefixed, which it is not.
+    const hits = parseSearchResults(String(result.data ?? ''));
+    testsLogger.info?.(`🎯 Found ${hits.length} tables`);
+    for (const hit of hits) {
+      expect(hit.name).toBeTruthy();
+      expect(hit.type).toBeTruthy();
     }
   }, 15000);
 

--- a/src/__tests__/integration/shared/search.test.ts
+++ b/src/__tests__/integration/shared/search.test.ts
@@ -89,6 +89,10 @@ describe('Shared - searchObjects', () => {
     // evidence that the payload was unprefixed, which it is not.
     const hits = parseSearchResults(String(result.data ?? ''));
     testsLogger.info?.(`🎯 Found ${hits.length} objects`);
+    // Assert the count FIRST. Asserting only inside the loop is how the old
+    // regex failed: on an empty result no assertion runs and the test passes,
+    // so a wrong namespace or a broken parser reads as success.
+    expect(hits.length).toBeGreaterThan(0);
     for (const hit of hits) {
       expect(hit.name).toBeTruthy();
       expect(hit.type).toBeTruthy();
@@ -127,6 +131,10 @@ describe('Shared - searchObjects', () => {
     // evidence that the payload was unprefixed, which it is not.
     const hits = parseSearchResults(String(result.data ?? ''));
     testsLogger.info?.(`🎯 Found ${hits.length} tables`);
+    // Assert the count FIRST. Asserting only inside the loop is how the old
+    // regex failed: on an empty result no assertion runs and the test passes,
+    // so a wrong namespace or a broken parser reads as success.
+    expect(hits.length).toBeGreaterThan(0);
     for (const hit of hits) {
       expect(hit.name).toBeTruthy();
       expect(hit.type).toBeTruthy();

--- a/src/__tests__/integration/shared/sqlQuery.test.ts
+++ b/src/__tests__/integration/shared/sqlQuery.test.ts
@@ -14,7 +14,7 @@ import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
 import { isCloudEnvironment } from '../../../utils/systemInfo';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { TestConfigResolver } from '../../helpers/TestConfigResolver';
 import { createTestsLogger } from '../../helpers/testLogger';
 import {
@@ -32,64 +32,6 @@ if (fs.existsSync(envPath)) {
 }
 
 const testsLogger: ILogger = createTestsLogger();
-
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    // Add refresh credentials for auto-refresh (if available)
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
 
 describe('Shared - getSqlQuery', () => {
   let connection: IAbapConnection;

--- a/src/__tests__/integration/shared/tableContents.test.ts
+++ b/src/__tests__/integration/shared/tableContents.test.ts
@@ -14,7 +14,7 @@ import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
 import type { AdtClient } from '../../../clients/AdtClient';
 import { isCloudEnvironment } from '../../../utils/systemInfo';
-import { createTestAdtClient } from '../../helpers/sessionConfig';
+import { createTestAdtClient, getConfig } from '../../helpers/sessionConfig';
 import { TestConfigResolver } from '../../helpers/TestConfigResolver';
 import { createTestsLogger } from '../../helpers/testLogger';
 import {
@@ -32,64 +32,6 @@ if (fs.existsSync(envPath)) {
 }
 
 const testsLogger: ILogger = createTestsLogger();
-
-function getConfig(): SapConfig {
-  const rawUrl = process.env.SAP_URL;
-  const url = rawUrl ? rawUrl.split('#')[0].trim() : rawUrl;
-  const rawClient = process.env.SAP_CLIENT;
-  const client = rawClient ? rawClient.split('#')[0].trim() : rawClient;
-  const rawAuthType = process.env.SAP_AUTH_TYPE || 'basic';
-  const authType = rawAuthType.split('#')[0].trim();
-
-  if (!url || !/^https?:\/\//.test(url)) {
-    throw new Error(`Missing or invalid SAP_URL: ${url}`);
-  }
-
-  const config: SapConfig = {
-    url,
-    authType: authType === 'xsuaa' ? 'jwt' : (authType as 'basic' | 'jwt'),
-  };
-
-  if (client) {
-    config.client = client;
-  }
-
-  if (authType === 'jwt' || authType === 'xsuaa') {
-    const jwtToken = process.env.SAP_JWT_TOKEN;
-    if (!jwtToken) {
-      throw new Error('Missing SAP_JWT_TOKEN for JWT authentication');
-    }
-    config.jwtToken = jwtToken;
-
-    // Add refresh credentials for auto-refresh (if available)
-    const refreshToken = process.env.SAP_REFRESH_TOKEN;
-    if (refreshToken) {
-      config.refreshToken = refreshToken;
-    }
-
-    const uaaUrl = process.env.SAP_UAA_URL || process.env.UAA_URL;
-    const uaaClientId =
-      process.env.SAP_UAA_CLIENT_ID || process.env.UAA_CLIENT_ID;
-    const uaaClientSecret =
-      process.env.SAP_UAA_CLIENT_SECRET || process.env.UAA_CLIENT_SECRET;
-
-    if (uaaUrl) config.uaaUrl = uaaUrl;
-    if (uaaClientId) config.uaaClientId = uaaClientId;
-    if (uaaClientSecret) config.uaaClientSecret = uaaClientSecret;
-  } else {
-    const username = process.env.SAP_USERNAME;
-    const password = process.env.SAP_PASSWORD;
-    if (!username || !password) {
-      throw new Error(
-        'Missing SAP_USERNAME or SAP_PASSWORD for basic authentication',
-      );
-    }
-    config.username = username;
-    config.password = password;
-  }
-
-  return config;
-}
 
 describe('Shared - getTableContents', () => {
   let connection: IAbapConnection;

--- a/src/__tests__/unit/parseSearchResults.test.ts
+++ b/src/__tests__/unit/parseSearchResults.test.ts
@@ -8,14 +8,11 @@
  */
 import { parseSearchResults } from '../../core/shared/search';
 
-const prefixed = `<?xml version="1.0" encoding="UTF-8"?>
-<adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core">
-  <adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/classes/zcl_a"
-    adtcore:type="CLAS/OC" adtcore:name="ZCL_A"
-    adtcore:packageName="ZPKG" adtcore:description="First class"/>
-  <adtcore:objectReference adtcore:uri="/sap/bc/adt/programs/programs/zp_b"
-    adtcore:type="PROG/P" adtcore:name="ZP_B"/>
-</adtcore:objectReferences>`;
+// Captured verbatim from an SAP BTP trial system (quickSearch, query Z*), so
+// the shape here is observed rather than imagined. Every attribute carries the
+// `adtcore:` prefix, and the third entry has no description at all — which is
+// why `description` is normalised to '' rather than left undefined.
+const prefixed = `<?xml version="1.0" encoding="utf-8"?><adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:objectReference adtcore:uri="/sap/bc/adt/packages/z" adtcore:type="DEVC/K" adtcore:name="Z" adtcore:packageName="Z" adtcore:description="gcek development"/><adtcore:objectReference adtcore:uri="/sap/bc/adt/vit/wb/object_type/sicftyp/object_name/ZX" adtcore:type="SICF/TYP" adtcore:name="ZX" adtcore:packageName="Z_RAG_PRO1"/></adtcore:objectReferences>`;
 
 const unprefixed = `<?xml version="1.0" encoding="UTF-8"?>
 <objectReferences>
@@ -29,15 +26,17 @@ describe('parseSearchResults', () => {
 
     expect(hits).toHaveLength(2);
     expect(hits[0]).toEqual({
-      name: 'ZCL_A',
-      type: 'CLAS/OC',
-      description: 'First class',
-      packageName: 'ZPKG',
-      uri: '/sap/bc/adt/oo/classes/zcl_a',
+      name: 'Z',
+      type: 'DEVC/K',
+      description: 'gcek development',
+      packageName: 'Z',
+      uri: '/sap/bc/adt/packages/z',
     });
   });
 
-  it('reads unprefixed attributes and a single hit', () => {
+  // Not observed on the trial, which prefixes everything. Kept because the
+  // parser accepts both and dropping the case would leave that untested.
+  it('also reads unprefixed attributes and a single hit', () => {
     const hits = parseSearchResults(unprefixed);
 
     expect(hits).toHaveLength(1);
@@ -51,7 +50,7 @@ describe('parseSearchResults', () => {
     const hits = parseSearchResults(prefixed);
 
     expect(hits[1].description).toBe('');
-    expect(hits[1].packageName).toBeUndefined();
+    expect(hits[1].packageName).toBe('Z_RAG_PRO1');
   });
 
   it('drops a reference with no name or no type', () => {

--- a/src/__tests__/unit/parseSearchResults.test.ts
+++ b/src/__tests__/unit/parseSearchResults.test.ts
@@ -10,7 +10,7 @@ import { parseSearchResults } from '../../core/shared/search';
 
 // Captured verbatim from an SAP BTP trial system (quickSearch, query Z*), so
 // the shape here is observed rather than imagined. Every attribute carries the
-// `adtcore:` prefix, and the third entry has no description at all — which is
+// `adtcore:` prefix, and the second entry has no description at all — which is
 // why `description` is normalised to '' rather than left undefined.
 const prefixed = `<?xml version="1.0" encoding="utf-8"?><adtcore:objectReferences xmlns:adtcore="http://www.sap.com/adt/core"><adtcore:objectReference adtcore:uri="/sap/bc/adt/packages/z" adtcore:type="DEVC/K" adtcore:name="Z" adtcore:packageName="Z" adtcore:description="gcek development"/><adtcore:objectReference adtcore:uri="/sap/bc/adt/vit/wb/object_type/sicftyp/object_name/ZX" adtcore:type="SICF/TYP" adtcore:name="ZX" adtcore:packageName="Z_RAG_PRO1"/></adtcore:objectReferences>`;
 


### PR DESCRIPTION
## What was wrong

Eight files under `src/__tests__/integration/shared/` defined their **own** `getConfig()` instead of using `helpers/sessionConfig`. The local copy defaults `SAP_AUTH_TYPE` to `'basic'` and throws:

```
Missing SAP_USERNAME or SAP_PASSWORD for basic authentication
```

on a JWT system. `beforeEach` caught it, set `hasConfig = false`, and every test returned early. **Jest reported PASS.**

So against the cloud trial these had never executed. Affected: `search`, `discovery`, `readSource`, `readMetadata`, `sqlQuery`, `tableContents`, `functionModulesList`, `functionGroupIncludesList`.

## How it stayed hidden

The tell was in the logs all along — those files printed **no steps at all** while their neighbours printed each one — and nobody read it that way, me included. Worse, I cited a regex from `search.test.ts` as evidence about the payload shape:

```ts
const matches = result.data?.match(/<objectReference/g);
if (matches) { /* log */ }
```

It never matches — SAP prefixes the element, `<adtcore:objectReference` — and the result is only logged, never asserted. I read "no error" as "the payload is unprefixed". It is not; the live payload prefixes everything.

**Found by writing a marker file from inside a test body and observing it was never created.** The logger route proves nothing here: the skip warning goes to a silent logger, so the suite is quiet whether it ran or not.

## Fixes

1. Use the shared `getConfig` — one resolver, which already handles JWT/xsuaa.
2. **Open the connection.** Four of the eight never called `connect()`, which `@mcp-abap-adt/connection` 3.0.0 requires. They could not have noticed while skipping.
3. Both dead regexes replaced with the shipped `parseSearchResults`, and the hits are now asserted rather than logged.
4. `parseSearchResults` unit fixture replaced with a payload **captured verbatim from the trial**, so the shape is observed rather than imagined. The unprefixed case stays, labelled as defensive rather than as something seen.

## Verified against the live trial

`readSource`, `functionModulesList`, `functionGroupIncludesList`, `discovery` and `search` now execute and print their steps — the direct contrast with the silent PASS they produced before.

Full shared suite: **76/77**. The one failure was `409 Conflict` creating `ZAC_STRU_GA01`, leftover state from a run I killed on a timeout; re-running `groupActivation.test.ts` alone passes in 60s.

Unit tests: **418** (79 suites). Down 2 from v9.0.0 because `docsImportsResolve` generates one test per markdown file and two implemented specs were deleted — not a lost test.

## Not fixed here

`createTestAdtClient` resolves `isLegacy = true` on the cloud trial, so these run through `AdtUtilsLegacy`. That looks wrong for a modern BTP system, but it is a separate question from why the tests were not running, and I have not chased it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)