### PR TITLE
fix(update): a read-modify-write update refuses to write what it could not patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+## [10.1.0] - 2026-08-07
+
+### Fixed
+- **A read-modify-write update no longer writes what it could not patch.** A full run failed with `update FAILED (HTTP 400): The description is missing for ZAC_DOM01` on a domain whose description was in the configuration throughout. Between the slow read and the rejected write sat two silent steps:
+
+  | step | what happened |
+  |---|---|
+  | `GET /ddic/domains/zac_dom01` | slow, or the object not yet ready |
+  | `extractXmlString(...)` | no check at all |
+  | `patchXmlAttribute('adtcore:description')` | no match → returned the body unchanged, silently |
+  | `PUT` | 400: the description is missing |
+
+  ADT answers a read of a not-yet-ready object with **HTTP 200 and an empty body**, never a 404, so no status revealed it; and `patchXmlAttribute`, being `String.replace`, found nothing to replace and said nothing. The varying response time of the ABAP system is the trigger and cannot be fixed here — what changes is the conversion. A slow read now surfaces as a read error naming the object (`Cannot update domain ZAC_DOM01: the read returned an empty body`) instead of a malformed write blamed on the server.
+
+  `extractXmlString` rejects a body that cannot be patched — empty, non-string (it used to `JSON.stringify` an object and pass it on as XML), or not XML. This covers all five read-modify-write modules at once — `domain`, `dataElement`, `package`, `tabletype`, `functionGroup`, the last of which carried its own inline copy of the same fallback. The four patch helpers throw `XmlPatchError` rather than passing the XML through untouched: a caller only reaches a patch when it intends the change, since `patchIf` skips the call for an absent value.
+
+### Changed
+- **Setting a reference that was not set before now takes effect.** `patchXmlElementAttribute` adds the attribute when the element is present without it, instead of silently doing nothing. Probed on a live system, ADT emits `<doma:valueTableRef/>` for a domain with no value table and `<pak:superPackage/>` for a package with no parent — so the previous behaviour ignored `value_table` and `super_package` in exactly the case where a caller would set them for the first time. Only a missing *element* is an error now.
+
+  This is the one behavioural change to a path that previously "succeeded": an update passing `super_package` for a root package used to change nothing and report success, and now moves the package. `patchXmlElement` needed no such split — ADT always emits the element, self-closing when empty (`<doma:conversionExit/>`), which its regex already matched.
+
+  No public export was added, removed or changed; `xmlPatch` is internal.
+
 ## [10.0.2] - 2026-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -364,7 +364,23 @@ implementations pass it internally on reads after create/update.
 See the caveat above — on the system measured, the flag had no effect on object
 reads at all.
 
-**Note:** Long polling is automatically used in `create()` and `update()` methods of all `AdtObject` implementations to ensure objects are ready before proceeding with subsequent operations.
+**Note:** `create()` and `update()` request long polling on their follow-up reads
+where the handler supports it. Read that as "asked for", not "ensured" — the
+caveat above stands, and nothing in this library can make the system answer
+sooner than it does.
+
+What the library does guarantee is that a read which came back empty is not
+written back. ADT answers a read of a not-yet-ready object with **HTTP 200 and
+an empty body**, never a 404, so a read-modify-write update used to patch that
+empty body — changing nothing, because there was nothing to change — and PUT the
+result. Since 10.1.0 that read fails with `XmlPatchError`, naming the object:
+
+```
+Cannot update domain ZAC_DOM01: the read returned an empty body.
+```
+
+A slow system therefore surfaces as a read error, not as a write the server
+rejects for a reason that points nowhere near the cause.
 
 ### Creating Behavior Implementation Classes
 

--- a/docs/usage/CLIENT_API_REFERENCE.md
+++ b/docs/usage/CLIENT_API_REFERENCE.md
@@ -250,6 +250,44 @@ await abapGit.unlink({ package: 'ZMY_PKG' });
 
 **Content-type version.** Defaults to `v3` for sapcli compatibility. Cloud MDD advertises `v4`; consumers can opt in via `new AdtAbapGitClient(conn, logger, { contentTypeVersion: 'v4' })`.
 
