### PR TITLE
fix(tests): root-package check reported "missing" when it could not look; template gaps

### DIFF
--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -111,6 +111,16 @@ shared_dependencies:
       length: 10
 
   structures:
+    - name: "ZAC_SHR_STRU"
+      description: "Shared structure used as a table type's row type"
+      source: |
+        @EndUserText.label: 'Shared structure for TableType row type'
+        @AbapCatalog.enhancement.category: #NOT_EXTENSIBLE
+        define structure ZAC_SHR_STRU {
+          mandt  : abap.clnt;
+          field1 : abap.int1;
+        }
+
     - name: "ZAC_SHR_APPSTRU"
       description: "Extensible structure — append-structure base"
       source: |
@@ -1032,7 +1042,7 @@ create_tabletype:
         # package_name: "ZAC_PKG01"
         # transport_request: ""
         # XML format parameters (for update - rowType added after create)
-        row_type_name: "ZAC_STRU01"  # Structure name (must exist)
+        row_type_name: "ZAC_SHR_STRU"  # shared_dependencies.structures — not another test's object
         row_type_kind: "dictionaryType"   # Type kind: dictionaryType, predefinedAbapType, etc.
         access_type: "standard"           # standard, sorted, hashed, index
         primary_key_definition: "standard"  # standard, rowType, keyComponents, empty
@@ -1093,7 +1103,7 @@ read_ddl_table_function:
       params:
         # Pre-existing AMDP table function on the target system (adt-clients
         # cannot create extend/AMDP-backed objects). Leave empty to skip.
-        ddl_name: "ZTOK_TF_ORD_TOTALS"
+        ddl_name: ""  # ← CHANGE to a table function that exists on your system
 
 # Create Service Definition
 create_service_definition:

