### PR TITLE
release(10.0.1): give the scalar-function test a definition to activate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - **The scalar-function test exercises the definition instead of skipping past it.** `create_scalar_function` had no `source_code`, so the branch that updates and activates never ran: the test did `create → read → delete` and left an empty definition behind whenever the delete did not take. A scalar function **definition** activates without an AMDP class — that requirement belongs to the separate implementation object (DSFI), which has its own test — so there was nothing standing in the way.
 
+  The object name in the DDL is `{name}`, substituted from `scalar_function_name`, so renaming the object cannot leave the source declaring a different one — the config invites the rename, and a hardcoded name would create one object and try to fill another.
+
   The DDL is configured without a leading annotation, because the parser refuses one: `Unexpected token "@". Expected was "DEFINE"`. A definition starts with the statement itself.
 
   The full chain `create → update → activate → read active → delete` now runs, and the object is gone afterwards rather than left as a shell.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+## [10.0.1] - 2026-08-05
+
+### Fixed
+- **The scalar-function test exercises the definition instead of skipping past it.** `create_scalar_function` had no `source_code`, so the branch that updates and activates never ran: the test did `create → read → delete` and left an empty definition behind whenever the delete did not take. A scalar function **definition** activates without an AMDP class — that requirement belongs to the separate implementation object (DSFI), which has its own test — so there was nothing standing in the way.
+
+  The DDL is configured without a leading annotation, because the parser refuses one: `Unexpected token "@". Expected was "DEFINE"`. A definition starts with the statement itself.
+
+  The full chain `create → update → activate → read active → delete` now runs, and the object is gone afterwards rather than left as a shell.
+
 ## [10.0.0] - 2026-08-05
 
 ### Migration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -1146,11 +1146,14 @@ create_scalar_function:
         # activate. The AMDP method belongs to the separate DSFI object, which
         # has its own test case. Without this the test only ever did
         # create → read → delete and left the definition empty.
+        # {name} is substituted with scalar_function_name above, so renaming the
+        # object cannot leave the DDL declaring a different one.
+        #
         # No leading annotation: the parser answers
         # 'Unexpected token "@". Expected was "DEFINE"' — a scalar function
         # definition starts with the statement itself.
         source_code: |
-          define scalar function ZADT_SCALAR_FUNC
+          define scalar function {name}
             with parameters
               p_portion : abap.int4,
               p_total   : abap.int4

--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -1163,11 +1163,13 @@ create_scalar_function:
         # source_code (OPTIONAL): when set, the suite runs the FULL update→activate
         # flow. A CDS scalar function only activates when implemented by an AMDP method
         # that already exists on the target system:
-        #   CLASS-METHODS m FOR SCALAR FUNCTION zadt_scalar_func.
+        #   CLASS-METHODS m FOR SCALAR FUNCTION {name}.
         #   METHOD m BY DATABASE FUNCTION FOR HDB LANGUAGE SQLSCRIPT OPTIONS READ-ONLY. ...
-        # Without source_code the suite validates create → read → delete only.
+        # A definition backed by an AMDP method would look like this — note
+        # {name} here too, for the same reason as above: a worked example that
+        # spells the object name out is the thing a reader copies.
         # source_code: |
-        #   define scalar function ZADT_SCALAR_FUNC
+        #   define scalar function {name}
         #     with parameters p_input : abap.int4
         #     returns abap.int4
         #     implemented by method zcl_your_amdp=>m;

--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -1141,6 +1141,20 @@ create_scalar_function:
       params:
         scalar_function_name: "ZADT_SCALAR_FUNC"  # ← CHANGE if needed
         description: "AdtScalarFunction integration test"
+        # DDL of the scalar function DEFINITION — parameters and a return type.
+        # A definition is not an implementation: it needs no AMDP class to
+        # activate. The AMDP method belongs to the separate DSFI object, which
+        # has its own test case. Without this the test only ever did
+        # create → read → delete and left the definition empty.
+        # No leading annotation: the parser answers
+        # 'Unexpected token "@". Expected was "DEFINE"' — a scalar function
+        # definition starts with the statement itself.
+        source_code: |
+          define scalar function ZADT_SCALAR_FUNC
+            with parameters
+              p_portion : abap.int4,
+              p_total   : abap.int4
+            returns abap.decfloat34;
         # package_name: "ZAC_PKG01"  # Uses environment.default_package if omitted
         # transport_request: ""  # Uses environment.default_transport if omitted
         # source_code (OPTIONAL): when set, the suite runs the FULL update→activate

--- a/src/__tests__/integration/core/scalarFunction/ScalarFunction.test.ts
+++ b/src/__tests__/integration/core/scalarFunction/ScalarFunction.test.ts
@@ -181,8 +181,13 @@ describe('ScalarFunction (DSFD/SCF) integration', () => {
           // create_scalar_function.params.source_code (and the companion AMDP class
           // is deployed). Otherwise we validate the DSFD wire contract via
           // create → read → delete, which needs no AMDP fixture.
-          const configuredSource: string | undefined =
-            testCase?.params?.source_code;
+          // {name} is substituted here so the DDL can never declare an object
+          // other than the one the test created — the config invites renaming
+          // scalar_function_name, and a hardcoded name in the source would then
+          // create one object and try to fill another.
+          const configuredSource: string | undefined = (
+            testCase?.params?.source_code as string | undefined
+          )?.replaceAll('{name}', scalarFunctionName);
 
           if (configuredSource) {
             // ── 3a) Full flow: update source + activate ──


### PR DESCRIPTION
## What was wrong

`create_scalar_function` carried no `source_code`, so this branch never ran:

```ts
if (configuredSource) {
  await sf.update(..., { activateOnUpdate: true });   // never reached
}
```

The test did `create → read → delete`. Two consequences: the DSFD update and activation paths were never exercised at all, and any run whose delete did not take left an **empty definition** sitting in the package — one of the shells that kept turning up.

The test file explains the omission as a limitation: activation needs a companion AMDP method. That is true of the **implementation** (DSFI), which has its own test case and its own AMDP class. A **definition** is a parameter list and a return type; it activates on its own.

## The fix

The DDL now lives in `test-config.yaml`:

```yaml
source_code: |
  define scalar function ZADT_SCALAR_FUNC
    with parameters
      p_portion : abap.int4,
      p_total   : abap.int4
    returns abap.decfloat34;
```

No leading annotation — the parser refuses one, and said so on the first attempt:

```
Unexpected token "@". Expected was "DEFINE"
```

Worth recording that an earlier version of this exact change was written and then withdrawn **without being run**. The system would have answered in four seconds.

## Verified on the trial

- `ScalarFunction` full workflow passes: `create → update → activate → read active → delete`.
- Reading `/sap/bc/adt/ddic/dsfd/sources/zadt_scalar_func/source/main` afterwards returns **404** — the object is genuinely gone, where before a shell could remain.
- Build and both typechecks clean; **418 unit tests**.

Test configuration only; no library code changed. Patch release because the published package is unaffected — the version moves so the tag matches the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)