+### What `update()` refuses to write
+
+Five object types — `domain`, `dataElement`, `package`, `tabletype`,
+`functionGroup` — update by **read-modify-write**: GET the current XML, patch the
+changed fields into it, PUT it back. Building the XML from scratch would drop
+fields the client does not model (`abapLanguageVersion` and friends), so the
+server's own body is the base.
+
+That makes the read a hard dependency, and ADT answers a read of a not-yet-ready
+object with **HTTP 200 and an empty body** — never a 404. Since **10.1.0** such a
+read fails instead of being patched and sent:
+
+```
+XmlPatchError: Cannot update domain ZAC_DOM01: the read returned an empty body.
+```
+
+Before, the patch found nothing to replace, returned the body unchanged
+silently, and the PUT went out without the field — which the server rejected
+with a message pointing nowhere near the cause (`The description is missing`).
+A slow system now surfaces as a read error naming the object.
+
+**A patch that cannot find its target throws.** A caller reaches a patch only
+when it intends the change, so "no match" means the PUT would not carry what was
+asked for.
+
+**One deliberate exception.** Setting an attribute on an element that is present
+without it *adds* the attribute rather than failing, because ADT emits exactly
+that for an unset reference:
+
+| ADT returns | meaning |
+|---|---|
+| `<doma:valueTableRef/>` | domain with no value table |
+| `<pak:superPackage/>` | package with no parent |
+
+So `value_table` and `super_package` now take effect when set for the first
+time; they were silently ignored before. If your code passes `super_package` on
+a root package and relied on it doing nothing, it now moves the package.
+
 ### What `activate()` treats as a failure
 
 `/sap/bc/adt/activation` answers **HTTP 200 even when activation fails**, so the verdict

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "10.0.2",
+  "version": "10.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "10.0.2",
+      "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "10.0.2",
+  "version": "10.1.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/unit/core/postUpdateReadinessRead.test.ts
+++ b/src/__tests__/unit/core/postUpdateReadinessRead.test.ts
@@ -48,7 +48,28 @@ interface ICall {
   params?: Record<string, unknown>;
 }
 
