### PR TITLE
fix(tests): annotate the shared CDS view so metadata extensions can activate

### DIFF
--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -176,6 +176,7 @@ shared_dependencies:
       source: |
         @EndUserText.label : 'Shared root view for BehaviorDefinition'
         @AccessControl.authorizationCheck : #NOT_REQUIRED
+        @Metadata.allowExtensions : true
         define root view entity ZAC_SHR_BDEF_DDLS
           as select from zac_shr_btabl
         {


### PR DESCRIPTION
Found by running the full `integration/core` suite against the cloud trial.

## The failure

```
Activation of ZAC_MEXT_DDLX failed:
Annotation 'Metadata.allowExtensions' missing in 'ZAC_SHR_BDEF_DDLS'
```

SAP refuses to activate a metadata extension against a view that has not opted in. The shared view it targets never declared `@Metadata.allowExtensions`, so this test could not have passed on **any** system. It is test data, not library code — the client did its job and surfaced SAP's refusal accurately.

## The fix

One line in the shared view's source in `test-config.yaml.template`.

**Not enough on its own, and worth saying explicitly:** the local `test-config.yaml` is gitignored, so an existing checkout needs the same line added by hand. And shared setup is *idempotent — it skips objects that already exist*, so editing the config changes nothing on a system where the view is already there. The view has to be recreated.

I did not do that recreation. `ZAC_SHR_BDEF_DDLS` has dependents — the shared behavior definition and the metadata extension itself — so deleting it on a live system is not something to do unasked.

## Full core run against the trial

**35 of 37 suites passed, 66 tests passed, 1 skipped, 2 failed** (~17 min).

The other failure was `Package - Full workflow`: `Read undefined failed: no response`. **Not a defect** — leftover state from an earlier run. Re-running `integration/core/package` alone passes in 32s. The same run shows `Domain` handling this case properly (`⏭ SKIP – ⚠️ SAFETY: Domain ZAC_DOM01 already exists!` followed by cleanup), so the Package flow is simply less idempotent than its neighbours. Separate issue, not fixed here.

Every skip in the run was a legitimate environment mismatch — "not available for cloud environment", "Programs are not supported in cloud systems". **No `No SAP configuration` skips**, so the silent-skip defect fixed in #95 does not extend into `integration/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)