### PR TITLE
feat(atc): run a check, ask whether it is done, read what it found (12.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ ATC check runs: start one, ask whether it is done, read what it found.
   const started = await atc.run({
     objects: [{ objectType: 'class', objectName: 'ZCL_MY_CLASS' }],
   });
-  // started.waited === false → { worklistId, runId }
 
-  // Poll under a bound you choose, then read the worklist.
-  const status = await atc.getRunStatus(started.runId);
-  if (status.isFinished) await atc.getFindings(started.worklistId);
+  // `waited` is the discriminant — narrowing on it is what yields runId.
+  if (!started.waited) {
+    // Poll under a bound you choose, then read the worklist.
+    const status = await atc.getRunStatus(started.runId);
+    if (status.isFinished) await atc.getFindings(started.worklistId);
+  }
   ```
 
 - **`AdtAtc`** is exported from the package root and from `@mcp-abap-adt/adt-clients/runtime`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,75 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+## [12.1.0] - 2026-08-18
+
+ATC check runs: start one, ask whether it is done, read what it found.
+
+### Added
+
+- **`AdtRuntimeClient.getAtc()`** — an ATC handler returning
+  `IAdtRunnable<IAtcRunTarget, IAtcRunResult, IAtcRunOptions> & IAtcRunStatusReadable &
+  IAtcFindings`. Three capabilities and no more: a check run is run and then read, never
+  created, locked, activated or versioned, and the type says so rather than offering the rest
+  and throwing.
+
+  ```typescript
+  const atc = runtime.getAtc();
+
+  const started = await atc.run({
+    objects: [{ objectType: 'class', objectName: 'ZCL_MY_CLASS' }],
+  });
+  // started.waited === false → { worklistId, runId }
+
+  // Poll under a bound you choose, then read the worklist.
+  const status = await atc.getRunStatus(started.runId);
+  if (status.isFinished) await atc.getFindings(started.worklistId);
+  ```
+
+- **`AdtAtc`** is exported from the package root and from `@mcp-abap-adt/adt-clients/runtime`.
+
+- **`wait: true`** hands the request to the server until the checks finish. It is not a timing
+  flag: the two modes answer with different shapes, so `IAtcRunResult` is a discriminated union
+  on `waited` — `{ worklistId, runId }` without waiting, `{ worklistId, findingStats }` with.
+
+- **Seven checkable object types** — `class`, `interface`, `function_group`, `package`,
+  `ddl_source`, `table`, `behavior_definition`. Each was confirmed on an ABAP Cloud trial by a
+  run submitted at the URI this client builds whose **finished** worklist then listed that
+  object under that type. A run being *accepted* proves nothing: a URI that cannot exist is
+  answered `201` too. `program` and `include` are absent because ABAP Cloud refuses to hold
+  either (`403`, `S_DEVELOP`), so nothing there could confirm them; adding them later is a
+  major, since the union is exhaustible.
+
+### Notes
+
+- **Nothing here defaults a missing value.** Each response the chain depends on carries one
+  thing the next step cannot work without — the check variant, the worklist id, the `Location`,
+  `FINDING_STATS`, `runs:status` — and where that thing is absent the call rejects naming it
+  (`ATC_NO_CHECK_VARIANT`, `ATC_NO_WORKLIST_ID`, `ATC_NO_RUN_LOCATION`,
+  `ATC_NO_FINDING_STATS`, `ATC_RUN_STATUS_MISSING`). The dangerous outcome on an unfamiliar
+  system is not an exception; it is a confident zero that reads exactly like a clean check.
+
+- **No `waitForRun` helper, deliberately.** Waiting needs a stopping condition for a run that
+  does not finish; no failed or cancelled run has been observed, so a helper would have to
+  invent one. `isFinished` is **completion, not success** — it says the run reached an end, not
+  that the end was a good one — and `status` travels beside it so a caller can report the state
+  they last saw. `docs/usage/CLIENT_API_REFERENCE.md` shows the loop with a caller-chosen bound.
+
+- **`findingStats` is the server's triple verbatim** (`"0,0,1"`), not parsed into named counts:
+  which position is which severity has been seen once, beside a single priority-3 finding,
+  which fits several orderings.
+
+- **`getAtc()` and `getAtcLog()` are different resources.** The first runs checks and reads a
+  worklist; the second reads the execution and check-failure logs and takes an execution id.
+  Neither accepts the other's identifier.
+
+### Changed
+
+- **`@mcp-abap-adt/interfaces` floor raised to `^17.1.0`**, which is where the ATC contract
+  (`AtcObjectType`, `IAtcRunTarget`, `IAtcRunOptions`, `IAtcRunResult`, `IAtcRunStatus`,
+  `IAtcRunStatusReadable`, `IAtcFindings`) is defined. Additive: 17.1.0 adds these and changes
+  nothing that existed in 17.0.0.
+
 ## [12.0.0] - 2026-08-15
 
 Every handler now declares what ADT gives it, and nothing else. This finishes what 8.0.0 began.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ TypeScript clients for SAP ABAP Development Tools (ADT).
   - `AdtClient` – high-level CRUD API with automatic operation chains
   - `AdtClientBatch` – batch mode: multiple read operations in a single HTTP round-trip
   - `AdtExecutor` – execution API via `IExecutor` contracts (class/program, with profiling)
-  - `AdtRuntimeClient` – stable runtime operations (ABAP debugger, traces, logs, dumps)
+  - `AdtRuntimeClient` – stable runtime operations (ABAP debugger, traces, logs, dumps, ATC check runs)
   - `AdtRuntimeClientBatch` – batch mode for runtime operations
   - `AdtRuntimeClientExperimental` – runtime APIs in progress (for example AMDP debugger)
   - `AdtClientsWS` – realtime WebSocket facade for event-driven workflows
@@ -68,7 +68,7 @@ This package is responsible for:
 
 This package interacts with external packages **ONLY through interfaces**:
 
-- **`@mcp-abap-adt/interfaces`** (`^14.1.0`): The contract package — the single definition site for every public type this package exposes (see [Type System](#type-system)). This is the one runtime dependency whose *types* are part of this package's public API.
+- **`@mcp-abap-adt/interfaces`** (`^17.1.0`): The contract package — the single definition site for every public type this package exposes (see [Type System](#type-system)). This is the one runtime dependency whose *types* are part of this package's public API.
 - **`@mcp-abap-adt/connection`**: Uses the `IAbapConnection` interface for HTTP requests — does not know about the concrete connection implementation. It is a **dev** dependency; consumers supply their own implementation.
 - **No other direct package dependencies**: all remaining interactions happen through well-defined interfaces
 
@@ -96,8 +96,9 @@ npm install @mcp-abap-adt/adt-clients
    - Example: `await client.getClass().create({...}, { activateOnCreate: true })`
 
 2. **AdtRuntimeClient**
-   - Stable runtime operations for ABAP debugging, traces, dumps, logs, feeds, and more
-   - Factory accessors: `getProfiler()`, `getCrossTrace()`, `getSt05Trace()`, `getDebugger()`, `getApplicationLog()`, `getAtcLog()`, `getDdicActivation()`, `getDumps()`, `getFeeds()`, `getSystemMessages()`, `getGatewayErrorLog()`
+   - Stable runtime operations for ABAP debugging, traces, dumps, logs, feeds, ATC check runs, and more
+   - Factory accessors: `getProfiler()`, `getCrossTrace()`, `getSt05Trace()`, `getDebugger()`, `getApplicationLog()`, `getAtc()`, `getAtcLog()`, `getDdicActivation()`, `getDumps()`, `getFeeds()`, `getSystemMessages()`, `getGatewayErrorLog()`
+   - `getAtc()` runs ATC checks; `getAtcLog()` reads the execution and check-failure logs. Same subject, different resources — see [ATC check runs](docs/usage/CLIENT_API_REFERENCE.md#atc-check-runs)
    - Example: `await runtimeClient.getDebugger().getAbap().launch()`
 
 3. **AdtExecutor**
@@ -583,7 +584,7 @@ everything else is not.
 
 ### Single Definition Site: `@mcp-abap-adt/interfaces`
 
-Since **7.5.0**, every public type is **defined once**, in `@mcp-abap-adt/interfaces` (`^14.1.0`). This package declares no copies of its own — the low-level `*Params` interfaces, every `IXxxConfig`/`IXxxState` pair, the option/result types and the cross-cutting shared types all live there.
+Since **7.5.0**, every public type is **defined once**, in `@mcp-abap-adt/interfaces` (`^17.1.0`). This package declares no copies of its own — the low-level `*Params` interfaces, every `IXxxConfig`/`IXxxState` pair, the option/result types and the cross-cutting shared types all live there.
 
 **Import them from the package that owns them:**
 
@@ -601,7 +602,7 @@ What this package exports is what it owns: the clients, the handler classes, the
 
 ### Honest capability types (since 8.0.0)
 
-`@mcp-abap-adt/interfaces` (`^17.0.0`) splits the fat `IAdtObject` contract into **capability atoms** — `IAdtCreatable`, `IAdtReadable`, `IAdtUpdatable`, `IAdtDeletable` (and `IAdtModifiable`/`IAdtCrud`, their composites), `IAdtValidatable`, `IAdtCheckable`, `IAdtActivatable`, `IAdtLockable`, `IAdtVersionable`, `IAdtTransportAware`, `IAdtSearchable` — each covering one slice of the lifecycle, plus one named composite, `IAdtSourceObject`. There is no composite for "everything but versions": a vocabulary states what an object supports, never what it lacks. Since interfaces 13.0.0 `IAdtObject` is itself assembled from the atoms, so the atoms are the definitions and the composite cannot drift from them.
+`@mcp-abap-adt/interfaces` (`^17.1.0`) splits the fat `IAdtObject` contract into **capability atoms** — `IAdtCreatable`, `IAdtReadable`, `IAdtUpdatable`, `IAdtDeletable` (and `IAdtModifiable`/`IAdtCrud`, their composites), `IAdtValidatable`, `IAdtCheckable`, `IAdtActivatable`, `IAdtLockable`, `IAdtVersionable`, `IAdtTransportAware`, `IAdtSearchable` — each covering one slice of the lifecycle, plus one named composite, `IAdtSourceObject`. There is no composite for "everything but versions": a vocabulary states what an object supports, never what it lacks. Since interfaces 13.0.0 `IAdtObject` is itself assembled from the atoms, so the atoms are the definitions and the composite cannot drift from them.
 
 Since **8.0.0**, each handler `implements` only the atoms it genuinely supports, and `AdtClient.getXxx()` (and `AdtClientBatch.getXxx()`) return types are narrowed to match:
 
@@ -618,7 +619,9 @@ Since **9.0.0** no accessor returns the wide type, and since **12.0.0** none ret
 
 `getUnitTest()` and `getCdsUnitTest()` changed meaning rather than shape: a unit test's subject is the container class and its `testclasses` include, so `create()` creates that class and writes the tests into it, `update`/`delete`/`read` manage the include, `lock`/`unlock` take the container's lock, and running is `IAdtRunnable` — one method, with `getStatus`/`getResult` on `ITestRunInformation` because asking about a run is not running it.
 
-**A guard keeps this true.** `src/__tests__/unit/capabilities/` compares all 36 factory return types against the 10 atoms in both directions at compile time, calls every method of every declared capability against a recording connection to check it issues the request its capability names, and fails if a new factory appears without an entry. Adding a throwing method back to a narrowed handler stops compiling.
+The runtime client narrows the same way. `AdtRuntimeClient.getAtc()` returns `IAdtRunnable & IAtcRunStatusReadable & IAtcFindings` — a check run is run and then read, never created, locked, activated or versioned, and the type says so rather than offering the rest and throwing.
+
+**A guard keeps this true.** `src/__tests__/unit/capabilities/` compares all 36 factory return types against the 10 atoms in both directions at compile time, calls every method of every declared capability against a recording connection to check it issues the request its capability names, and fails if a new factory appears without an entry. Adding a throwing method back to a narrowed handler stops compiling. The guard walks `AdtClient` and `AdtClientLegacy` only; the runtime accessors are pinned by `src/__tests__/unit/clients/AdtRuntimeClient.factory.test.ts`.
 
 One category deliberately remains local, because it is code, not contract:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ The package provides the main client classes:
 
 - **AdtClient** - High-level CRUD API with automatic operation chains (recommended)
 - **AdtClientBatch** - Batch mode: multiple read operations in a single HTTP round-trip
-- **AdtRuntimeClient** - Stable runtime operations (ABAP debugger, traces, dumps, logs, feeds)
+- **AdtRuntimeClient** - Stable runtime operations (ABAP debugger, traces, dumps, logs, feeds, ATC check runs)
 - **AdtRuntimeClientBatch** - Batch mode for runtime operations
 - **AdtRuntimeClientExperimental** - Runtime APIs in progress (AMDP debugger/data preview)
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -8,7 +8,7 @@ Primary public entry points:
 - `AdtClient` - high-level CRUD-style object operations.
 - `AdtClientLegacy` - extends `AdtClient` for legacy systems (BASIS < 7.50): blocks unsupported types, uses legacy deletion and versionless content types.
 - `createAdtClient()` - factory that auto-detects system version and returns `AdtClient` or `AdtClientLegacy`.
-- `AdtRuntimeClient` - stable runtime operations (debugger, traces, dumps, logs, feeds, DDIC runtime helpers).
+- `AdtRuntimeClient` - stable runtime operations (debugger, traces, dumps, logs, feeds, ATC check runs, DDIC runtime helpers).
 - `AdtRuntimeClientExperimental` - runtime APIs in progress (currently AMDP debugger/data preview).
 - `AdtClientsWS` - WebSocket request/event facade.
 - `AdtExecutor` - execution-oriented facade (currently class execution with optional profiling helpers).
@@ -117,6 +117,14 @@ Runtime clients are facades over pure runtime functions in `src/runtime/*`.
 - `AdtRuntimeClient`: stable APIs.
 - `AdtRuntimeClientExperimental`: extends stable runtime client and adds AMDP-in-progress APIs.
 
+Runtime accessors return handlers narrowed to what the subject actually
+supports, rather than a uniform object interface. `getAtc()` is the clearest
+case: a check run is run and then read, never created, locked, activated or
+versioned, so `AdtAtc` declares `IAdtRunnable` plus `IAtcRunStatusReadable` and
+`IAtcFindings` — three capabilities and no more. `src/runtime/atc/` holds both
+it and `AtcLog`, which reads the execution and check-failure logs: the same
+subject at different resources, and neither takes the other's identifier.
+
 ### 3) `AdtClientsWS`
 
 WebSocket abstraction around `IWebSocketTransport`:
@@ -185,7 +193,7 @@ Common behaviors in implementations:
 
 ## Type System and Exports
 
-**Types are defined once, in `@mcp-abap-adt/interfaces` (`^14.1.0`).** As of 7.5.0 this package declares no type it shares with the contract package. Each `src/core/<object>/types.ts` is a re-export surface:
+**Types are defined once, in `@mcp-abap-adt/interfaces` (`^17.1.0`).** As of 7.5.0 this package declares no type it shares with the contract package. Each `src/core/<object>/types.ts` is a re-export surface:
 
 ```ts
 export type {

--- a/docs/usage/ADT_OBJECT_ENTITIES.md
+++ b/docs/usage/ADT_OBJECT_ENTITIES.md
@@ -240,7 +240,7 @@ Top-level client classes instantiated directly (not via `AdtClient.getXxx()`). T
 
 ### AdtRuntimeClient
 - Source: `src/clients/AdtRuntimeClient.ts`
-- Public methods: `getApplicationLog`, `getAtcLog`, `getCrossTrace`, `getDdicActivation`, `getDebugger`, `getDumps`, `getFeeds`, `getGatewayErrorLog`, `getProfiler`, `getSt05Trace`, `getSystemMessages`
+- Public methods: `getApplicationLog`, `getAtc`, `getAtcLog`, `getCrossTrace`, `getDdicActivation`, `getDebugger`, `getDumps`, `getFeeds`, `getGatewayErrorLog`, `getProfiler`, `getSt05Trace`, `getSystemMessages`
 
 ### AdtRuntimeClientExperimental
 - Source: `src/clients/AdtRuntimeClientExperimental.ts`

--- a/docs/usage/CLIENT_API_REFERENCE.md
+++ b/docs/usage/CLIENT_API_REFERENCE.md
@@ -4,7 +4,7 @@ This project exposes the following client classes:
 
 - `AdtClient` - high-level CRUD operations for ADT objects.
 - `AdtClientBatch` - batch mode: multiple read operations in a single HTTP round-trip.
-- `AdtRuntimeClient` - stable runtime operations (ABAP debugger, traces, dumps, logs, feeds, etc.).
+- `AdtRuntimeClient` - stable runtime operations (ABAP debugger, traces, dumps, logs, feeds, ATC check runs, etc.).
 - `AdtRuntimeClientBatch` - batch mode for runtime operations.
 - `AdtRuntimeClientExperimental` - runtime APIs in progress (currently AMDP debugger/data preview).
 
@@ -880,7 +880,104 @@ const logObject = await appLog.getObject('Z_MY_LOG');
 const logSource = await appLog.getSource('Z_MY_LOG');
 ```
 
+### ATC check runs
+
+`runtime.getAtc()` starts a check run, asks whether it is done, and reads what
+it found. Three capabilities and no more — a check run is not created, locked,
+activated or versioned, and the returned handler's type says so.
+
+Objects are named by kind, not by URI: the client builds the URI. The kinds are
+`class`, `interface`, `function_group`, `package`, `ddl_source`, `table` and
+`behavior_definition`. Each was confirmed by a run submitted at the URI this
+client builds whose *finished* worklist then listed that object under that
+type; a run being accepted proves nothing, since a URI that cannot exist is
+answered `201` too. `program` and `include` are absent because ABAP Cloud
+refuses to hold either, so nothing there could confirm them.
+
+**Two modes, two shapes.** `wait` is not a timing flag — it changes what the
+server answers with, and the result is a discriminated union on `waited`.
+
+```typescript
+const atc = runtime.getAtc();
+
+// Default: the server answers at once with a run id to poll.
+const started = await atc.run({
+  objects: [
+    { objectType: 'class', objectName: 'ZCL_MY_CLASS' },
+    { objectType: 'ddl_source', objectName: 'ZI_MY_VIEW' },
+  ],
+});
+// started.waited === false, and it carries { worklistId, runId }
+```
+
+```typescript
+// Or have the server hold the request until the checks finish.
+const done = await atc.run(
+  { objects: [{ objectType: 'class', objectName: 'ZCL_MY_CLASS' }] },
+  { wait: true },
+);
+// done.waited === true, and it carries { worklistId, findingStats }
+```
+
+`findingStats` is the server's `FINDING_STATS` triple verbatim, for example
+`"0,0,1"`. It is not parsed into named counts: which position is which severity
+has been observed once, in a worklist with a single priority-3 finding, which
+fits several orderings.
+
+**Polling under a bound you choose.** There is no `waitForRun` helper, and its
+absence is the design: waiting needs a stopping condition for a run that does
+not finish, no failed or cancelled run has ever been observed, and a helper
+would have to invent one. Whoever knows how long their checks take is the one
+who can decide when to give up — and `status` travels beside `isFinished` so
+they can report the state they last saw.
+
+```typescript
+const deadline = Date.now() + 5 * 60_000; // yours to choose
+let status = await atc.getRunStatus(started.runId);
+
+while (!status.isFinished && Date.now() < deadline) {
+  await new Promise((r) => setTimeout(r, 2_000));
+  status = await atc.getRunStatus(started.runId);
+}
+
+if (!status.isFinished) {
+  throw new Error(`ATC run ${started.runId} still ${status.status} after 5 min`);
+}
+
+const findings = await atc.getFindings(started.worklistId);
+```
+
+`isFinished` is **completion, not success**: it says the run reached an end, not
+that the end was a good one. And read the worklist only once a run reports
+finished — read earlier it is empty whatever happened, which is
+indistinguishable from a run that found nothing.
+
+The worklist lists **every object the run checked**, each with its findings,
+empty for the ones that were clean. `getFindings()` returns the raw
+`IAdtResponse`; no finding model is published, because none has been confirmed
+against more than one system.
+
+Two options beyond `wait`:
+
+- `checkVariant` — omitted, the client reads `systemCheckVariant` from ATC
+  customizing. On a system whose variant list comes back empty, customizing is
+  the only source of a usable one.
+- `maximumVerdicts` — a **cap on results**, not a page size. Defaults to 100; a
+  caller wanting everything raises it rather than paging. Must be a positive
+  integer.
+
+**Nothing here defaults a missing value.** Each response the chain depends on
+carries one thing the next step cannot work without — the check variant, the
+worklist id, the `Location`, `FINDING_STATS`, `runs:status` — and where that
+thing is absent the call rejects naming it (`ATC_NO_CHECK_VARIANT`,
+`ATC_NO_WORKLIST_ID`, `ATC_NO_RUN_LOCATION`, `ATC_NO_FINDING_STATS`,
+`ATC_RUN_STATUS_MISSING`). The dangerous outcome on an unfamiliar system is not
+an exception; it is a confident zero that reads exactly like a clean check.
+
 ### ATC Log
+
+Different resources, same subject: `getAtcLog()` reads the execution log and the
+check-failure logs, and takes an execution id rather than a worklist id.
 
 ```typescript
 const atcLog = runtime.getAtcLog();

--- a/docs/usage/CLIENT_API_REFERENCE.md
+++ b/docs/usage/CLIENT_API_REFERENCE.md
@@ -897,6 +897,11 @@ refuses to hold either, so nothing there could confirm them.
 **Two modes, two shapes.** `wait` is not a timing flag — it changes what the
 server answers with, and the result is a discriminated union on `waited`.
 
+`run()` is one method with one return type, so **narrowing on `waited` is how
+you reach the rest**. That is the point of the union rather than a nuisance from
+it: with four optional fields on one interface, `result.runId!` would compile and
+be `undefined` exactly when the caller waited.
+
 ```typescript
 const atc = runtime.getAtc();
 
@@ -907,7 +912,11 @@ const started = await atc.run({
     { objectType: 'ddl_source', objectName: 'ZI_MY_VIEW' },
   ],
 });
-// started.waited === false, and it carries { worklistId, runId }
+
+if (!started.waited) {
+  // Narrowed to { waited: false; worklistId: string; runId: string }
+  console.log(started.runId, started.worklistId);
+}
 ```
 
 ```typescript
@@ -916,7 +925,11 @@ const done = await atc.run(
   { objects: [{ objectType: 'class', objectName: 'ZCL_MY_CLASS' }] },
   { wait: true },
 );
-// done.waited === true, and it carries { worklistId, findingStats }
+
+if (done.waited) {
+  // Narrowed to { waited: true; worklistId: string; findingStats: string }
+  console.log(done.findingStats); // "0,0,1"
+}
 ```
 
 `findingStats` is the server's `FINDING_STATS` triple verbatim, for example
@@ -932,19 +945,26 @@ who can decide when to give up — and `status` travels beside `isFinished` so
 they can report the state they last saw.
 
 ```typescript
-const deadline = Date.now() + 5 * 60_000; // yours to choose
-let status = await atc.getRunStatus(started.runId);
+const started = await atc.run({
+  objects: [{ objectType: 'class', objectName: 'ZCL_MY_CLASS' }],
+});
 
-while (!status.isFinished && Date.now() < deadline) {
-  await new Promise((r) => setTimeout(r, 2_000));
-  status = await atc.getRunStatus(started.runId);
+if (!started.waited) {
+  const { runId, worklistId } = started;
+  const deadline = Date.now() + 5 * 60_000; // yours to choose
+  let status = await atc.getRunStatus(runId);
+
+  while (!status.isFinished && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    status = await atc.getRunStatus(runId);
+  }
+
+  if (!status.isFinished) {
+    throw new Error(`ATC run ${runId} still ${status.status} after 5 min`);
+  }
+
+  const findings = await atc.getFindings(worklistId);
 }
-
-if (!status.isFinished) {
-  throw new Error(`ATC run ${started.runId} still ${status.status} after 5 min`);
-}
-
-const findings = await atc.getFindings(started.worklistId);
 ```
 
 `isFinished` is **completion, not success**: it says the run reached an end, not

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.0.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^17.0.0",
+        "@mcp-abap-adt/interfaces": "^17.1.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -2183,9 +2183,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-17.0.0.tgz",
-      "integrity": "sha512-gtC6Ad2MFt+qPxnxJglL//RL+l8ALoG8tMw11hyWfRdpAawKBLsUYNdlqdx9/JTgA+SAYb14qdTADJyGRtiRiQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-17.1.0.tgz",
+      "integrity": "sha512-BGsWbU3esd1hbYaq4ngjvx9ybjRgvyqWeTVXXZwaF6gmFZyQ5kZ4kyQ3qHsJuyFh0SO5Au/4EbXQ1KmPnzgr/w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "12.0.0",
+      "version": "12.1.0",
       "license": "MIT",
       "dependencies": {
         "@mcp-abap-adt/interfaces": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^17.0.0",
+    "@mcp-abap-adt/interfaces": "^17.1.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.18.1",
     "fast-xml-parser": "^5.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/__tests__/unit/clients/AdtRuntimeClient.factory.test.ts
+++ b/src/__tests__/unit/clients/AdtRuntimeClient.factory.test.ts
@@ -1,6 +1,7 @@
 import type { IAbapConnection, ILogger } from '@mcp-abap-adt/interfaces';
 import { AdtRuntimeClient } from '../../../clients/AdtRuntimeClient';
 import { ApplicationLog } from '../../../runtime/applicationLog/ApplicationLog';
+import { AdtAtc } from '../../../runtime/atc/AdtAtc';
 import { AtcLog } from '../../../runtime/atc/AtcLog';
 import { DdicActivation } from '../../../runtime/ddic/DdicActivation';
 import { AbapDebugger } from '../../../runtime/debugger/AbapDebugger';
@@ -64,6 +65,16 @@ describe('AdtRuntimeClient factory pattern', () => {
     expect(client.getAtcLog()).toBeInstanceOf(AtcLog);
   });
 
+  // Two neighbours with almost the same name reading the same subject from
+  // different resources: getAtc() runs checks, getAtcLog() reads execution logs.
+  // Asserting they are different objects is the cheap way to catch a factory
+  // wired to the wrong cached field.
+  it('getAtc() returns an AdtAtc instance, distinct from getAtcLog()', () => {
+    const { client } = createRuntimeClient();
+    expect(client.getAtc()).toBeInstanceOf(AdtAtc);
+    expect(client.getAtc()).not.toBe(client.getAtcLog());
+  });
+
   it('getDdicActivation() returns a DdicActivation instance', () => {
     const { client } = createRuntimeClient();
     expect(client.getDdicActivation()).toBeInstanceOf(DdicActivation);
@@ -118,6 +129,11 @@ describe('AdtRuntimeClient factory pattern', () => {
     it('getAtcLog() returns the same instance on repeated calls', () => {
       const { client } = createRuntimeClient();
       expect(client.getAtcLog()).toBe(client.getAtcLog());
+    });
+
+    it('getAtc() returns the same instance on repeated calls', () => {
+      const { client } = createRuntimeClient();
+      expect(client.getAtc()).toBe(client.getAtc());
     });
 
     it('getDdicActivation() returns the same instance on repeated calls', () => {
@@ -211,6 +227,16 @@ describe('AdtRuntimeClient factory pattern', () => {
       expect(typeof d.launch).toBe('function');
       expect(typeof d.stop).toBe('function');
       expect(typeof d.getCallStack).toBe('function');
+    });
+
+    // The three capabilities the narrowed return type promises, and nothing
+    // else: no create, no lock, no activate.
+    it('atc has exactly the runnable and reader methods', () => {
+      const { client } = createRuntimeClient();
+      const atc = client.getAtc();
+      expect(typeof atc.run).toBe('function');
+      expect(typeof atc.getRunStatus).toBe('function');
+      expect(typeof atc.getFindings).toBe('function');
     });
 
     it('dumps has expected methods', () => {

--- a/src/__tests__/unit/publicApiSurface.test.ts
+++ b/src/__tests__/unit/publicApiSurface.test.ts
@@ -78,6 +78,7 @@ const RUNTIME_EXPORTS = [
   'AbapDebugger',
   'AdtAbapGitClient',
   'AdtAppendStructure',
+  'AdtAtc',
   'AdtClient',
   'AdtClientBatch',
   'AdtClientLegacy',

--- a/src/__tests__/unit/runtime/AdtAtc.test.ts
+++ b/src/__tests__/unit/runtime/AdtAtc.test.ts
@@ -1,0 +1,498 @@
+/**
+ * ATC check runs.
+ *
+ * Written against the captures in `docs/evidence/2026-08-16-atc-trial-probe.md`
+ * and `docs/evidence/2026-08-17-atc-objecttype-confirmed.md`, and the numbering
+ * follows the plan's test list.
+ *
+ * Three groups earn their place for different reasons: the ones that read the
+ * **request** (headers and payload), because in ATC the media type is the
+ * resource and the payload is the whole instruction; the ones that assert a
+ * **rejection**, because every silent default this package has removed had the
+ * shape of a missing field quietly becoming a plausible value; and the URI
+ * table, because those seven templates are the only part of the contract that
+ * rests on evidence rather than on reasoning.
+ */
+
+import type { IAbapConnection, IAtcRunTarget } from '@mcp-abap-adt/interfaces';
+import { AdtAtc } from '../../../runtime/atc/AdtAtc';
+
+const CUSTOMIZING = `<?xml version="1.0" encoding="utf-8"?>
+<atc:customizing xmlns:atc="http://www.sap.com/adt/atc"><properties>
+<property name="systemCheckVariant" value="ABAP_CLOUD_DEVELOPMENT_DEFAULT"/>
+</properties></atc:customizing>`;
+
+const WORKLIST_ID = '0ABD945AC5681FE1A6C51EE2E3AB6030';
+const RUN_ID = '6E27F48C3C661FD1A6C51F2A0B7C4030';
+
+const WAITING_RUN = `<?xml version="1.0" encoding="utf-8"?>
+<atcworklist:worklistRun xmlns:atcworklist="http://www.sap.com/adt/atc/worklist">
+<atcworklist:worklistId>${WORKLIST_ID}</atcworklist:worklistId>
+<atcworklist:infos><atcinfo:info xmlns:atcinfo="http://www.sap.com/adt/atc/info">
+<atcinfo:type>FINDING_STATS</atcinfo:type><atcinfo:description>0,0,1</atcinfo:description>
+</atcinfo:info></atcworklist:infos></atcworklist:worklistRun>`;
+
+const STATUS_FINISHED = `<?xml version="1.0" encoding="utf-8"?>
+<runs:run runs:status="finished" xmlns:runs="http://www.sap.com/adt/backgroundruns"><runs:result>
+<atom:link href="/sap/bc/adt/atc/results/RESULT99" rel="http://www.sap.com/abap/checks/atc/relations/results/displayid" xmlns:atom="http://www.w3.org/2005/Atom"/>
+<atom:link href="/sap/bc/adt/atc/worklists/${WORKLIST_ID}" rel="http://www.sap.com/abap/checks/atc/relations/results/worklistid" xmlns:atom="http://www.w3.org/2005/Atom"/>
+</runs:result></runs:run>`;
+
+const TARGET: IAtcRunTarget = {
+  objects: [{ objectType: 'class', objectName: 'ZCL_X' }],
+};
+
+function logger() {
+  return {
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+/**
+ * A connection that answers by URL, so a test says what the server does rather
+ * than counting calls in order.
+ */
+function connectionFor(
+  overrides: Partial<{
+    customizing: unknown;
+    worklist: unknown;
+    run: unknown;
+    status: unknown;
+    worklistRead: unknown;
+  }> = {},
+) {
+  const calls: {
+    url: string;
+    method: string;
+    headers?: unknown;
+    data?: unknown;
+  }[] = [];
+  const answer = (url: string) => {
+    if (url.includes('/atc/customizing'))
+      return (
+        overrides.customizing ?? { status: 200, data: CUSTOMIZING, headers: {} }
+      );
+    if (url.includes('/atc/worklists?'))
+      return (
+        overrides.worklist ?? { status: 200, data: WORKLIST_ID, headers: {} }
+      );
+    if (url.includes('/atc/runs?'))
+      return (
+        overrides.run ?? {
+          status: 201,
+          data: '',
+          headers: { location: `/sap/bc/adt/atc/runs/${RUN_ID}` },
+        }
+      );
+    if (url.includes('/atc/runs/'))
+      return (
+        overrides.status ?? { status: 200, data: STATUS_FINISHED, headers: {} }
+      );
+    return (
+      overrides.worklistRead ?? {
+        status: 200,
+        data: '<worklist/>',
+        headers: {},
+      }
+    );
+  };
+  const connection = {
+    makeAdtRequest: jest.fn(async (req: any) => {
+      calls.push(req);
+      return answer(req.url);
+    }),
+  } as unknown as IAbapConnection;
+  return { connection, calls };
+}
+
+const urlsOf = (calls: { url: string }[]) => calls.map((c) => c.url);
+
+describe('AdtAtc — resolving the check variant', () => {
+  // 1. The interface makes `options` optional. A handler reading `options.wait`
+  // throws on this call, and a test passing `{}` would sail past it.
+  it('run(target) with no options at all uses every default', async () => {
+    const { connection, calls } = connectionFor();
+
+    const result = await new AdtAtc(connection, logger() as never).run(TARGET);
+
+    expect(result).toEqual({
+      waited: false,
+      worklistId: WORKLIST_ID,
+      runId: RUN_ID,
+    });
+    expect(urlsOf(calls)[0]).toContain('/atc/customizing');
+    const run = calls.find((c) => c.url.includes('/atc/runs?'));
+    expect(run?.url).toContain('clientWait=false');
+    expect(run?.data).toContain('maximumVerdicts="100"');
+  });
+
+  // 2.
+  it('reads customizing with GET and uses systemCheckVariant', async () => {
+    const { connection, calls } = connectionFor();
+
+    await new AdtAtc(connection, logger() as never).run(TARGET, {});
+
+    const customizing = calls.find((c) => c.url.includes('/atc/customizing'));
+    expect(customizing?.method).toBe('GET');
+    expect(calls.find((c) => c.url.includes('/atc/worklists?'))?.url).toContain(
+      'checkVariant=ABAP_CLOUD_DEVELOPMENT_DEFAULT',
+    );
+  });
+
+  // 3. Asserting the request was never made, not merely that the right variant
+  // was used — a handler could read customizing and then ignore it.
+  it('an explicit checkVariant skips /atc/customizing entirely', async () => {
+    const { connection, calls } = connectionFor();
+
+    await new AdtAtc(connection, logger() as never).run(TARGET, {
+      checkVariant: 'ZMY_VARIANT',
+    });
+
+    expect(urlsOf(calls).some((u) => u.includes('/atc/customizing'))).toBe(
+      false,
+    );
+    expect(calls.find((c) => c.url.includes('/atc/worklists?'))?.url).toContain(
+      'checkVariant=ZMY_VARIANT',
+    );
+  });
+
+  // 4.
+  it('customizing without systemCheckVariant rejects locally', async () => {
+    const { connection, calls } = connectionFor({
+      customizing: { status: 200, data: '<atc:customizing/>', headers: {} },
+    });
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run(TARGET),
+    ).rejects.toMatchObject({ code: 'ATC_NO_CHECK_VARIANT' });
+
+    // No worklist created with `undefined` in the URL.
+    expect(urlsOf(calls).some((u) => u.includes('/atc/worklists?'))).toBe(
+      false,
+    );
+  });
+});
+
+describe('AdtAtc — the request itself', () => {
+  // 5. The one test that reads the payload. A handler sending only the first
+  // object, the wrong kind, or a lost maximumVerdicts satisfies every
+  // result-level assertion in this file.
+  it('the run payload carries every object, the inclusive kind and the cap', async () => {
+    const { connection, calls } = connectionFor();
+
+    await new AdtAtc(connection, logger() as never).run(
+      {
+        objects: [
+          { objectType: 'class', objectName: 'ZCL_X' },
+          { objectType: 'table', objectName: 'ZT_Y' },
+        ],
+      },
+      { maximumVerdicts: 500 },
+    );
+
+    const body = String(calls.find((c) => c.url.includes('/atc/runs?'))?.data);
+    expect(body).toContain('maximumVerdicts="500"');
+    expect(body).toContain('<objectSet kind="inclusive">');
+    expect(body).toContain('adtcore:uri="/sap/bc/adt/oo/classes/ZCL_X"');
+    expect(body).toContain('adtcore:uri="/sap/bc/adt/ddic/tables/ZT_Y"');
+  });
+
+  it('clientWait follows the wait option', async () => {
+    const { connection, calls } = connectionFor({
+      run: { status: 200, data: WAITING_RUN, headers: {} },
+    });
+
+    await new AdtAtc(connection, logger() as never).run(TARGET, { wait: true });
+
+    expect(calls.find((c) => c.url.includes('/atc/runs?'))?.url).toContain(
+      'clientWait=true',
+    );
+  });
+
+  // In ATC the header IS the resource: the same path answers differently by
+  // Accept, worklist creation is text/plain where everything around it is XML,
+  // and a checkstyle Accept is refused with 406.
+  it('every request carries the media types the server answers to', async () => {
+    const { connection, calls } = connectionFor();
+    const atc = new AdtAtc(connection, logger() as never);
+
+    await atc.run(TARGET);
+    await atc.getRunStatus(RUN_ID);
+    await atc.getFindings(WORKLIST_ID);
+
+    const headersOf = (fragment: string) =>
+      calls.find((c) => c.url.includes(fragment))?.headers as Record<
+        string,
+        string
+      >;
+
+    expect(headersOf('/atc/customizing').Accept).toBe(
+      'application/xml, application/vnd.sap.atc.customizing-v1+xml, application/vnd.sap.atc.customizing-v2+xml',
+    );
+    expect(headersOf('/atc/worklists?')).toEqual({
+      'Content-Type': 'text/plain',
+      Accept: 'text/plain',
+    });
+    expect(headersOf('/atc/runs?')).toEqual({
+      'Content-Type': 'application/xml',
+      Accept: 'application/xml',
+    });
+    expect(headersOf('/atc/runs/').Accept).toBe(
+      'application/vnd.sap.adt.backgroundrun.v1+xml',
+    );
+    expect(headersOf('/atc/worklists/').Accept).toBe(
+      'application/atc.worklist.v1+xml, application/vnd.sap.atc.worklist.v1+xml',
+    );
+  });
+});
+
+describe('AdtAtc — what a started run answers with', () => {
+  // 6. worklistId and runId are different values from different responses, and
+  // the worklist id is what getFindings is called with next.
+  it('wait: false returns the run id from Location and the created worklist id', async () => {
+    const { connection } = connectionFor();
+
+    const result = await new AdtAtc(connection, logger() as never).run(TARGET);
+
+    expect(result).toEqual({
+      waited: false,
+      worklistId: WORKLIST_ID,
+      runId: RUN_ID,
+    });
+  });
+
+  // 7. The silent-success shape this package removed from fifteen handlers.
+  it('wait: false with no Location rejects instead of using the worklist id', async () => {
+    const { connection } = connectionFor({
+      run: { status: 201, data: '', headers: {} },
+    });
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run(TARGET),
+    ).rejects.toMatchObject({ code: 'ATC_NO_RUN_LOCATION' });
+  });
+
+  // 8. The happy path, saying nothing about where the id came from — that is
+  // test 15's job.
+  it('wait: true returns the stats verbatim and the worklist id', async () => {
+    const { connection } = connectionFor({
+      run: { status: 200, data: WAITING_RUN, headers: {} },
+    });
+
+    const result = await new AdtAtc(connection, logger() as never).run(TARGET, {
+      wait: true,
+    });
+
+    expect(result).toEqual({
+      waited: true,
+      worklistId: WORKLIST_ID,
+      findingStats: '0,0,1',
+    });
+  });
+
+  // 9. A confident zero is indistinguishable from a clean check.
+  it('wait: true with no FINDING_STATS rejects instead of reporting "0,0,0"', async () => {
+    const { connection } = connectionFor({
+      run: {
+        status: 200,
+        data: '<atcworklist:worklistRun/>',
+        headers: {},
+      },
+    });
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run(TARGET, { wait: true }),
+    ).rejects.toMatchObject({ code: 'ATC_NO_FINDING_STATS' });
+  });
+
+  // 15. Which id is authoritative. A positive test where the two agree cannot
+  // tell "returns the created id" from "trusts the response id". This asserts a
+  // SUCCESS: the spec defines no failure here, and an implementation plan does
+  // not get to add one.
+  it('a differing echoed worklist id is warned about, not obeyed, and not fatal', async () => {
+    const log = logger();
+    const { connection } = connectionFor({
+      run: {
+        status: 200,
+        data: WAITING_RUN.replace(WORKLIST_ID, 'SOMEONE_ELSES_WORKLIST'),
+        headers: {},
+      },
+    });
+
+    const result = await new AdtAtc(connection, log as never).run(TARGET, {
+      wait: true,
+    });
+
+    expect(result).toMatchObject({ waited: true, worklistId: WORKLIST_ID });
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('SOMEONE_ELSES_WORKLIST'),
+    );
+  });
+
+  it('a waiting run with no echoed worklist id still succeeds', async () => {
+    const { connection } = connectionFor({
+      run: {
+        status: 200,
+        data: `<atcworklist:worklistRun><atcworklist:infos><atcinfo:info><atcinfo:type>FINDING_STATS</atcinfo:type><atcinfo:description>1,2,3</atcinfo:description></atcinfo:info></atcworklist:infos></atcworklist:worklistRun>`,
+        headers: {},
+      },
+    });
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run(TARGET, { wait: true }),
+    ).resolves.toMatchObject({
+      worklistId: WORKLIST_ID,
+      findingStats: '1,2,3',
+    });
+  });
+});
+
+describe('AdtAtc — asking whether a run is done', () => {
+  // 10.
+  it('isFinished is exact: "finished" yes, "unfinished" and "not_finished" no', async () => {
+    for (const [status, expected] of [
+      ['finished', true],
+      ['FINISHED', true],
+      ['unfinished', false],
+      ['not_finished', false],
+      ['running', false],
+    ] as const) {
+      const { connection } = connectionFor({
+        status: {
+          status: 200,
+          data: `<runs:run runs:status="${status}"/>`,
+          headers: {},
+        },
+      });
+
+      const result = await new AdtAtc(
+        connection,
+        logger() as never,
+      ).getRunStatus(RUN_ID);
+
+      expect(result.status).toBe(status);
+      expect(result.isFinished).toBe(expected);
+    }
+  });
+
+  // 11. Both links, each from its own rel. Asserting only the absent case
+  // leaves a parser free to take the first href it sees, or to swap the two.
+  it('takes each id from its own atom link', async () => {
+    const { connection } = connectionFor();
+
+    const result = await new AdtAtc(connection, logger() as never).getRunStatus(
+      RUN_ID,
+    );
+
+    expect(result.worklistId).toBe(WORKLIST_ID);
+    expect(result.resultId).toBe('RESULT99');
+  });
+
+  // 12. The state polling exists for, and the one nobody has captured.
+  it('resolves without the links, leaving the ids undefined', async () => {
+    const { connection } = connectionFor({
+      status: {
+        status: 200,
+        data: '<runs:run runs:status="running"/>',
+        headers: {},
+      },
+    });
+
+    const result = await new AdtAtc(connection, logger() as never).getRunStatus(
+      RUN_ID,
+    );
+
+    expect(result).toEqual({
+      status: 'running',
+      isFinished: false,
+      worklistId: undefined,
+      resultId: undefined,
+    });
+  });
+
+  // 14. `status` is not optional in the contract; resolving with undefined
+  // through it is a lie the type cannot catch.
+  it('a run resource with no runs:status rejects', async () => {
+    const { connection } = connectionFor({
+      status: { status: 200, data: '<runs:run/>', headers: {} },
+    });
+
+    await expect(
+      new AdtAtc(connection, logger() as never).getRunStatus(RUN_ID),
+    ).rejects.toMatchObject({ code: 'ATC_RUN_STATUS_MISSING' });
+  });
+});
+
+describe('AdtAtc — refusing before the request', () => {
+  // 13. Non-empty and nothing more: no length, no character class, since no
+  // contract states a format.
+  it('an empty worklist id rejects rather than being run against', async () => {
+    const { connection, calls } = connectionFor({
+      worklist: { status: 200, data: '   ', headers: {} },
+    });
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run(TARGET),
+    ).rejects.toMatchObject({ code: 'ATC_NO_WORKLIST_ID' });
+
+    expect(urlsOf(calls).some((u) => u.includes('/atc/runs?'))).toBe(false);
+  });
+
+  // 16. The tuple type stops a TypeScript caller; a JavaScript one arrives.
+  it('an empty object set rejects before any request', async () => {
+    const { connection } = connectionFor();
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run({ objects: [] } as never),
+    ).rejects.toMatchObject({ code: 'ADT_VALIDATION_FAILED' });
+
+    expect(connection.makeAdtRequest).not.toHaveBeenCalled();
+  });
+
+  // 17. The server answers 0 with a 400; a client that can name the problem
+  // should not spend a round trip being told.
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+  ])('maximumVerdicts of %p rejects before any request', async (value) => {
+    const { connection } = connectionFor();
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run(TARGET, {
+        maximumVerdicts: value,
+      }),
+    ).rejects.toMatchObject({ code: 'ADT_VALIDATION_FAILED' });
+
+    expect(connection.makeAdtRequest).not.toHaveBeenCalled();
+  });
+});
+
+// 18. The one part of the contract resting on evidence rather than reasoning:
+// each template was confirmed by a run submitted at it whose finished worklist
+// then listed that object under that type. A changed template must fail loudly.
+describe('AdtAtc — the confirmed URI templates', () => {
+  it.each([
+    ['class', '/sap/bc/adt/oo/classes/ZX'],
+    ['interface', '/sap/bc/adt/oo/interfaces/ZX'],
+    ['function_group', '/sap/bc/adt/functions/groups/ZX'],
+    ['package', '/sap/bc/adt/packages/ZX'],
+    ['ddl_source', '/sap/bc/adt/ddic/ddl/sources/ZX'],
+    ['table', '/sap/bc/adt/ddic/tables/ZX'],
+    ['behavior_definition', '/sap/bc/adt/bo/behaviordefinitions/ZX'],
+  ] as const)('%s is checked at %s', async (objectType, uri) => {
+    const { connection, calls } = connectionFor();
+
+    await new AdtAtc(connection, logger() as never).run({
+      objects: [{ objectType, objectName: 'ZX' }],
+    });
+
+    expect(
+      String(calls.find((c) => c.url.includes('/atc/runs?'))?.data),
+    ).toContain(`adtcore:uri="${uri}"`);
+  });
+});