-/** Answers LOCK with a handle; everything else 200/empty. */
+/**
+ * A body every read-modify-write update can actually patch.
+ *
+ * This stub used to answer every non-LOCK request with an empty body. That is
+ * what ADT returns for an object which is not ready yet — and since the patch
+ * helpers started refusing to write a body they could not patch, asserting the
+ * update proceeds from one is asserting the wrong thing.
+ */
+const OBJECT_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<adtcore:wbObject xmlns:adtcore="http://www.sap.com/adt/core" ' +
+  `adtcore:name="${OBJ}" adtcore:description="before" ` +
+  'adtcore:responsible="TESTER" adtcore:masterSystem="TRL">' +
+  // The package handler patches these; ADT emits them empty when unset, which
+  // is what a root package really returns.
+  '<pak:attributes pak:packageType=""/>' +
+  '<pak:superPackage/>' +
+  '<pak:softwareComponent pak:name=""/>' +
+  '<pak:transportLayer pak:name=""/>' +
+  '</adtcore:wbObject>';
+
+/** Answers LOCK with a handle; everything else 200 with a patchable body. */
 function fakeConnection(): { conn: IAbapConnection; calls: ICall[] } {
   const calls: ICall[] = [];
   const makeAdtRequest = jest.fn(async (req: any) => {
@@ -59,7 +80,7 @@ function fakeConnection(): { conn: IAbapConnection; calls: ICall[] } {
     ) {
       return { status: 200, data: LOCK_XML };
     }
-    return { status: 200, data: '' };
+    return { status: 200, data: OBJECT_XML };
   });
   return {
     conn: {

--- a/src/__tests__/unit/session/sessionRecorder.ts
+++ b/src/__tests__/unit/session/sessionRecorder.ts
@@ -41,6 +41,27 @@ const lockXml = (handle: string): string =>
 const CHECKRUN_OK =
   '<chkrun:checkRunReports xmlns:chkrun="http://www.sap.com/adt/checkrun"/>';
 
+/**
+ * A body a read-modify-write update can patch.
+ *
+ * Reads used to answer with an empty string. That is what ADT returns for an
+ * object which is not ready yet, and since `extractXmlString` started refusing
+ * such a body, a recorder that hands one out is asserting the wrong thing:
+ * these tests are about the *order* of requests in the lock window, not about
+ * what a not-ready object does.
+ */
+const OBJECT_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<doma:wbobject xmlns:doma="http://www.sap.com/dictionary/domain" ' +
+  'xmlns:adtcore="http://www.sap.com/adt/core" adtcore:description="before">' +
+  '<doma:typeInformation><doma:datatype>CHAR</doma:datatype>' +
+  '<doma:length>5</doma:length><doma:decimals>0</doma:decimals>' +
+  '<doma:outputLength>5</doma:outputLength><doma:conversionExit/>' +
+  '<doma:signExists>false</doma:signExists>' +
+  '<doma:lowercase>false</doma:lowercase></doma:typeInformation>' +
+  '<doma:valueTableRef/>' +
+  '</doma:wbobject>';
+
 const ok = (data: unknown): IAdtResponse =>
   ({ data, status: 200, statusText: 'OK', headers: {} }) as IAdtResponse;
 
@@ -84,6 +105,9 @@ export function createSessionRecorder(
       }
       if (url.includes('/checkruns')) {
         return ok(CHECKRUN_OK);
+      }
+      if (method === 'GET') {
+        return ok(OBJECT_XML);
       }
       return ok('');
     },

--- a/src/__tests__/unit/utils/xmlPatchFailsLoudly.test.ts
+++ b/src/__tests__/unit/utils/xmlPatchFailsLoudly.test.ts
@@ -1,0 +1,193 @@
+/**
+ * A patch that cannot find its target must say so.
+ *
+ * Written from a live failure. A full run reported
+ * `update FAILED (HTTP 400): The description is missing for ZAC_DOM01` on a
+ * domain whose description was in the configuration the whole time. The GET
+ * before the PUT had come back empty — which ADT returns with HTTP 200, not an
+ * error — so `patchXmlAttribute` had no `adtcore:description` to replace, and
+ * `String.replace` handed the body back unchanged without a word. The PUT then
+ * shipped without a description and the server rejected it.
+ *
+ * The varying response time of the ABAP system is the trigger and cannot be
+ * fixed here. What these guard is the conversion: a slow read must surface as a
+ * read error naming the object, not as a malformed write blamed on the server.
+ */
+import {
+  extractXmlString,
+  patchIf,
+  patchXmlAttribute,
+  patchXmlBlock,
+  patchXmlElement,
+  patchXmlElementAttribute,
+  XmlPatchError,
+} from '../../../utils/xmlPatch';
+
+const DOMAIN_XML =
+  '<?xml version="1.0" encoding="UTF-8"?>' +
+  '<doma:wbobject xmlns:doma="http://www.sap.com/dictionary/domain" ' +
+  'xmlns:adtcore="http://www.sap.com/adt/core" adtcore:name="ZAC_DOM01" ' +
+  'adtcore:description="old text">' +
+  '<doma:typeInformation><doma:datatype>CHAR</doma:datatype>' +
+  '<doma:length>5</doma:length></doma:typeInformation>' +
+  '</doma:wbobject>';
+
+describe('a patch applies or throws — it never passes the XML through', () => {
+  it('patches the attribute when it is there', () => {
+    const patched = patchXmlAttribute(
+      DOMAIN_XML,
+      'adtcore:description',
+      'new text',
+    );
+
+    expect(patched).toContain('adtcore:description="new text"');
+    expect(patched).not.toContain('old text');
+  });
+
+  it('throws instead of silently dropping the description', () => {
+    // The exact shape that produced the live 400: a body with no description
+    // to replace. Before this guard the call returned the input unchanged.
+    const withoutDescription = '<doma:wbobject adtcore:name="ZAC_DOM01"/>';
+
+    expect(() =>
+      patchXmlAttribute(withoutDescription, 'adtcore:description', 'new text'),
+    ).toThrow(XmlPatchError);
+  });
+
+  it('names the target it could not find', () => {
+    expect(() => patchXmlAttribute('<a/>', 'adtcore:description', 'x')).toThrow(
+      /adtcore:description/,
+    );
+  });
+
+  it.each([
+    ['element', () => patchXmlElement('<a/>', 'doma:datatype', 'CHAR')],
+    [
+      'element attribute',
+      () => patchXmlElementAttribute('<a/>', 'pak:super', 'adtcore:name', 'X'),
+    ],
+    ['block', () => patchXmlBlock('<a/>', 'doma:typeInformation', '<b/>')],
+  ])('throws for a missing %s too', (_label, call) => {
+    expect(call).toThrow(XmlPatchError);
+  });
+
+  it('patches an element that ADT emits empty, rather than refusing it', () => {
+    // `<doma:conversionExit/>` is what a domain with no conversion exit
+    // actually returns — probed on a live system. The element is there; only
+    // its content is not.
+    expect(
+      patchXmlElement(
+        '<x><doma:conversionExit/></x>',
+        'doma:conversionExit',
+        'ALPHA',
+      ),
+    ).toContain('<doma:conversionExit>ALPHA</doma:conversionExit>');
+  });
+
+  it('leaves patchIf free to skip an absent value', () => {
+    // `patchIf` is how a caller says "only if provided". Reaching a patch at
+    // all means the change was intended, which is why the patch may throw.
+    expect(patchIf(DOMAIN_XML, undefined, () => 'never')).toBe(DOMAIN_XML);
+    expect(patchIf(DOMAIN_XML, null, () => 'never')).toBe(DOMAIN_XML);
+  });
+});
+
+describe('setting an attribute on an element ADT left empty', () => {
+  // Both shapes below were read from a live system. Refusing them would forbid
+  // ever setting these for the first time — which is why this one patch adds
+  // the attribute instead of throwing.
+  it('adds a value table to a domain that has none', () => {
+    const patched = patchXmlElementAttribute(
+      '<doma:wbobject><doma:valueTableRef/></doma:wbobject>',
+      'doma:valueTableRef',
+      'adtcore:name',
+      'ZAC_SHR_VTABL',
+    );
+
+    expect(patched).toContain(
+      '<doma:valueTableRef adtcore:name="ZAC_SHR_VTABL"/>',
+    );
+  });
+
+  it('adds a super package to a root package', () => {
+    expect(
+      patchXmlElementAttribute(
+        '<pak:package><pak:superPackage/></pak:package>',
+        'pak:superPackage',
+        'adtcore:name',
+        'ZLOCAL',
+      ),
+    ).toContain('<pak:superPackage adtcore:name="ZLOCAL"/>');
+  });
+
+  it('keeps the attributes the element already had', () => {
+    const patched = patchXmlElementAttribute(
+      '<pak:superPackage adtcore:uri="/sap/bc/adt/packages/zlocal"/>',
+      'pak:superPackage',
+      'adtcore:name',
+      'ZLOCAL',
+    );
+
+    expect(patched).toContain('adtcore:uri="/sap/bc/adt/packages/zlocal"');
+    expect(patched).toContain('adtcore:name="ZLOCAL"');
+  });
+
+  it('replaces the value when the attribute is already there', () => {
+    expect(
+      patchXmlElementAttribute(
+        '<pak:superPackage adtcore:name="OLD"/>',
+        'pak:superPackage',
+        'adtcore:name',
+        'ZLOCAL',
+      ),
+    ).toBe('<pak:superPackage adtcore:name="ZLOCAL"/>');
+  });
+
+  it('still throws when the element itself is missing', () => {
+    // The partial-read case — the one this whole module exists to catch.
+    expect(() =>
+      patchXmlElementAttribute(
+        '<pak:package/>',
+        'pak:superPackage',
+        'adtcore:name',
+        'ZLOCAL',
+      ),
+    ).toThrow(/<pak:superPackage> is not present/);
+  });
+});
+
+describe('the body of a read is checked before anything is patched into it', () => {
+  it('accepts real XML', () => {
+    expect(extractXmlString(DOMAIN_XML, 'domain ZAC_DOM01')).toBe(DOMAIN_XML);
+  });
+
+  it('rejects the empty body ADT returns for a not-yet-ready object', () => {
+    expect(() => extractXmlString('', 'domain ZAC_DOM01')).toThrow(
+      /empty body/,
+    );
+  });
+
+  it('names the object, so the error says what could not be updated', () => {
+    expect(() => extractXmlString('   ', 'domain ZAC_DOM01')).toThrow(
+      /domain ZAC_DOM01/,
+    );
+  });
+
+  it('rejects a non-string body instead of JSON-stringifying it', () => {
+    // The old behaviour turned an object into `{"foo":"bar"}` and handed it on
+    // as if it were XML: not a match for any patch, one step earlier than the
+    // patches themselves.
+    expect(() => extractXmlString({ foo: 'bar' }, 'domain ZAC_DOM01')).toThrow(
+      XmlPatchError,
+    );
+    expect(() => extractXmlString(undefined, 'domain ZAC_DOM01')).toThrow(
+      /undefined/,
+    );
+  });
+
+  it('rejects a body that is not XML at all', () => {
+    expect(() => extractXmlString('Service Unavailable', 'domain X')).toThrow(
+      /not XML/,
+    );
+  });
+});

--- a/src/core/dataElement/update.ts
+++ b/src/core/dataElement/update.ts
@@ -232,7 +232,10 @@ export async function updateDataElement(
     timeout: getTimeout('default'),
     headers: { Accept: ACCEPT_DATA_ELEMENT },
   });
-  const currentXml = extractXmlString(currentResponse.data);
+  const currentXml = extractXmlString(
+    currentResponse.data,
+    `data element ${params.data_element_name}`,
+  );
 
   // 2. Patch only changed fields
   const updatedXml = patchDataElementXml(currentXml, params);

--- a/src/core/domain/update.ts
+++ b/src/core/domain/update.ts
@@ -109,7 +109,10 @@ export async function updateDomain(
     timeout: getTimeout('default'),
     headers: { Accept: ACCEPT_DOMAIN },
   });
