### PR TITLE
fix(tests): a skip says which precondition is actually missing

### DIFF
--- a/src/__tests__/integration/core/unitTest/CdsUnitTest.test.ts
+++ b/src/__tests__/integration/core/unitTest/CdsUnitTest.test.ts
@@ -152,13 +152,22 @@ describe('AdtCdsUnitTest (using AdtClient)', () => {
             testCase.params.transport_request,
         );
 
-        if (
-          !className ||
-          !testClassName ||
-          !ddlName ||
-          !classTemplate ||
-          !testClassSource
-        ) {
+        // Name the parameter that is actually absent. Listing all five joined
+        // by "or" says only that one of them is missing, which sent me looking
+        // in the wrong place twice: `ddl_name` alone was gone (the config had
+        // drifted to `view_name`), while the message implicated the four that
+        // were present.
+        const missingParams = Object.entries({
+          'cds_unit_test.class_name': className,
+          'cds_unit_test.test_class_name': testClassName,
+          ddl_name: ddlName,
+          'cds_unit_test.template_xml': classTemplate,
+          'cds_unit_test.test_class_source': testClassSource,
+        })
+          .filter(([, value]) => !value)
+          .map(([key]) => key);
+
+        if (missingParams.length > 0) {
           logTestStart(
             testsLogger,
             'CdsUnitTest - create CDS unit test class',
@@ -170,7 +179,7 @@ describe('AdtCdsUnitTest (using AdtClient)', () => {
           logTestSkip(
             testsLogger,
             'CdsUnitTest - create CDS unit test class',
-            'Required parameters missing: class_name, test_class_name, ddl_name, template_xml, or test_class_source',
+            `Missing in test-config.yaml under create_cds_unit_test: ${missingParams.join(', ')}`,
           );
           return;
         }

--- a/src/__tests__/integration/shared/readAccept.test.ts
+++ b/src/__tests__/integration/shared/readAccept.test.ts
@@ -155,27 +155,40 @@ describe('Shared - read Accept headers', () => {
    *
    * Every guard below used to print one sentence naming all three causes joined
    * by "or", so a skip told you only that one of them applied. That is how a
-   * config drift stays hidden: the message implicates the parameters that are
+   * config drift stays hidden: the message implicates the requirements that are
    * present alongside the one that is not.
    *
-   * The caller keeps its own `if` — moving the condition in here would read
-   * better and cost more than it is worth, because TypeScript stops narrowing
-   * the `string | null` names once the test lives behind a function call.
+   * Requirements are passed as named entries rather than positionally, because
+   * the first version of this helper took values and reported only the label —
+   * which reproduced the same ambiguity for the two guards that check more than
+   * one thing: an absent `function_group_name` was reported as "function module
+   * not configured".
+   *
+   * Where a value has one config key, the key is the name. Where it may come
+   * from either `standard_objects` or `params`, the name is the object in
+   * prose — naming one of the two sources would be a different half-truth.
+   *
+   * The caller keeps its own `if` — moving the condition in here reads better
+   * and costs more than it is worth, because TypeScript stops narrowing the
+   * `string | null` names once the test lives behind a function call.
    */
   const skipReason = (
-    label: string,
-    ...names: (string | null | undefined)[]
+    requirements: Record<string, string | null | undefined>,
   ): string => {
     if (!hasConfig) return 'no SAP configuration';
     if (!hasTestCase) return 'read_accept not configured in test-config.yaml';
-    if (names.some((name) => !name)) return `${label} not configured`;
-    return 'unknown reason';
+    const missing = Object.keys(requirements).filter(
+      (name) => !requirements[name],
+    );
+    return missing.length > 0
+      ? `missing configuration: ${missing.join(', ')}`
+      : 'unknown reason';
   };
 
   it('should read class source', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'standard class': standardClassName })}`,
       );
       return;
     }
@@ -197,7 +210,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local definitions include', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'standard class': standardClassName })}`,
       );
       return;
     }
@@ -227,7 +240,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local types include', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'standard class': standardClassName })}`,
       );
       return;
     }
@@ -253,7 +266,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local test classes include', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'standard class': standardClassName })}`,
       );
       return;
     }