--- a/src/__tests__/unit/runtime/AdtAtc.test.ts
+++ b/src/__tests__/unit/runtime/AdtAtc.test.ts
@@ -17,9 +17,14 @@
 import type { IAbapConnection, IAtcRunTarget } from '@mcp-abap-adt/interfaces';
 import { AdtAtc } from '../../../runtime/atc/AdtAtc';
 
+// The properties as the trial sent them: four of them, and the one this client
+// needs is not the first.
 const CUSTOMIZING = `<?xml version="1.0" encoding="utf-8"?>
 <atc:customizing xmlns:atc="http://www.sap.com/adt/atc"><properties>
+<property name="ciCheckFlavour" value="true"/>
 <property name="systemCheckVariant" value="ABAP_CLOUD_DEVELOPMENT_DEFAULT"/>
+<property name="isCCSTunnelEnabled" value="false"/>
+<property name="isTransportableExemptionTypeUsed" value="true"/>
 </properties></atc:customizing>`;
 
 const WORKLIST_ID = '0ABD945AC5681FE1A6C51EE2E3AB6030';
@@ -469,6 +474,112 @@ describe('AdtAtc — refusing before the request', () => {
     ).rejects.toMatchObject({ code: 'ADT_VALIDATION_FAILED' });
 
     expect(connection.makeAdtRequest).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Two things about an XML document carry no meaning: the order of attributes on
+ * an element, and which prefix a namespace was bound to. Every case here is a
+ * document a server may validly send that differs from the trial's captures in
+ * one of those two ways, and every one of them defeated the pattern-matching
+ * this file's first implementation used.
+ */
+describe('AdtAtc — the documents are read structurally', () => {
+  it('finds the check variant with the attributes the other way round', async () => {
+    const { connection, calls } = connectionFor({
+      customizing: {
+        status: 200,
+        data: '<atc:customizing><properties><property value="ZREVERSED" name="systemCheckVariant"/></properties></atc:customizing>',
+        headers: {},
+      },
+    });
+
+    await new AdtAtc(connection, logger() as never).run(TARGET);
+
+    expect(calls.find((c) => c.url.includes('/atc/worklists?'))?.url).toContain(
+      'checkVariant=ZREVERSED',
+    );
+  });
+
+  it('reads runs:status under any namespace prefix', async () => {
+    const { connection } = connectionFor({
+      status: {
+        status: 200,
+        data: '<r:run r:status="finished" xmlns:r="http://www.sap.com/adt/backgroundruns"/>',
+        headers: {},
+      },
+    });
+
+    const result = await new AdtAtc(connection, logger() as never).getRunStatus(
+      RUN_ID,
+    );
+
+    expect(result).toMatchObject({ status: 'finished', isFinished: true });
+  });
+
+  it('takes each atom link id with rel before href', async () => {
+    const { connection } = connectionFor({
+      status: {
+        status: 200,
+        data: `<runs:run runs:status="finished"><runs:result>
+<atom:link rel="http://www.sap.com/abap/checks/atc/relations/results/worklistid" href="/sap/bc/adt/atc/worklists/${WORKLIST_ID}" type="application/xml"/>
+<atom:link rel="http://www.sap.com/abap/checks/atc/relations/results/displayid" href="/sap/bc/adt/atc/results/RESULT99" type="application/xml"/>
+</runs:result></runs:run>`,
+        headers: {},
+      },
+    });
+
+    const result = await new AdtAtc(connection, logger() as never).getRunStatus(
+      RUN_ID,
+    );
+
+    expect(result.worklistId).toBe(WORKLIST_ID);
+    expect(result.resultId).toBe('RESULT99');
+  });
+
+  it('finds FINDING_STATS past an earlier info and with description first', async () => {
+    const { connection } = connectionFor({
+      run: {
+        status: 200,
+        data: `<atcworklist:worklistRun>
+<atcworklist:worklistId>${WORKLIST_ID}</atcworklist:worklistId>
+<atcworklist:infos>
+<atcinfo:info><atcinfo:type>SOMETHING_ELSE</atcinfo:type><atcinfo:description>9,9,9</atcinfo:description></atcinfo:info>
+<atcinfo:info><atcinfo:description>4,5,6</atcinfo:description><atcinfo:type>FINDING_STATS</atcinfo:type></atcinfo:info>
+</atcworklist:infos></atcworklist:worklistRun>`,
+        headers: {},
+      },
+    });
+
+    await expect(
+      new AdtAtc(connection, logger() as never).run(TARGET, { wait: true }),
+    ).resolves.toMatchObject({ findingStats: '4,5,6' });
+  });
+
+  // An all-digit id is a string, not a number: `String(12345)` would round-trip
+  // but an id with a leading zero, or one long enough to lose precision, would
+  // not — and both are shapes ADT has been seen to send.
+  it('keeps an all-digit worklist id a string', async () => {
+    const digits = '00000000000000000000000000000000';
+    const { connection } = connectionFor({
+      run: {
+        status: 200,
+        data: `<atcworklist:worklistRun><atcworklist:worklistId>${digits}</atcworklist:worklistId>
+<atcworklist:infos><atcinfo:info><atcinfo:type>FINDING_STATS</atcinfo:type><atcinfo:description>0,0,0</atcinfo:description></atcinfo:info></atcworklist:infos>
+</atcworklist:worklistRun>`,
+        headers: {},
+      },
+    });
+    const log = logger();
+
+    const result = await new AdtAtc(connection, log as never).run(TARGET, {
+      wait: true,
+    });
+
+    // The echo differs from the created id, so it is warned about verbatim —
+    // which is where a number would have shown itself.
+    expect(result).toMatchObject({ findingStats: '0,0,0' });
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining(digits));
   });
 });
 