-  const currentXml = extractXmlString(currentResponse.data);
+  const currentXml = extractXmlString(
+    currentResponse.data,
+    `domain ${args.domain_name}`,
+  );
 
   // 2. Patch only changed fields
   const updatedXml = patchDomainXml(currentXml, args);

--- a/src/core/functionGroup/update.ts
+++ b/src/core/functionGroup/update.ts
@@ -16,7 +16,7 @@ import {
   limitDescription,
 } from '../../utils/internalUtils';
 import { getTimeout } from '../../utils/timeouts';
-import { patchXmlAttribute } from '../../utils/xmlPatch';
+import { extractXmlString, patchXmlAttribute } from '../../utils/xmlPatch';
 import type { IAdtContentTypes } from '../shared/contentTypes';
 import { lockFunctionGroup } from './lock';
 import { getFunctionGroup } from './read';
@@ -103,10 +103,10 @@ export async function updateFunctionGroup(
       params.function_group_name,
       undefined,
     );
-    const currentXml =
-      typeof currentResponse.data === 'string'
-        ? currentResponse.data
-        : JSON.stringify(currentResponse.data);
+    const currentXml = extractXmlString(
+      currentResponse.data,
+      `function group ${params.function_group_name}`,
+    );
 
     // Update metadata
     const updateResponse = await updateFunctionGroupMetadata(

--- a/src/core/package/update.ts
+++ b/src/core/package/update.ts
@@ -111,7 +111,10 @@ export async function updatePackage(
     timeout: getTimeout('default'),
     headers: { Accept: ACCEPT_PACKAGE },
   });