@@ -287,7 +300,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local macros include (on-prem only)', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'standard class': standardClassName })}`,
       );
       return;
     }
@@ -323,7 +336,7 @@ describe('Shared - read Accept headers', () => {
   it('should read interface source', async () => {
     if (!hasConfig || !hasTestCase || !standardInterfaceName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('standard interface', standardInterfaceName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'standard interface': standardInterfaceName })}`,
       );
       return;
     }
@@ -357,7 +370,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !programName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('program', programName)}`,
+        `⚠️ Skipping test: ${skipReason({ program: programName })}`,
       );
       return;
     }
@@ -383,7 +396,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !domainName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('domain', domainName)}`,
+        `⚠️ Skipping test: ${skipReason({ domain: domainName })}`,
       );
       return;
     }
@@ -409,7 +422,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !dataElementName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('data element', dataElementName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'data element': dataElementName })}`,
       );
       return;
     }
@@ -439,7 +452,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !structureName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('structure', structureName)}`,
+        `⚠️ Skipping test: ${skipReason({ structure: structureName })}`,
       );
       return;
     }
@@ -464,7 +477,9 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.table_name ||
       null;
     if (!hasConfig || !hasTestCase || !tableName) {
-      testsLogger.warn?.(`⚠️ Skipping test: ${skipReason('table', tableName)}`);
+      testsLogger.warn?.(
+        `⚠️ Skipping test: ${skipReason({ table: tableName })}`,
+      );
       return;
     }
 
@@ -489,7 +504,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !tableTypeName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('table type', tableTypeName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'table type': tableTypeName })}`,
       );
       return;
     }
@@ -514,7 +529,7 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.ddl_name ||
       null;
     if (!hasConfig || !hasTestCase || !ddlName) {
-      testsLogger.warn?.(`⚠️ Skipping test: ${skipReason('view', ddlName)}`);
+      testsLogger.warn?.(`⚠️ Skipping test: ${skipReason({ view: ddlName })}`);
       return;
     }
 
@@ -539,7 +554,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !functionGroupName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('function group', functionGroupName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'function group': functionGroupName })}`,
       );
       return;
     }
@@ -576,7 +591,7 @@ describe('Shared - read Accept headers', () => {
       !functionGroupName
     ) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('function module', functionModuleName, functionGroupName)}`,
+        `⚠️ Skipping test: ${skipReason({ function_module_name: functionModuleName, function_group_name: functionGroupName })}`,
       );
       return;
     }
@@ -611,7 +626,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !packageName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('package', packageName)}`,
+        `⚠️ Skipping test: ${skipReason({ package: packageName })}`,
       );
       return;
     }
@@ -638,7 +653,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !serviceDefinitionName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('service definition', serviceDefinitionName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'service definition': serviceDefinitionName })}`,
       );
       return;
     }
@@ -668,7 +683,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !behaviorDefinitionName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('behavior definition', behaviorDefinitionName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'behavior definition': behaviorDefinitionName })}`,
       );
       return;
     }
@@ -700,7 +715,7 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.behavior_implementation_class_name || null;
     if (!hasConfig || !hasTestCase || !behaviorImplementationClassName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('behavior implementation', behaviorImplementationClassName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'behavior implementation': behaviorImplementationClassName })}`,
       );
       return;
     }