--- a/src/clients/AdtRuntimeClient.ts
+++ b/src/clients/AdtRuntimeClient.ts
@@ -7,6 +7,7 @@
  * - getSt05Trace() — ST05 performance traces
  * - getDebugger() — Composite debugger (ABAP, AMDP, memory snapshots)
  * - getApplicationLog() — Application log analysis
+ * - getAtc() — ATC check runs: start one, poll it, read the worklist
  * - getAtcLog() — ATC check failure and execution logs
  * - getDdicActivation() — DDIC activation graph
  * - getDumps() — Runtime dump analysis
@@ -30,14 +31,23 @@
  *
  * // Logs
  * const appLog = await client.getApplicationLog().getObject('Z_MY_LOG');
+ * const started = await client.getAtc().run({
+ *   objects: [{ objectType: 'class', objectName: 'ZCL_MY_CLASS' }],
+ * });
  * const atcLogs = await client.getAtcLog().getCheckFailureLogs();
  * ```
  */
 
 import type {
   IAbapConnection,
+  IAdtRunnable,
   IApplicationLog,
+  IAtcFindings,
   IAtcLog,
+  IAtcRunOptions,
+  IAtcRunResult,
+  IAtcRunStatusReadable,
+  IAtcRunTarget,
   ICrossTrace,
   IDdicActivation,
   IDebugger,
@@ -50,6 +60,7 @@ import type {
   ISystemMessages,
 } from '@mcp-abap-adt/interfaces';
 import { ApplicationLog } from '../runtime/applicationLog/ApplicationLog';
+import { AdtAtc } from '../runtime/atc/AdtAtc';
 import { AtcLog } from '../runtime/atc/AtcLog';
 import { DdicActivation } from '../runtime/ddic/DdicActivation';
 import { Debugger } from '../runtime/debugger/Debugger';
@@ -70,6 +81,7 @@ export class AdtRuntimeClient {
   private _st05Trace?: St05Trace;
   private _debugger?: Debugger;
   private _applicationLog?: ApplicationLog;
+  private _atc?: AdtAtc;
   private _atcLog?: AtcLog;
   private _ddicActivation?: DdicActivation;
   private _dumps?: RuntimeDumps;
@@ -149,6 +161,21 @@ export class AdtRuntimeClient {
       this._applicationLog = new ApplicationLog(this.connection, this.logger);
     }
     return this._applicationLog;
+  }
+
+  /**
+   * ATC check runs.
+   *
+   * The intersection is spelled here rather than given a name: one getter has
+   * this set, and a composite earns a name when more than one handler does.
+   */
+  getAtc(): IAdtRunnable<IAtcRunTarget, IAtcRunResult, IAtcRunOptions> &
+    IAtcRunStatusReadable &
+    IAtcFindings {
+    if (!this._atc) {
+      this._atc = new AdtAtc(this.connection, this.logger);
+    }
+    return this._atc;
   }
 
   getAtcLog(): IAtcLog {

--- a/src/constants/contentTypes.ts
+++ b/src/constants/contentTypes.ts
@@ -267,3 +267,21 @@ export const CT_ABAPGIT_EXTERNAL_REPO_INFO_REQUEST_V2 =
   'application/abapgit.adt.repo.info.ext.request.v2+xml';
 export const ACCEPT_ABAPGIT_EXTERNAL_REPO_INFO_RESPONSE_V2 =
   'application/abapgit.adt.repo.info.ext.response.v2+xml';
+
+// ATC (ABAP Test Cockpit) — captured against a cloud trial, not taken from
+// documentation. Two of these are the resource rather than a detail: the
+// worklist is created and its id read as text/plain where everything around it
+// is XML, and the run resource answers only to the backgroundrun type. A
+// checkstyle Accept on the worklist is refused with 406 naming the one type it
+// will serve, which is why there is no format option and no checkstyle
+// constant here.
+export const CT_ATC_WORKLIST_CREATE = 'text/plain';
+export const ACCEPT_ATC_WORKLIST_ID = 'text/plain';
+export const CT_ATC_RUN = 'application/xml';
+export const ACCEPT_ATC_RUN_RESPONSE = 'application/xml';
+export const ACCEPT_ATC_RUN_STATUS =
+  'application/vnd.sap.adt.backgroundrun.v1+xml';
+export const ACCEPT_ATC_WORKLIST_XML =
+  'application/atc.worklist.v1+xml, application/vnd.sap.atc.worklist.v1+xml';
+export const ACCEPT_ATC_CUSTOMIZING =
+  'application/xml, application/vnd.sap.atc.customizing-v1+xml, application/vnd.sap.atc.customizing-v2+xml';

--- a/src/index.runtime.ts
+++ b/src/index.runtime.ts
@@ -6,6 +6,7 @@
 export { AdtRuntimeClient } from './clients/AdtRuntimeClient';
 export { AdtRuntimeClientExperimental } from './clients/AdtRuntimeClientExperimental';
 export { ApplicationLog } from './runtime/applicationLog/ApplicationLog';
+export { AdtAtc } from './runtime/atc/AdtAtc';
 export { AtcLog } from './runtime/atc/AtcLog';
 export { DdicActivation } from './runtime/ddic/DdicActivation';
 export { AbapDebugger } from './runtime/debugger/AbapDebugger';

--- a/src/runtime/atc/AdtAtc.ts
+++ b/src/runtime/atc/AdtAtc.ts
@@ -1,0 +1,260 @@
+/**
+ * ATC check runs: start one, ask whether it is done, read what it found.
+ *
+ * Three capabilities and no more. A check run is not created, updated, locked,
+ * activated or versioned — it is run, and then read — so this declares
+ * `IAdtRunnable` plus two readers rather than `IAdtObject`.
+ *
+ * **Nothing here defaults a missing value.** Each response this depends on
+ * carries one thing the next step cannot work without, and where that thing is
+ * absent the call fails naming it. A missing `Location` never becomes the
+ * worklist id and a missing `FINDING_STATS` never becomes `"0,0,0"`: the
+ * dangerous outcome on an unfamiliar system is not an exception, it is a
+ * confident zero that reads exactly like a clean check.
+ */
+
+import {
+  AdtObjectErrorCodes,
+  AdtOperationError,
+  type IAbapConnection,
+  type IAdtResponse,
+  type IAdtRunnable,
+  type IAtcFindings,
+  type IAtcRunOptions,
+  type IAtcRunResult,
+  type IAtcRunStatus,
+  type IAtcRunStatusReadable,
+  type IAtcRunTarget,
+  type ILogger,
+} from '@mcp-abap-adt/interfaces';
+import {
+  buildAtcObjectUri,
+  createAtcWorklist,
+  getAtcCustomizing,
+  getAtcRunStatus,
+  getAtcWorklist,
+  parseSystemCheckVariant,
+  startAtcRun,
+} from './run';
+
+/** The default cap on results, and the only value anyone has run with. */
+const DEFAULT_MAXIMUM_VERDICTS = 100;
+
+function asText(data: unknown): string {
+  return typeof data === 'string' ? data : String(data ?? '');
+}
+
+/** Header lookup that does not assume the server's capitalisation. */
+function header(
+  headers: Record<string, unknown> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  const key = Object.keys(headers).find(
+    (k) => k.toLowerCase() === name.toLowerCase(),
+  );
+  const value = key ? headers[key] : undefined;
+  return typeof value === 'string' ? value : undefined;
+}
+
+export class AdtAtc
+  implements
+    IAdtRunnable<IAtcRunTarget, IAtcRunResult, IAtcRunOptions>,
+    IAtcRunStatusReadable,
+    IAtcFindings
+{
+  constructor(
+    private readonly connection: IAbapConnection,
+    private readonly logger: ILogger,
+  ) {}
+
+  async run(
+    target: IAtcRunTarget,
+    options?: IAtcRunOptions,
+  ): Promise<IAtcRunResult> {
+    // `options` is optional in the contract, so every read of it is guarded.
+    // A caller writing `run(target)` is doing what the interface allows.
+    const wait = options?.wait ?? false;
+    const maximumVerdicts =
+      options?.maximumVerdicts ?? DEFAULT_MAXIMUM_VERDICTS;
+
+    this.assertTarget(target);
+    this.assertMaximumVerdicts(maximumVerdicts);
+
+    const checkVariant =
+      options?.checkVariant ?? (await this.resolveCheckVariant());
+
+    const worklistId = await this.createWorklist(checkVariant);
+    const uris = target.objects.map((o) =>
+      buildAtcObjectUri(o.objectType, o.objectName),
+    );
+
+    const response = await startAtcRun(
+      this.connection,
+      worklistId,
+      uris,
+      maximumVerdicts,
+      wait,
+    );
+
+    return wait
+      ? this.readWaitingRun(response, worklistId)
+      : this.readStartedRun(response, worklistId);
+  }
+
+  async getRunStatus(runId: string): Promise<IAtcRunStatus> {
+    const response = await getAtcRunStatus(this.connection, runId);
+    const body = asText(response.data);
+
+    const status = body.match(/runs:status="([^"]+)"/)?.[1];
+    if (!status) {
+      const error = new AdtOperationError(
+        `ATC run ${runId}: the run resource carried no runs:status. IAtcRunStatus.status is not optional, and resolving with undefined through it would be a lie the type cannot catch.`,
+      );
+      error.code = 'ATC_RUN_STATUS_MISSING';
+      throw error;
+    }
+
+    return {
+      status,
+      // Exact and case-normalised. A substring test would accept `unfinished`
+      // and `not_finished`, opening the worklist on a run that had not run.
+      isFinished: status.trim().toLowerCase() === 'finished',
+      worklistId: this.linkId(body, 'worklistid'),
+      resultId: this.linkId(body, 'displayid'),
+    };
+  }
+
+  async getFindings(worklistId: string): Promise<IAdtResponse> {
+    return getAtcWorklist(this.connection, worklistId);
+  }
+
+  // ---------------------------------------------------------------- private
+
+  private assertTarget(target: IAtcRunTarget): void {
+    // The tuple type stops a TypeScript caller; a JavaScript one arrives here
+    // anyway, and an empty object set would start a run over nothing.
+    if (!target?.objects?.length) {
+      const error = new AdtOperationError(
+        'ATC run needs at least one object to check.',
+      );
+      error.code = AdtObjectErrorCodes.VALIDATION_FAILED;
+      throw error;
+    }
+  }
+
+  private assertMaximumVerdicts(value: number): void {
+    if (!Number.isInteger(value) || value < 1) {
+      const error = new AdtOperationError(
+        `maximumVerdicts must be a positive integer, got ${value}. The server answers 0 with a 400, and a client that can name the problem should not spend a round trip being told.`,
+      );
+      error.code = AdtObjectErrorCodes.VALIDATION_FAILED;
+      throw error;
+    }
+  }
+
+  private async resolveCheckVariant(): Promise<string> {
+    const response = await getAtcCustomizing(this.connection);
+    const variant = parseSystemCheckVariant(response.data);
+    if (!variant) {
+      const error = new AdtOperationError(
+        'ATC customizing carried no systemCheckVariant, and no checkVariant was given. Creating a worklist with an undefined variant would leave the server to decide what that means.',
+      );
+      error.code = 'ATC_NO_CHECK_VARIANT';
+      throw error;
+    }
+    this.logger?.debug?.(`ATC check variant from customizing: ${variant}`);
+    return variant;
+  }
+
+  private async createWorklist(checkVariant: string): Promise<string> {
+    const response = await createAtcWorklist(this.connection, checkVariant);
+    const worklistId = asText(response.data).trim();
+    // Non-empty, and nothing more specific: the observed ids are 32-character
+    // hex on one system, but no contract states a format, and a stricter test
+    // would risk refusing a valid id from a system nobody has probed.
+    if (!worklistId) {
+      const error = new AdtOperationError(
+        'ATC worklist creation answered with no id. A run against an empty worklist id is a request nobody can interpret.',
+      );
+      error.code = 'ATC_NO_WORKLIST_ID';
+      throw error;
+    }
+    return worklistId;
+  }
+
+  /** `clientWait=false`: 201, empty body, the run id in `Location`. */
+  private readStartedRun(
+    response: IAdtResponse,
+    worklistId: string,
+  ): IAtcRunResult {
+    const location =
+      header(response.headers as Record<string, unknown>, 'location') ??
+      header(response.headers as Record<string, unknown>, 'content-location');
+    if (!location) {
+      const error = new AdtOperationError(
+        'ATC run was accepted without a Location header, so it has no run id to poll. Falling back to the worklist id would look like success and fetch a run that does not exist.',
+      );
+      error.code = 'ATC_NO_RUN_LOCATION';
+      throw error;
+    }
+    const runId = location.replace(/\/+$/, '').split('/').pop();
+    if (!runId) {
+      const error = new AdtOperationError(
+        `ATC run Location carried no id: ${location}`,
+      );
+      error.code = 'ATC_NO_RUN_LOCATION';
+      throw error;
+    }
+    return { waited: false, worklistId, runId };
+  }
+
+  /** `clientWait=true`: 200, `<atcworklist:worklistRun>` with FINDING_STATS. */
+  private readWaitingRun(
+    response: IAdtResponse,
+    worklistId: string,
+  ): IAtcRunResult {
+    const body = asText(response.data);
+    const findingStats = this.findingStats(body);
+    if (!findingStats) {
+      const error = new AdtOperationError(
+        'ATC waiting run answered without FINDING_STATS. Defaulting it to "0,0,0" would report a confident zero, which is indistinguishable from a clean check.',
+      );
+      error.code = 'ATC_NO_FINDING_STATS';
+      throw error;
+    }
+
+    // The response echoes a worklist id. The one returned is the one this
+    // handler created — that is the id it controls and the id getFindings
+    // takes — so a differing echo is worth a warning and nothing more. It is
+    // not an error: the contract does not make it one, and turning a usable
+    // answer into a failure is not a decision an implementation gets to make.
+    const echoed = body.match(
+      /<atcworklist:worklistId>([^<]+)<\/atcworklist:worklistId>/,
+    )?.[1];
+    if (echoed && echoed !== worklistId) {
+      this.logger?.warn?.(
+        `ATC run echoed worklist ${echoed} but was started against ${worklistId}; returning the one this client created.`,
+      );
+    }
+
+    return { waited: true, worklistId, findingStats };
+  }
+
+  private findingStats(body: string): string | undefined {
+    // FINDING_STATS is an <atcinfo:info> whose type says so; the triple is in
+    // the description beside it. Matched as a pair rather than by reaching for
+    // the first description in the document.
+    const info = body.match(
+      /<atcinfo:type>FINDING_STATS<\/atcinfo:type>\s*<atcinfo:description>([^<]*)<\/atcinfo:description>/,
+    );
+    return info?.[1];
+  }
+
+  private linkId(body: string, rel: string): string | undefined {
+    const link = body.match(
+      new RegExp(`href="([^"]+)"[^>]*rel="[^"]*${rel}"`, 'i'),
+    );
+    return link?.[1].replace(/\/+$/, '').split('/').pop();
+  }
+}

--- a/src/runtime/atc/AdtAtc.ts
+++ b/src/runtime/atc/AdtAtc.ts
@@ -28,12 +28,16 @@ import {
   type ILogger,
 } from '@mcp-abap-adt/interfaces';
 import {
+  parseRunStatus,
+  parseSystemCheckVariant,
+  parseWaitingRun,
+} from './parse';
+import {
   buildAtcObjectUri,
   createAtcWorklist,
   getAtcCustomizing,
   getAtcRunStatus,
   getAtcWorklist,
-  parseSystemCheckVariant,
   startAtcRun,
 } from './run';
 
@@ -104,9 +108,9 @@ export class AdtAtc
 
   async getRunStatus(runId: string): Promise<IAtcRunStatus> {
     const response = await getAtcRunStatus(this.connection, runId);
-    const body = asText(response.data);
+    const parsed = parseRunStatus(response.data);
 
-    const status = body.match(/runs:status="([^"]+)"/)?.[1];
+    const status = parsed.status;
     if (!status) {
       const error = new AdtOperationError(
         `ATC run ${runId}: the run resource carried no runs:status. IAtcRunStatus.status is not optional, and resolving with undefined through it would be a lie the type cannot catch.`,
@@ -120,8 +124,8 @@ export class AdtAtc
       // Exact and case-normalised. A substring test would accept `unfinished`
       // and `not_finished`, opening the worklist on a run that had not run.
       isFinished: status.trim().toLowerCase() === 'finished',
-      worklistId: this.linkId(body, 'worklistid'),
-      resultId: this.linkId(body, 'displayid'),
+      worklistId: parsed.worklistId,
+      resultId: parsed.resultId,
     };
   }
 
@@ -214,8 +218,8 @@ export class AdtAtc
     response: IAdtResponse,
     worklistId: string,
   ): IAtcRunResult {
-    const body = asText(response.data);
-    const findingStats = this.findingStats(body);
+    const parsed = parseWaitingRun(response.data);
+    const findingStats = parsed.findingStats;
     if (!findingStats) {
       const error = new AdtOperationError(
         'ATC waiting run answered without FINDING_STATS. Defaulting it to "0,0,0" would report a confident zero, which is indistinguishable from a clean check.',
@@ -229,9 +233,7 @@ export class AdtAtc
     // takes — so a differing echo is worth a warning and nothing more. It is
     // not an error: the contract does not make it one, and turning a usable
     // answer into a failure is not a decision an implementation gets to make.
-    const echoed = body.match(
-      /<atcworklist:worklistId>([^<]+)<\/atcworklist:worklistId>/,
-    )?.[1];
+    const echoed = parsed.worklistId;
     if (echoed && echoed !== worklistId) {
       this.logger?.warn?.(
         `ATC run echoed worklist ${echoed} but was started against ${worklistId}; returning the one this client created.`,
@@ -239,22 +241,5 @@ export class AdtAtc
     }
 
     return { waited: true, worklistId, findingStats };
-  }
-
-  private findingStats(body: string): string | undefined {
-    // FINDING_STATS is an <atcinfo:info> whose type says so; the triple is in
-    // the description beside it. Matched as a pair rather than by reaching for
-    // the first description in the document.
-    const info = body.match(
-      /<atcinfo:type>FINDING_STATS<\/atcinfo:type>\s*<atcinfo:description>([^<]*)<\/atcinfo:description>/,
-    );
-    return info?.[1];
-  }
-
-  private linkId(body: string, rel: string): string | undefined {
-    const link = body.match(
-      new RegExp(`href="([^"]+)"[^>]*rel="[^"]*${rel}"`, 'i'),
-    );
-    return link?.[1].replace(/\/+$/, '').split('/').pop();
   }
 }

--- a/src/runtime/atc/index.ts
+++ b/src/runtime/atc/index.ts
@@ -2,6 +2,7 @@
  * ATC (ABAP Test Cockpit) - Exports
  */
 
+export { AdtAtc } from './AdtAtc';
 export { AtcLog } from './AtcLog';
 export {
   getCheckFailureLogs,

--- a/src/runtime/atc/parse.ts
+++ b/src/runtime/atc/parse.ts
@@ -1,0 +1,143 @@
+/**
+ * Reading the four ATC responses this client depends on.
+ *
+ * **Structurally, not by pattern.** These are XML documents, and two things
+ * about an XML document carry no meaning: the order of attributes on an
+ * element, and which prefix a namespace was bound to. A reader that depends on
+ * either is reading a formatting accident. `<property value="X"
+ * name="systemCheckVariant"/>` is the same element as the one the trial sent
+ * with the attributes the other way round, and a server free to emit it would
+ * have been told this system has no check variant.
+ *
+ * `removeNSPrefix` drops the prefixes so `runs:status` and `r:status` are the
+ * same attribute; `parseTagValue: false` keeps every text value a string, so a
+ * worklist id of `00000000000000000000000000000000` does not arrive as a
+ * number.
+ *
+ * The shapes come from `docs/evidence/2026-08-16-atc-trial-probe.md`.
+ */
+
+import { XMLParser } from 'fast-xml-parser';
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  removeNSPrefix: true,
+  parseTagValue: false,
+  parseAttributeValue: false,
+  trimValues: true,
+});
+
+type Node = Record<string, unknown>;
+
+function parseXml(body: unknown): Node | null {
+  if (typeof body !== 'string' || body.trim() === '') return null;
+  try {
+    return parser.parse(body) as Node;
+  } catch {
+    // A body that is not XML is a body that carries none of what is looked for
+    // here. Each caller already fails naming the value it could not find, and
+    // that message is more useful than a parser's.
+    return null;
+  }
+}
+
+/** Elements that appear once are objects and many times are arrays. */
+function asArray(value: unknown): Node[] {
+  if (value === undefined || value === null) return [];
+  return (Array.isArray(value) ? value : [value]).filter(
+    (v): v is Node => typeof v === 'object' && v !== null,
+  );
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** The last path segment of a URI, ignoring trailing slashes. */
+function lastSegment(uri: string): string | undefined {
+  return uri.replace(/\/+$/, '').split('/').pop() || undefined;
+}
+
+/**
+ * `systemCheckVariant` out of an ATC customizing response, or null.
+ *
+ * It is one of several `<property>` elements and not the first, so it is found
+ * by its `name` rather than by position.
+ */
+export function parseSystemCheckVariant(body: unknown): string | null {
+  const root = parseXml(body)?.customizing as Node | undefined;
+  const properties = (root?.properties as Node | undefined)?.property;
+  const match = asArray(properties).find(
+    (p) => text(p['@_name']) === 'systemCheckVariant',
+  );
+  return text(match?.['@_value']) ?? null;
+}
+
+export interface IParsedRunStatus {
+  /** `runs:status`, whatever prefix it arrived under. */
+  status?: string;
+  /** From the `worklistid` atom link, when the run carries a result. */
+  worklistId?: string;
+  /** From the `displayid` atom link. */
+  resultId?: string;
+}
+
+/**
+ * The run resource: its status, and the ids its result links point at.
+ *
+ * A run still going carries no `<result>` at all, so both ids are optional —
+ * this is the method that gets polled, and it will be called on states nobody
+ * has captured.
+ */
+export function parseRunStatus(body: unknown): IParsedRunStatus {
+  const run = parseXml(body)?.run as Node | undefined;
+  if (!run) return {};
+
+  const links = asArray((run.result as Node | undefined)?.link);
+  // `rel` is a full URL whose last segment names the relation. Matched on that
+  // segment rather than on the whole URL: the relation is what is meant, and
+  // the host in front of it is not this client's business.
+  const idOf = (relation: string) => {
+    const link = links.find(
+      (l) =>
+        lastSegment(text(l['@_rel']) ?? '')?.toLowerCase() ===
+        relation.toLowerCase(),
+    );
+    const href = text(link?.['@_href']);
+    return href ? lastSegment(href) : undefined;
+  };
+
+  return {
+    status: text(run['@_status']),
+    worklistId: idOf('worklistid'),
+    resultId: idOf('displayid'),
+  };
+}
+
+export interface IParsedWaitingRun {
+  /** The worklist id the server echoed, if it echoed one. */
+  worklistId?: string;
+  /** The `FINDING_STATS` triple verbatim, if the run reported one. */
+  findingStats?: string;
+}
+
+/**
+ * The `<worklistRun>` a `clientWait=true` run answers with.
+ *
+ * `FINDING_STATS` is one `<info>` among possibly several, and the triple is a
+ * sibling of the type that names it — so the pair is found together, not by
+ * reaching for the first description in the document.
+ */
+export function parseWaitingRun(body: unknown): IParsedWaitingRun {
+  const run = parseXml(body)?.worklistRun as Node | undefined;
+  if (!run) return {};
+
+  const infos = asArray((run.infos as Node | undefined)?.info);
+  const stats = infos.find((i) => text(i.type) === 'FINDING_STATS');
+
+  return {
+    worklistId: text(run.worklistId),
+    findingStats: text(stats?.description),
+  };
+}

--- a/src/runtime/atc/run.ts
+++ b/src/runtime/atc/run.ts
@@ -1,0 +1,187 @@
+/**
+ * ATC check runs: the five requests a run is made of.
+ *
+ * The traffic here was captured against a cloud trial rather than taken from
+ * documentation, and two of the headers are the resource rather than a detail:
+ * the worklist is created and read as `text/plain` where everything around it
+ * is XML, and the run resource answers only to
+ * `application/vnd.sap.adt.backgroundrun.v1+xml`. A checkstyle `Accept` on the
+ * worklist is refused with 406 naming the one type it will serve, which is why
+ * no format option exists.
+ *
+ * See `docs/evidence/2026-08-16-atc-trial-probe.md` for the captures.
+ */
+
+import type {
+  AtcObjectType,
+  IAbapConnection,
+  IAdtResponse,
+} from '@mcp-abap-adt/interfaces';
+import {
+  ACCEPT_ATC_CUSTOMIZING,
+  ACCEPT_ATC_RUN_RESPONSE,
+  ACCEPT_ATC_RUN_STATUS,
+  ACCEPT_ATC_WORKLIST_ID,
+  ACCEPT_ATC_WORKLIST_XML,
+  CT_ATC_RUN,
+  CT_ATC_WORKLIST_CREATE,
+} from '../../constants/contentTypes';
+import { encodeSapObjectName } from '../../utils/internalUtils';
+import { getTimeout } from '../../utils/timeouts';
+
+const ATC = '/sap/bc/adt/atc';
+
+/**
+ * Where each checkable kind lives.
+ *
+ * Every template was confirmed by a run submitted at it whose finished
+ * worklist then listed the object under that type — see
+ * `docs/evidence/2026-08-17-atc-objecttype-confirmed.md`. A run being accepted
+ * proved nothing: a URI that cannot exist is answered 201 too.
+ *
+ * `program` and `include` are absent from `AtcObjectType` and so from here.
+ * The outside PR this work started from sent includes to
+ * `/programs/programs/`, which this library builds as `/programs/includes/`
+ * everywhere else; neither could be settled on a system that refuses to hold
+ * either kind.
+ */
+const URI_TEMPLATES: Record<AtcObjectType, string> = {
+  class: '/sap/bc/adt/oo/classes/',
+  interface: '/sap/bc/adt/oo/interfaces/',
+  function_group: '/sap/bc/adt/functions/groups/',
+  package: '/sap/bc/adt/packages/',
+  ddl_source: '/sap/bc/adt/ddic/ddl/sources/',
+  table: '/sap/bc/adt/ddic/tables/',
+  behavior_definition: '/sap/bc/adt/bo/behaviordefinitions/',
+};
+
+/** The ADT URI ATC checks an object at. */
+export function buildAtcObjectUri(
+  objectType: AtcObjectType,
+  objectName: string,
+): string {
+  return `${URI_TEMPLATES[objectType]}${encodeSapObjectName(objectName).toUpperCase()}`;
+}
+
+/**
+ * ATC customizing, which carries the system's default check variant.
+ *
+ * `GET`, not `POST`: the same path answers a POST with **405, "Resource
+ * controller does not support method POST"**.
+ */
+export async function getAtcCustomizing(
+  connection: IAbapConnection,
+): Promise<IAdtResponse> {
+  return connection.makeAdtRequest({
+    url: `${ATC}/customizing`,
+    method: 'GET',
+    timeout: getTimeout('default'),
+    headers: { Accept: ACCEPT_ATC_CUSTOMIZING },
+  });
+}
+
+/** `systemCheckVariant` out of a customizing response, or null. */
+export function parseSystemCheckVariant(body: unknown): string | null {
+  if (typeof body !== 'string') return null;
+  return (
+    body.match(/name="systemCheckVariant"[^>]*value="([^"]+)"/)?.[1] ?? null
+  );
+}
+
+/**
+ * Create the worklist a run writes its findings into.
+ *
+ * Answers with a bare id in the body — no XML envelope, which is why both
+ * content types are `text/plain`.
+ */
+export async function createAtcWorklist(
+  connection: IAbapConnection,
+  checkVariant: string,
+): Promise<IAdtResponse> {
+  return connection.makeAdtRequest({
+    url: `${ATC}/worklists?checkVariant=${encodeURIComponent(checkVariant)}`,
+    method: 'POST',
+    timeout: getTimeout('default'),
+    data: '',
+    headers: {
+      'Content-Type': CT_ATC_WORKLIST_CREATE,
+      Accept: ACCEPT_ATC_WORKLIST_ID,
+    },
+  });
+}
+
+/** The run payload: one inclusive object set, every reference in it. */
+export function buildRunPayload(
+  objectUris: readonly string[],
+  maximumVerdicts: number,
+): string {
+  const references = objectUris
+    .map((uri) => `<adtcore:objectReference adtcore:uri="${uri}"/>`)
+    .join('');
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    `<atc:run maximumVerdicts="${maximumVerdicts}" xmlns:atc="http://www.sap.com/adt/atc">` +
+    '<objectSets xmlns:adtcore="http://www.sap.com/adt/core">' +
+    '<objectSet kind="inclusive">' +
+    `<adtcore:objectReferences>${references}</adtcore:objectReferences>` +
+    '</objectSet>' +
+    '</objectSets>' +
+    '</atc:run>'
+  );
+}
+
+/**
+ * Start the run.
+ *
+ * `clientWait` decides the shape of the answer, not just its timing:
+ * `false` → 201 with an empty body and the run id in `Location`;
+ * `true` → 200 with `<atcworklist:worklistRun>` and no `Location`.
+ */
+export async function startAtcRun(
+  connection: IAbapConnection,
+  worklistId: string,
+  objectUris: readonly string[],
+  maximumVerdicts: number,
+  wait: boolean,
+): Promise<IAdtResponse> {
+  return connection.makeAdtRequest({
+    url: `${ATC}/runs?worklistId=${encodeURIComponent(worklistId)}&clientWait=${wait}`,
+    method: 'POST',
+    timeout: getTimeout('default'),
+    data: buildRunPayload(objectUris, maximumVerdicts),
+    headers: { 'Content-Type': CT_ATC_RUN, Accept: ACCEPT_ATC_RUN_RESPONSE },
+  });
+}
+
+/** The run resource, which carries `runs:status` and links to its results. */
+export async function getAtcRunStatus(
+  connection: IAbapConnection,
+  runId: string,
+): Promise<IAdtResponse> {
+  return connection.makeAdtRequest({
+    url: `${ATC}/runs/${encodeURIComponent(runId)}`,
+    method: 'GET',
+    timeout: getTimeout('default'),
+    headers: { Accept: ACCEPT_ATC_RUN_STATUS },
+  });
+}
+
+/**
+ * The worklist: every object the run checked, each with its findings.
+ *
+ * `includeExemptedFindings=false` is the observed form. `true` was answered
+ * once, but the only `false` read happened before a run had finished and the
+ * only `true` read after, so the two differ by timing rather than by the flag
+ * — which is why it is not an option.
+ */
+export async function getAtcWorklist(
+  connection: IAbapConnection,
+  worklistId: string,
+): Promise<IAdtResponse> {
+  return connection.makeAdtRequest({
+    url: `${ATC}/worklists/${encodeURIComponent(worklistId)}?includeExemptedFindings=false`,
+    method: 'GET',
+    timeout: getTimeout('default'),
+    headers: { Accept: ACCEPT_ATC_WORKLIST_XML },
+  });
+}

--- a/src/runtime/atc/run.ts
+++ b/src/runtime/atc/run.ts
@@ -80,14 +80,6 @@ export async function getAtcCustomizing(
   });
 }
 
-/** `systemCheckVariant` out of a customizing response, or null. */
-export function parseSystemCheckVariant(body: unknown): string | null {
-  if (typeof body !== 'string') return null;
-  return (
-    body.match(/name="systemCheckVariant"[^>]*value="([^"]+)"/)?.[1] ?? null
-  );
-}
-
 /**
  * Create the worklist a run writes its findings into.
  *


### PR DESCRIPTION
Part Two of the ATC work: the handler that runs a check, asks whether it is done, and reads what it found. Part One — the contract in `@mcp-abap-adt/interfaces` 17.1.0 — is on npm; this consumes it.

Spec: `docs/superpowers/specs/2026-08-15-atc-run-and-findings.md`.
Plan: `docs/superpowers/plans/2026-08-17-atc-run-and-findings-plan.md` (tasks 3–7).

## What ships

`AdtRuntimeClient.getAtc()` returns `IAdtRunnable<IAtcRunTarget, IAtcRunResult, IAtcRunOptions> & IAtcRunStatusReadable & IAtcFindings`. Three capabilities and no more: a check run is run and then read, never created, locked, activated or versioned, so the type offers nothing that would have to throw.

```typescript
const atc = runtime.getAtc();

const started = await atc.run({
  objects: [{ objectType: 'class', objectName: 'ZCL_MY_CLASS' }],
});

// `waited` is the discriminant — narrowing on it is what yields runId.
if (!started.waited) {
  const status = await atc.getRunStatus(started.runId);
  if (status.isFinished) await atc.getFindings(started.worklistId);
}
```

Five requests underneath (`src/runtime/atc/run.ts`), and in ATC the media type **is** the resource: the worklist is created and read as `text/plain` where everything around it is XML, the run resource answers only to `application/vnd.sap.adt.backgroundrun.v1+xml`, and a checkstyle `Accept` on the worklist is refused with a 406 naming the one type it will serve — which is why no format option exists.

`wait` is not a timing flag. `false` → `201`, empty body, run id in `Location`; `true` → `200`, `<atcworklist:worklistRun>` with `FINDING_STATS` and no `Location`. Two shapes, so `IAtcRunResult` is a discriminated union on `waited` rather than one interface with four optional fields a caller could `!`-assert wrongly.

## Two things this deliberately does not do

**No `waitForRun` helper.** Waiting needs a stopping condition for a run that does not finish. No failed or cancelled run has ever been observed, so a helper would have to invent one — and whoever knows how long their checks take is the one who can decide when to give up. `isFinished` is **completion, not success**, and `status` travels beside it so a caller can report the state they last saw. The API reference writes out the loop with a caller-chosen bound.

**No parsing of `FINDING_STATS`.** The triple comes back verbatim. Which position is which severity has been seen once, in a worklist with a single priority-3 finding, which fits several orderings; naming them would publish two guesses to save a caller one `split(',')`.

## Nothing here defaults a missing value

Each response the chain depends on carries one thing the next step cannot work without, and where that thing is absent the call rejects naming it: `ATC_NO_CHECK_VARIANT`, `ATC_NO_WORKLIST_ID`, `ATC_NO_RUN_LOCATION`, `ATC_NO_FINDING_STATS`, `ATC_RUN_STATUS_MISSING`. The dangerous outcome on an unfamiliar system is not an exception; it is a confident zero that reads exactly like a clean check.

One case goes the other way. When a waiting run echoes a *different* worklist id, the handler logs a warning and returns the id it created. That is a `logger.warn`, not an error: the spec defines no failure there, and turning a usable answer into a rejection is not a decision an implementation gets to make.

## The responses are read as XML, not as text

Two things about an XML document carry no meaning: the order of attributes on an element, and which prefix a namespace was bound to. The first round of this PR depended on both, and review caught it. `<property value="X" name="systemCheckVariant"/>` is the same element the trial sent with the attributes the other way round, and it would have produced `ATC_NO_CHECK_VARIANT` on a system that has a check variant; a reordered `<atom:link>` would have *silently* dropped the worklist id, which is the worse one — the run then reads a worklist that is not its own.

All of it now lives in `src/runtime/atc/parse.ts` on `fast-xml-parser`, already a dependency. `removeNSPrefix` makes the prefix irrelevant, attributes are looked up by name, `FINDING_STATS` is the info whose *type* says so wherever it sits among the infos, and `parseTagValue: false` keeps an all-digit worklist id a string rather than a number that round-trips fine until the first id with a leading zero.

Five tests send documents a server may validly emit that differ from the captures in exactly one of those ways, and each was mutation-checked by restoring the form of pattern-matching it rules out.

## The seven object types, and why only seven

`class`, `interface`, `function_group`, `package`, `ddl_source`, `table`, `behavior_definition`.

Each was confirmed by a run submitted at the URI **this client builds** whose **finished** worklist then listed that object under that `adtcore:type` — `docs/evidence/2026-08-17-atc-objecttype-confirmed.md`, seven distinct worklist ids, four steps each. Two weaker criteria were tried and refuted first, and the spec records both: acceptance proves nothing (a URI that cannot exist is answered `201` too), and a worklist read before its run finished is empty whatever happened.

`program` and `include` are absent because ABAP Cloud refuses to hold either (`403`, `S_DEVELOP`), so nothing on that system could confirm them. Adding them later is a **major** — the union is exhaustible, and `Record<AtcObjectType, …>` in `run.ts` is exactly the structure that breaks.

## Tests

35 unit cases against a connection that answers **by URL**, so a test states what the server does rather than counting calls in order; plus three factory cases, because without them the `_atc` field could be forgotten or a fresh handler built per call and no request-level test would notice.

Four groups earn their place for different reasons: the ones reading the **request** (all five media types, and the payload — a handler sending only the first object, the wrong `kind`, or a lost `maximumVerdicts` satisfies every result-level assertion in the file); the ones asserting a **rejection**, because every silent default this package has removed had the shape of a missing field quietly becoming a plausible value; the ones sending a **validly-different document** (see below); and the URI table, which keeps the templates tied to the evidence.

One test calls `run(target)` with **no second argument** — the way the interface allows and most callers will. A handler reading `options.wait` throws on that call, and a test passing `{}` sails past it.

**Mutation-checked: 28 mutations, one at a time, each caught by the test that pins it** — and each mutation asserts its anchor matched exactly once first, because a `.replace` that matches nothing leaves "tests passed" reading as "the test survived".

## Also in here

- `12.1.0` in CHANGELOG (additive; user picked the version).
- `@mcp-abap-adt/interfaces` floor `^17.0.0` → `^17.1.0`, installed from npm, no `link: true` in the lockfile.
- README / `docs/README.md` / ARCHITECTURE / API reference gain ATC, and `getAtc()` vs `getAtcLog()` is stated in both places rather than left to the names.
- The interfaces version claimed in the docs now matches the manifest. It said `^14.1.0` in three places and `^17.0.0` in a fourth.
- The capability-guard paragraph now says the guard walks `AdtClient`/`AdtClientLegacy` only — claiming otherwise would have covered `getAtc()` by implication and not in fact.

## Verification

`npm run build` clean, `npx tsc --noEmit -p tsconfig.test.json` clean, 999 unit tests pass. The four documented snippets were compiled under `--strict` against the real types, and the check was confirmed to fail when the narrowing is removed. No SAP-touching test run is part of this PR.

Nothing automatically compiles the examples in `docs/`; that check was run by hand this time.

## Still open, and scheduled rather than forgotten

What a **failed** run reports and where; what `withLongPolling=true` does to a run in flight; whether `includeExemptedFindings` changes a *finished* worklist; what the `FINDING_STATS` positions mean; `program`/`include` on an on-prem system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