-  const currentXml = extractXmlString(currentResponse.data);
+  const currentXml = extractXmlString(
+    currentResponse.data,
+    `package ${params.package_name}`,
+  );
 
   // 2. Patch only changed fields
   const updatedXml = patchPackageXml(currentXml, params);

--- a/src/core/tabletype/update.ts
+++ b/src/core/tabletype/update.ts
@@ -95,7 +95,10 @@ export async function updateTableType(
     undefined,
     logger,
   );
-  const currentXml = extractXmlString(currentResponse.data);
+  const currentXml = extractXmlString(
+    currentResponse.data,
+    `table type ${params.tabletype_name}`,
+  );
 
   // 2. Patch only changed fields
   const updatedXml = patchTableTypeXml(currentXml, params);

--- a/src/utils/xmlPatch.ts
+++ b/src/utils/xmlPatch.ts
@@ -1,48 +1,126 @@
 /**
- * XML patch utilities for read-modify-write update pattern.
+ * XML patch utilities for the read-modify-write update pattern.
  *
- * Instead of building XML from scratch (which loses unknown fields like abapLanguageVersion),
- * these helpers modify specific values in the original XML string obtained from GET.
+ * Instead of building XML from scratch (which loses unknown fields like
+ * abapLanguageVersion), these helpers modify specific values in the original
+ * XML string obtained from GET.
+ *
+ * **Every patch here fails loudly when it cannot find its target.** That is the
+ * point of this module's error handling, and it was learned from a live
+ * failure: a full test run reported
+ *
+ * ```
+ * update FAILED (HTTP 400): The description is missing for ZAC_DOM01
+ * ```
+ *
+ * on a domain whose description was present in the configuration all along. The
+ * chain was:
+ *
+ * 1. the GET came back slow, or the object was not yet ready — ADT answers such
+ *    reads with **200 and an empty body**, never a 404, so nothing upstream had
+ *    a status to react to;
+ * 2. `patchXmlAttribute` was asked to set `adtcore:description` and found no
+ *    attribute to replace. Being `String.replace`, it returned the input
+ *    unchanged — silently;
+ * 3. the PUT went out without a description, and the server rejected it.
+ *
+ * The ABAP system's varying response time is the trigger, and nothing here can
+ * change that. What these helpers control is what a slow read turns into: a
+ * read error naming the object, or a malformed write blamed on the server. It
+ * used to be the second.
  */