@@ -736,7 +751,7 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.metadata_extension_name || null;
     if (!hasConfig || !hasTestCase || !metadataExtensionName) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('metadata extension', metadataExtensionName)}`,
+        `⚠️ Skipping test: ${skipReason({ 'metadata extension': metadataExtensionName })}`,
       );
       return;
     }
@@ -768,7 +783,7 @@ describe('Shared - read Accept headers', () => {
     const enhancementType = testCase?.params?.enhancement_type || null;
     if (!hasConfig || !hasTestCase || !enhancementName || !enhancementType) {
       testsLogger.warn?.(
-        `⚠️ Skipping test: ${skipReason('enhancement', enhancementName, enhancementType)}`,
+        `⚠️ Skipping test: ${skipReason({ enhancement_name: enhancementName, enhancement_type: enhancementType })}`,
       );
       return;
     }

--- a/src/__tests__/integration/shared/readAccept.test.ts
+++ b/src/__tests__/integration/shared/readAccept.test.ts
@@ -150,10 +150,32 @@ describe('Shared - read Accept headers', () => {
     }
   });
 
+  /**
+   * Say which precondition is actually absent.
+   *
+   * Every guard below used to print one sentence naming all three causes joined
+   * by "or", so a skip told you only that one of them applied. That is how a
+   * config drift stays hidden: the message implicates the parameters that are
+   * present alongside the one that is not.
+   *
+   * The caller keeps its own `if` — moving the condition in here would read
+   * better and cost more than it is worth, because TypeScript stops narrowing
+   * the `string | null` names once the test lives behind a function call.
+   */
+  const skipReason = (
+    label: string,
+    ...names: (string | null | undefined)[]
+  ): string => {
+    if (!hasConfig) return 'no SAP configuration';
+    if (!hasTestCase) return 'read_accept not configured in test-config.yaml';
+    if (names.some((name) => !name)) return `${label} not configured`;
+    return 'unknown reason';
+  };
+
   it('should read class source', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or standard class not found',
+        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
       );
       return;
     }
@@ -175,7 +197,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local definitions include', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or standard class not found',
+        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
       );
       return;
     }
@@ -205,7 +227,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local types include', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or standard class not found',
+        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
       );
       return;
     }
@@ -231,7 +253,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local test classes include', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or standard class not found',
+        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
       );
       return;
     }
@@ -265,7 +287,7 @@ describe('Shared - read Accept headers', () => {
   it('should read local macros include (on-prem only)', async () => {
     if (!hasConfig || !hasTestCase || !standardClassName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or standard class not found',
+        `⚠️ Skipping test: ${skipReason('standard class', standardClassName)}`,
       );
       return;
     }
@@ -301,7 +323,7 @@ describe('Shared - read Accept headers', () => {
   it('should read interface source', async () => {
     if (!hasConfig || !hasTestCase || !standardInterfaceName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or standard interface not found',
+        `⚠️ Skipping test: ${skipReason('standard interface', standardInterfaceName)}`,
       );
       return;
     }
@@ -335,7 +357,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !programName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or program not configured',
+        `⚠️ Skipping test: ${skipReason('program', programName)}`,
       );
       return;
     }
@@ -361,7 +383,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !domainName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or domain not configured',
+        `⚠️ Skipping test: ${skipReason('domain', domainName)}`,
       );
       return;
     }
@@ -387,7 +409,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !dataElementName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or data element not configured',
+        `⚠️ Skipping test: ${skipReason('data element', dataElementName)}`,
       );
       return;
     }
@@ -417,7 +439,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !structureName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or structure not configured',
+        `⚠️ Skipping test: ${skipReason('structure', structureName)}`,
       );
       return;
     }
@@ -442,9 +464,7 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.table_name ||
       null;
     if (!hasConfig || !hasTestCase || !tableName) {
-      testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or table not configured',
-      );
+      testsLogger.warn?.(`⚠️ Skipping test: ${skipReason('table', tableName)}`);
       return;
     }
 
@@ -469,7 +489,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !tableTypeName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or table type not configured',
+        `⚠️ Skipping test: ${skipReason('table type', tableTypeName)}`,
       );
       return;
     }
@@ -494,9 +514,7 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.ddl_name ||
       null;
     if (!hasConfig || !hasTestCase || !ddlName) {
-      testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or view not configured',
-      );
+      testsLogger.warn?.(`⚠️ Skipping test: ${skipReason('view', ddlName)}`);
       return;
     }
 
@@ -521,7 +539,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !functionGroupName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or function group not configured',
+        `⚠️ Skipping test: ${skipReason('function group', functionGroupName)}`,
       );
       return;
     }
@@ -558,7 +576,7 @@ describe('Shared - read Accept headers', () => {
       !functionGroupName
     ) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or function module not configured',
+        `⚠️ Skipping test: ${skipReason('function module', functionModuleName, functionGroupName)}`,
       );
       return;
     }
@@ -593,7 +611,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !packageName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or package not configured',
+        `⚠️ Skipping test: ${skipReason('package', packageName)}`,
       );
       return;
     }
@@ -620,7 +638,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !serviceDefinitionName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or service definition not configured',
+        `⚠️ Skipping test: ${skipReason('service definition', serviceDefinitionName)}`,
       );
       return;
     }
@@ -650,7 +668,7 @@ describe('Shared - read Accept headers', () => {
       null;
     if (!hasConfig || !hasTestCase || !behaviorDefinitionName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or behavior definition not configured',
+        `⚠️ Skipping test: ${skipReason('behavior definition', behaviorDefinitionName)}`,
       );
       return;
     }
@@ -682,7 +700,7 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.behavior_implementation_class_name || null;
     if (!hasConfig || !hasTestCase || !behaviorImplementationClassName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or behavior implementation not configured',
+        `⚠️ Skipping test: ${skipReason('behavior implementation', behaviorImplementationClassName)}`,
       );
       return;
     }
@@ -718,7 +736,7 @@ describe('Shared - read Accept headers', () => {
       testCase?.params?.metadata_extension_name || null;
     if (!hasConfig || !hasTestCase || !metadataExtensionName) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or metadata extension not configured',
+        `⚠️ Skipping test: ${skipReason('metadata extension', metadataExtensionName)}`,
       );
       return;
     }
@@ -750,7 +768,7 @@ describe('Shared - read Accept headers', () => {
     const enhancementType = testCase?.params?.enhancement_type || null;
     if (!hasConfig || !hasTestCase || !enhancementName || !enhancementType) {
       testsLogger.warn?.(
-        '⚠️ Skipping test: No SAP configuration, read_accept not configured, or enhancement not configured',
+        `⚠️ Skipping test: ${skipReason('enhancement', enhancementName, enhancementType)}`,
       );
       return;
     }


### PR DESCRIPTION
Both files printed one sentence naming every possible cause joined by "or", so a skip told you only that **one of them** applied — never which.

That is how a config drift stayed hidden for a whole session. `CdsUnitTest` reported

```
Required parameters missing: class_name, test_class_name, ddl_name, template_xml, or test_class_source
```

when only `ddl_name` was absent — the message implicated the four that were present. I looked in the wrong place twice and twice reported the template lacked things it did not.

## Changes

- **`CdsUnitTest`** lists the absent parameters by full config path (`cds_unit_test.class_name`, `ddl_name`, …).
- **`readAccept`** had **21** copies of the same sentence — not 20; the `enhancement` guard has a different shape and escaped the first count. Its wording was worse: *"No SAP configuration, read_accept not configured, or X not configured"* conflates a missing connection, a missing config section and a missing object name. A skip blaming absent SAP configuration while SAP is configured is a known false-signal here, and this sentence produced it on sight. Each now reports one real cause.

The condition stays **inline** at every call site; only the message moved into `skipReason`. Moving the test itself reads better and costs more than it is worth — TypeScript stops narrowing the `string | null` names once the check lives behind a function call, which surfaced immediately as two errors on `standardInterfaceName`.

## Full cloud run with these in place

147 suites, **615 passed, 2 failed, 2 skipped**, 1838 s.

Every skip now carries an environment-specific reason — no `No SAP configuration` false signals. Three are genuine config gaps rather than environment limits, worth a separate look: `ScalarFunction - read standard object` (test case not defined), `Class - read transport request` and `AdtClient - readTransport` (`transport_request` not configured).

The two failures both **pass standalone** (`Domain` 34.3 s, `AccessControl` 35.1 s) and are not in this diff's scope:

| suite | failure |
|---|---|
| `Domain` | `update FAILED (HTTP 400): The description is missing for ZAC_DOM01` — the config **does** carry a description |
| `AccessControl` | `read (wait for object ready) FAILED: Read undefined failed: no response` |

They are consistent with one mechanism rather than two flakes: object readiness after create is not reliably awaited under load, and the consequence differs by type — `AccessControl` fails the readiness read outright, while `Domain` proceeds to build its update payload from a read that came back partial, and the server rejects it. Not proven, and I am not fixing it here.

Secondary defect visible in that message: `Read undefined failed` — `BaseTester.readVersion` prints an undefined version label, so the diagnostic cannot say which version it tried.

## No release

`files` publishes `dist`, `README.md`, `LICENSE`; this touches two files under `src/__tests__/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)