--- a/src/__tests__/helpers/test-helper.js
+++ b/src/__tests__/helpers/test-helper.js
@@ -1003,6 +1003,15 @@ async function retryCheckAfterActivate(checkFunction, options = {}) {
  * still reported PASS, while the tests around it created objects in the very
  * package this claimed was absent.
  *
+ * Parsing goes through `searchObjectsTyped` rather than a local XML reader.
+ * ADT is not consistent across releases about namespacing quickSearch hits —
+ * `<adtcore:objectReference adtcore:name>` on some, `<objectReference name>` on
+ * others — and `parseSearchResults` already accepts both, with tests. The copy
+ * that used to live here required the literal `<adtcore:objectReference` and
+ * read only the prefixed attribute, so on a system emitting the unprefixed
+ * form the lookup would succeed and this would still answer "missing" — the
+ * same silent skip as above, reached by a different route.
+ *
  * @param {Object} connection - ABAP connection
  * @param {string} packageName - Package name to check
  * @returns {Promise<boolean>} True if package exists, false if it does not
@@ -1010,36 +1019,17 @@ async function retryCheckAfterActivate(checkFunction, options = {}) {
  */
 async function checkPackageExists(connection, packageName) {
   try {
-    // Dynamically require searchObjects to avoid circular dependencies
-    const { searchObjects } = require('../../core/shared/search');
+    // Dynamically required to avoid circular dependencies
+    const { searchObjectsTyped } = require('../../core/shared/search');
 
-    const response = await searchObjects(connection, {
+    const hits = await searchObjectsTyped(connection, {
       query: `${packageName}*`,
       objectType: 'DEVC',
       maxResults: 101,
     });
 
-    if (response.status !== 200) {
-      return false;
-    }
-
-    const xmlData = typeof response.data === 'string' ? response.data : '';
-    if (!xmlData || !xmlData.includes('<adtcore:objectReference')) {
-      return false;
-    }
-
-    const parser = new XMLParser({
-      ignoreAttributes: false,
-      attributeNamePrefix: '@_',
-    });
-    const parsed = parser.parse(xmlData);
-    const refs =
-      parsed['adtcore:objectReferences']?.['adtcore:objectReference'];
-    const objects = refs ? (Array.isArray(refs) ? refs : [refs]) : [];
-
-    return objects.some(
-      (obj) =>
-        obj['@_adtcore:name']?.toUpperCase() === packageName.toUpperCase(),
+    return hits.some(
+      (hit) => hit.name?.toUpperCase() === packageName.toUpperCase(),
     );
   } catch (error) {
     throw new Error(

--- a/src/__tests__/helpers/test-helper.js
+++ b/src/__tests__/helpers/test-helper.js
@@ -992,14 +992,26 @@ async function retryCheckAfterActivate(checkFunction, options = {}) {
 
 /**
  * Check if package exists using searchObjects
+ *
+ * Throws when the check itself could not run. It previously answered `false` for
+ * that case, which is a different statement: "the package is not there" rather
+ * than "I could not look". The `require` below pointed at
+ * `src/__tests__/src/core/...` — a path that has never existed — so every call
+ * threw `MODULE_NOT_FOUND`, was caught here, and reported the root package
+ * missing. `Ddl.test.ts` is the only integration test that calls
+ * `checkDefaultTestEnvironment`, so it alone skipped every test it owns and
+ * still reported PASS, while the tests around it created objects in the very
+ * package this claimed was absent.
+ *
  * @param {Object} connection - ABAP connection
  * @param {string} packageName - Package name to check
- * @returns {Promise<boolean>} True if package exists, false otherwise
+ * @returns {Promise<boolean>} True if package exists, false if it does not
+ * @throws when the existence check could not be performed
  */
 async function checkPackageExists(connection, packageName) {
   try {
     // Dynamically require searchObjects to avoid circular dependencies
-    const { searchObjects } = require('../src/core/shared/search');
+    const { searchObjects } = require('../../core/shared/search');
 
     const response = await searchObjects(connection, {
       query: `${packageName}*`,
@@ -1030,7 +1042,9 @@ async function checkPackageExists(connection, packageName) {
         obj['@_adtcore:name']?.toUpperCase() === packageName.toUpperCase(),
     );
   } catch (error) {
-    return false;
+    throw new Error(
+      `Could not check whether package ${packageName} exists: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 


### PR DESCRIPTION
Found while auditing the local `test-config.yaml` against the template key by key.

## A precondition probe that lied, and a suite that skipped green

`checkPackageExists` required `../src/core/shared/search` from `src/__tests__/helpers/`, which resolves to `src/__tests__/src/core/shared/search` — **a path that has never existed**. Every call threw `MODULE_NOT_FOUND`, and `catch { return false }` converted that into a factual claim: the package is not there.

`Ddl.test.ts` is the **only** integration test that calls `checkDefaultTestEnvironment`, so it alone paid:

```
Environment check failed: Default package ZADT_BLD_PKG03 does not exist.
All tests will be skipped.
```

It then skipped everything and **reported PASS** — while `TableType`, `CdsUnitTest` and `groupActivation`, in the same run, were creating objects in that same package. The tell was duration: **7s against 34–66s** for its neighbours, with no step lines at all. A direct probe of the identical search found the package **6 times out of 6**.

Two changes, because fixing the path alone leaves the trap armed for the next caller:

- the require path is corrected to `../../core/shared/search`;
- a failed check now **throws** instead of answering `false`. *"I could not look"* and *"it is not there"* are different statements, and only one of them was true.

The DDL suite now runs its full chain — `validate → create → read → update → read inactive → …`.

## Template gaps

| gap | why it matters |
|---|---|
| `shared_dependencies.structures` had no `ZAC_SHR_STRU`, and `create_tabletype.row_type_name` pointed at `ZAC_STRU01` | that is an object **owned by the `create_structure` test** — a test taking its row type from another test's object is exactly the dependency shape shared objects exist to prevent |
| `read_ddl_table_function.ddl_name` hardcoded `ZTOK_TF_ORD_TOTALS` | a name from no namespace this project owns. Emptied, so the existing *"leave empty to skip"* comment is now true |

## On the local config (gitignored, not in this PR)

The audit compared every key. Most differences are ABAP identifier casing (harmless) or your own environment values. The 45 `available_in` keys absent locally are all `["onprem","cloud"]` — absence means the same thing, so they are cosmetic.

Five had consequences, all traceable to my earlier mass-replace damage, and all repaired locally:

- `create_view.params.view_name` → `ddl_name` (`Ddl.test.ts` reads `ddl_name`)
- shared table `ZAC_SHR_VTABL` declared itself as `zac_tab01`
- shared view `ZAC_SHR_CDSUT_DDLS` selected from `zac_tab01` instead of `zac_shr_vtabl`
- `create_view.ddl_source` likewise
- `group_activation.structure_ddl_code` declared `zac_stru01` referencing `zac_dtel01`, while its params name `ZAC_STRU_GA01` / `ZAC_DTEL_GA01` — the dangling dependency you flagged

I probed the system before repairing: `ZAC_SHR_VTABL` declares itself correctly, the shared view selects from `zac_shr_vtabl`, and `ZAC_TAB01` returns 404. **The system was right and the local YAML had drifted** — no reconciliation needed.

## Verification

`ddl`, `tabletype`, `groupActivation`, `CdsUnitTest` — all pass against the trial, with visible step output rather than silent skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)