+
+/** Raised when a patch cannot find what it was asked to change. */
+export class XmlPatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'XmlPatchError';
+  }
+}
+
+/**
+ * Apply a replacement, refusing to pass the XML through untouched.
+ *
+ * A caller reaches a patch only when it intends the change — `patchIf` skips
+ * the call entirely for an absent value — so "no match" always means the PUT
+ * would not carry what the caller asked for. There is no case where quietly
+ * returning the input is the right answer.
+ */
+function replaceOrThrow(
+  xml: string,
+  regex: RegExp,
+  replacement: string,
+  target: string,
+): string {
+  if (!regex.test(xml)) {
+    throw new XmlPatchError(
+      `Cannot patch ${target}: it is not present in the XML being updated. ` +
+        'This usually means the preceding read returned an empty or partial ' +
+        'body — ADT answers a read of a not-yet-ready object with HTTP 200 and ' +
+        'no content rather than an error.',
+    );
+  }
+  return xml.replace(regex, replacement);
+}
 
 /**
  * Replace an XML attribute value.
  * Example: `adtcore:description="old"` → `adtcore:description="new"`
+ *
+ * @throws {XmlPatchError} when the attribute is absent
  */
 export function patchXmlAttribute(
   xml: string,
   attrName: string,
   newValue: string,
 ): string {
-  const regex = new RegExp(`${attrName}="[^"]*"`);
-  return xml.replace(regex, `${attrName}="${escapeXmlAttr(newValue)}"`);
+  return replaceOrThrow(
+    xml,
+    new RegExp(`${attrName}="[^"]*"`),
+    `${attrName}="${escapeXmlAttr(newValue)}"`,
+    `attribute ${attrName}`,
+  );
 }
 
 /**
  * Replace XML element text content.
  * Handles both `<tag>content</tag>` and self-closing `<tag/>`.
+ *
+ * @throws {XmlPatchError} when the element is absent
  */
 export function patchXmlElement(
   xml: string,
   tagName: string,
   newValue: string,
 ): string {
-  // Match <tag>...</tag> or <tag/> (self-closing)
   const regex = new RegExp(
     `<${tagName}>([^<]*)</${tagName}>|<${tagName}\\s*/>`,
   );
-  if (newValue === '' || newValue === undefined) {
-    return xml.replace(regex, `<${tagName}/>`);
-  }
-  return xml.replace(
-    regex,
-    `<${tagName}>${escapeXmlText(newValue)}</${tagName}>`,
-  );
+  const replacement =
+    newValue === '' || newValue === undefined
+      ? `<${tagName}/>`
+      : `<${tagName}>${escapeXmlText(newValue)}</${tagName}>`;
+  return replaceOrThrow(xml, regex, replacement, `element <${tagName}>`);
 }
 
 /**
- * Replace an XML attribute on a specific element.
+ * Set an XML attribute on a specific element.
  * Example: `<pak:superPackage adtcore:name="OLD"/>` → `<pak:superPackage adtcore:name="NEW"/>`
+ *
+ * Unlike the other patches this one **adds** the attribute when the element is
+ * there without it, because that is a state ADT genuinely produces for an unset
+ * reference — probed on a live system:
+ *
+ * ```
+ * <doma:valueTableRef/>    a domain with no value table
+ * <pak:superPackage/>      a package with no parent
+ * ```
+ *
+ * Refusing those would forbid ever setting a value table or a super package for
+ * the first time. Only a missing *element* means the XML is not what the caller
+ * thinks it is, and only that throws.
+ *
+ * @throws {XmlPatchError} when the element itself is absent
  */
 export function patchXmlElementAttribute(
   xml: string,
@@ -50,23 +128,47 @@ export function patchXmlElementAttribute(
   attrName: string,
   newValue: string,
 ): string {
-  const regex = new RegExp(`(<${elementTag}[^>]*?)${attrName}="[^"]*"`);
-  return xml.replace(regex, `$1${attrName}="${escapeXmlAttr(newValue)}"`);
+  const value = escapeXmlAttr(newValue);
+
+  const withAttribute = new RegExp(`(<${elementTag}[^>]*?)${attrName}="[^"]*"`);
+  if (withAttribute.test(xml)) {
+    return xml.replace(withAttribute, `$1${attrName}="${value}"`);
+  }
+
+  const element = new RegExp(`<${elementTag}(\\s[^>]*?)?(/?)>`);
+  if (element.test(xml)) {
+    return xml.replace(
+      element,
+      (_match, attrs: string | undefined, selfClosing: string) =>
+        `<${elementTag}${attrs ?? ''} ${attrName}="${value}"${selfClosing}>`,
+    );
+  }
+
+  throw new XmlPatchError(
+    `Cannot patch attribute ${attrName}: element <${elementTag}> is not present ` +
+      'in the XML being updated. This usually means the preceding read returned ' +
+      'an empty or partial body — ADT answers a read of a not-yet-ready object ' +
+      'with HTTP 200 and no content rather than an error.',
+  );
 }
 
 /**
  * Replace an entire XML block (from opening to closing tag) with new content.
  * Handles both `<tag>...</tag>` (including nested content) and self-closing `<tag/>`.
+ *
+ * @throws {XmlPatchError} when the block is absent
  */
 export function patchXmlBlock(
   xml: string,
   tagName: string,
   newContent: string,
 ): string {
-  const regex = new RegExp(
-    `<${tagName}[\\s\\S]*?</${tagName}>|<${tagName}\\s*/>`,
+  return replaceOrThrow(
+    xml,
+    new RegExp(`<${tagName}[\\s\\S]*?</${tagName}>|<${tagName}\\s*/>`),
+    newContent,
+    `block <${tagName}>`,
   );
-  return xml.replace(regex, newContent);
 }
 
 /**
@@ -82,11 +184,34 @@ export function patchIf<T>(
 }
 
 /**
- * Extract raw XML string from response data.
+ * Take the XML out of a response, refusing anything that cannot be patched.
+ *
+ * This used to `JSON.stringify` a non-string body and hand back the result,
+ * which is not XML and matches no patch — turning a bad read into a bad write
+ * one step earlier than the patches did. An empty body passed through just as
+ * quietly, and an empty body is exactly what ADT returns for an object that is
+ * not ready yet.
+ *
+ * @param what object being read, named in the error (e.g. `'domain ZAC_DOM01'`)
+ * @throws {XmlPatchError} when the body is not usable XML
  */
-export function extractXmlString(data: unknown): string {
-  if (typeof data === 'string') return data;
-  return JSON.stringify(data);
+export function extractXmlString(data: unknown, what = 'object'): string {
+  if (typeof data !== 'string') {
+    const kind =
+      data === null || data === undefined ? String(data) : typeof data;
+    throw new XmlPatchError(
+      `Cannot update ${what}: the read returned ${kind}, not XML.`,
+    );
+  }
+  const xml = data.trim();
+  if (xml === '' || !xml.startsWith('<')) {
+    throw new XmlPatchError(
+      `Cannot update ${what}: the read returned ${xml === '' ? 'an empty body' : 'a body that is not XML'}. ` +
+        'ADT answers a read of a not-yet-ready object with HTTP 200 and no ' +
+        'content, so the status alone does not show this.',
+    );
+  }
+  return data;
 }
 
 /** Escape special characters for XML attribute values */


### PR DESCRIPTION
Your hypothesis holds — the trigger is the ABAP system's varying response time. This is what the library **did with it**.

## The chain

```
update FAILED (HTTP 400): The description is missing for ZAC_DOM01
```

on a domain whose description was in the configuration the whole time:

| step | what happened |
|---|---|
| `GET /ddic/domains/zac_dom01` | slow, or the object not yet ready |
| `extractXmlString(...)` | **no check at all** |
| `patchXmlAttribute('adtcore:description')` | **no match → returned the body unchanged, silently** |
| `PUT` | 400: the description is missing |

Two silent steps in the middle. ADT answers a read of a not-ready object with **200 and an empty body**, never a 404, so no status showed it. Then `patchXmlAttribute` — being `String.replace` — found nothing to replace and said nothing. The PUT shipped without a description and the server was blamed for rejecting it.

Nothing here can fix a slow system. What it fixes is **the conversion**: a slow read now surfaces as a read error naming the object, instead of a malformed write.

## Layer 1 — the body is checked before anything is patched into it

`extractXmlString` rejects what cannot be patched — empty, non-string (it used to `JSON.stringify` an object and hand it on as "XML"), or not XML — and names the object:

```
Cannot update domain ZAC_DOM01: the read returned an empty body.
```

One change covers all five read-modify-write modules, including `functionGroup`, which carried its own copy of the same `JSON.stringify` fallback inline.

## Layer 2 — a patch applies or throws

A caller only reaches a patch when it intends the change (`patchIf` skips the call for an absent value), so "no match" always meant the PUT would not carry what was asked for.

### One exception, and the system decided it — not me

`patchXmlElementAttribute` **adds** the attribute when the element is there without it, because that state is real. Probed on the trial:

```
<doma:valueTableRef/>    a domain with no value table
<pak:superPackage/>      a package with no parent
```

Throwing there would have forbidden ever setting a value table or a super package **for the first time** — a capability regression sold as a bug fix. My first draft did exactly that, and the package unit test caught it; I probed rather than adjusted the test. Only a missing *element* throws now.

`patchXmlElement` needed no such split: ADT always emits the element, self-closing when empty (`<doma:conversionExit/>`), which its regex already matches.

## Test doubles updated, not worked around

`postUpdateReadinessRead` and `sessionRecorder` answered every read with an empty body — the shape ADT gives **only** for a not-ready object — so they were asserting that an update proceeds from one. Both now return a body a patch can work on. Their subject is the *order* of requests in the lock window, which is unchanged.

## Verification

- 443 unit tests across 81 suites, including new coverage of all three states (attribute present / element present without it / element absent).
- Against the trial, the five read-modify-write types — `domain`, `package`, `dataElement`, `tabletype`, `functionGroup` — **12 tests, all pass**.
- `lint:check` and `tsc` clean.

## Release

This one **does** touch `dist`. No public export changed — `xmlPatch` is internal — but `XmlPatchError` is a new failure mode where callers previously got a server-side 400 or a silently wrong write. Tell me the version and I will add the CHANGELOG entry and the docs note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)