### PR TITLE
fix(probe): the ATC probe printed COMPLETE on the runs it could not decide

### DIFF
--- a/scripts/probe-atc.ts
+++ b/scripts/probe-atc.ts
@@ -99,7 +99,6 @@ import * as dotenv from 'dotenv';
 import { getConfig } from '../src/__tests__/helpers/sessionConfig';
 import { createConnectionLogger } from '../src/__tests__/helpers/testLogger';
 import { AdtUtils } from '../src/core/shared/AdtUtils';
-import { isCloudEnvironment } from '../src/utils/systemInfo';
 
 const envPath = process.env.MCP_ENV_PATH || path.resolve(__dirname, '../.env');
 if (fs.existsSync(envPath)) {
@@ -555,21 +554,43 @@ function parseArgsChecked(argv: string[]) {
 }
 
 /**
- * The candidate keys a run is judged on, and the reason for the choice.
+ * Host suffixes that only ABAP Cloud uses. Deliberately short.
  *
- * The verdict used to count cloud-scope candidates and nothing else. On the
- * trial that was right — a classic program cannot exist on ABAP Cloud, and
- * counting it would have left the probe permanently INCOMPLETE. Run on an
- * **on-prem** system it became a trap: `program` and `include` were probed,
- * reported on a line of their own, and then left out of the verdict, so the
- * probe printed `COMPLETE` and exited 0 on exactly the run whose purpose was
- * to settle them.
- *
- * The fix is not to infer the set from the system. `isCloudEnvironment()` is a
- * heuristic over the base URL, and swapping one silent inference for another
- * would move the trap rather than remove it. **The caller states what must be
- * confirmed**; detection is used only to refuse a pass that would mislead.
+ * A name missing from this list costs one `--require` flag. A name wrongly on
+ * it costs a false COMPLETE, which is the failure this whole file is about, so
+ * the list only grows against a system somebody has actually seen.
  */
+const CLOUD_HOST_SUFFIXES = ['.hana.ondemand.com', '.abap.cloud.sap'];
+
+/**
+ * Whether the base URL *proves* this is ABAP Cloud.
+ *
+ * Not `isCloudEnvironment()`, and the difference is the point. That helper
+ * falls back to "does `/sap/bc/adt/core/http/systeminformation` answer" — an
+ * endpoint a **modern on-prem serves too**. Using it here would let a 7.5x
+ * system be taken for cloud, apply the cloud-only default, and hand back
+ * `COMPLETE` with `program` and `include` uncounted: exactly the bug this file
+ * was changed to remove, reintroduced through the detector.
+ *
+ * The asymmetry is deliberate. Refusing on a false negative costs one flag;
+ * passing on a false positive costs a wrong answer that reads like a right one.
+ * So the permissive branch demands proof, and everything else — an unknown
+ * host, an unparseable URL, no URL at all — asks the caller to say what they
+ * require.
+ */
+export function looksUnambiguouslyCloud(baseUrl: string | undefined): boolean {
+  if (!baseUrl) return false;
+  let host: string;
+  try {
+    host = new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  // Suffix on a host boundary, not `includes`: `ondemand.com.example.org` is
+  // somebody else's domain, and a substring test would hand it the cloud path.
+  return CLOUD_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix));
+}
+
 /**
  * Reject a candidate key nobody defines, naming the ones that exist.
  *
@@ -596,6 +617,23 @@ export function assertKnownKeys(keys: string[]): void {
   }
 }
 
+/**
+ * The candidate keys a run is judged on, and the reason for the choice.
+ *
+ * The verdict used to count cloud-scope candidates and nothing else. On the
+ * trial that was right — a classic program cannot exist on ABAP Cloud, and
+ * counting it would have left the probe permanently INCOMPLETE. Run on an
+ * **on-prem** system it became a trap: `program` and `include` were probed,
+ * reported on a line of their own, and then left out of the verdict, so the
+ * probe printed `COMPLETE` and exited 0 on exactly the run whose purpose was
+ * to settle them.
+ *
+ * The fix is not to infer the set from the system. **The caller states what
+ * must be confirmed**, and `isCloud` here means *proven* cloud — see
+ * `looksUnambiguouslyCloud`, and note that the first attempt at this used
+ * `isCloudEnvironment()`, whose endpoint fallback a modern on-prem also
+ * answers, which let the trap back in through the detector.
+ */
 export function requiredKeysFor(
   explicit: string[] | undefined,
   isCloud: boolean,
@@ -623,7 +661,7 @@ export function requiredKeysFor(
   // no behaviour definitions, a 7.5x has both those and classic programs — and
   // guessing produces either a false COMPLETE or a permanent INCOMPLETE.
   logger.error(
-    'This system does not look like ABAP Cloud, and --require was not given.',
+    'The base URL does not prove this is ABAP Cloud, and --require was not given. It may well be a cloud system under a host this probe does not recognise — that is precisely why it will not decide for you.',
   );
   logger.error(
     `Say what this run must confirm, e.g. --require=${[...cloudKeys, 'program', 'include'].join(',')} on a modern on-prem, or --require=all. Every candidate is probed either way; --require decides what the VERDICT counts.`,
@@ -766,20 +804,19 @@ async function main(): Promise<void> {
   await connection.connect();
   logger.info(`Connected to ${sapConfig.url}`);
 
-  // Detection decides nothing on its own; it only lets the probe refuse a pass
-  // that would mislead. A failure to detect is treated as "not cloud", which
-  // errs towards demanding --require rather than towards a clean exit.
+  // Read from the URL, not from an endpoint: see `looksUnambiguouslyCloud`.
+  // Anything short of proof errs towards demanding --require.
   let isCloud = false;
   try {
-    isCloud = await isCloudEnvironment(connection);
+    isCloud = looksUnambiguouslyCloud(await connection.getBaseUrl());
   } catch (error) {
     logger.warn(
-      `Could not tell whether this is a cloud system (${String(error)}) — treating it as not cloud, which asks for --require rather than assuming.`,
+      `Could not read the base URL (${String(error)}) — treating this as not provably cloud, which asks for --require rather than assuming.`,
     );
   }
   const required = requiredKeysFor(args.require, isCloud, logger);
   logger.info(
-    `Judged on: ${required.keys.join(', ')} (${required.source}); system looks like ${isCloud ? 'ABAP Cloud' : 'not ABAP Cloud'}.`,
+    `Judged on: ${required.keys.join(', ')} (${required.source}); host ${isCloud ? 'is provably ABAP Cloud' : 'is NOT provably ABAP Cloud'}.`,
   );
 
   const rec = new Recorder(connection, outDir, logger);

--- a/scripts/probe-atc.ts
+++ b/scripts/probe-atc.ts
@@ -68,9 +68,18 @@
  *                    a triple of zeroes is the one value that tells you nothing
  *                    about the ordering. KEY is a candidate key (`class`,
  *                    `program`, …)
+ *   --require=KEYS   comma-separated candidate keys this run must confirm, or
+ *                    `all`. **Every candidate is probed either way** — this
+ *                    decides only what the VERDICT counts. Omitted on a cloud
+ *                    system it defaults to the cloud-scope types; omitted on
+ *                    anything else the probe exits non-zero and says so,
+ *                    because it does not know which types that system holds.
  *
- * Exit code is **1 unless every candidate is confirmed**, so an incomplete
- * probe cannot be mistaken for a finished one.
+ * Exit code is **1 unless every required candidate is confirmed**, so an
+ * incomplete probe cannot be mistaken for a finished one. On an on-prem run
+ * that means `--require` is not optional: without it the run cannot decide
+ * `program` and `include`, which are the two types an on-prem probe exists to
+ * settle.
  *
  * Writes `DIR/manifest.json` (every step, plus the verdict, machine-readable)
  * and one raw body file per step. Read the raw files — the manifest is an index,
@@ -90,6 +99,7 @@ import * as dotenv from 'dotenv';
 import { getConfig } from '../src/__tests__/helpers/sessionConfig';
 import { createConnectionLogger } from '../src/__tests__/helpers/testLogger';
 import { AdtUtils } from '../src/core/shared/AdtUtils';
+import { isCloudEnvironment } from '../src/utils/systemInfo';
 
 const envPath = process.env.MCP_ENV_PATH || path.resolve(__dirname, '../.env');
 if (fs.existsSync(envPath)) {
@@ -163,7 +173,7 @@ interface ICandidate {
   scope: 'cloud' | 'onprem';
 }
 
-const CANDIDATES: ICandidate[] = [
+export const CANDIDATES: ICandidate[] = [
   {
     key: 'class',
     worklistTypeCode: 'CLAS',
@@ -512,13 +522,120 @@ function parseArgs(argv: string[]) {
   const [knownBadType, knownBadName] = knownBad
     ? knownBad.split(':')
     : [undefined, undefined];
+  const require = get('require');
   return {
     packageName: get('package'),
     outDir: get('out') ?? 'atc-probe',
     extras: argv.includes('--extras'),
     knownBadType,
     knownBadName,
+    /**
+     * Which candidate keys this run must confirm, or undefined when the caller
+     * did not say. Undefined is not the same as "the default set": it is the
+     * state in which this probe refuses to report a clean pass on a system it
+     * was not written for. See `requiredKeysFor`.
+     */
+    require:
+      require === undefined
+        ? undefined
+        : require === 'all'
+          ? CANDIDATES.map((c) => c.key)
+          : require
+              .split(',')
+              .map((k) => k.trim())
+              .filter(Boolean),
   };
+}
+
+/** Parse, then reject a bad key before anything connects. */
+function parseArgsChecked(argv: string[]) {
+  const args = parseArgs(argv);
+  if (args.require) assertKnownKeys(args.require);
+  return args;
+}
+
+/**
+ * The candidate keys a run is judged on, and the reason for the choice.
+ *
+ * The verdict used to count cloud-scope candidates and nothing else. On the
+ * trial that was right — a classic program cannot exist on ABAP Cloud, and
+ * counting it would have left the probe permanently INCOMPLETE. Run on an
+ * **on-prem** system it became a trap: `program` and `include` were probed,
+ * reported on a line of their own, and then left out of the verdict, so the
+ * probe printed `COMPLETE` and exited 0 on exactly the run whose purpose was
+ * to settle them.
+ *
+ * The fix is not to infer the set from the system. `isCloudEnvironment()` is a
+ * heuristic over the base URL, and swapping one silent inference for another
+ * would move the trap rather than remove it. **The caller states what must be
+ * confirmed**; detection is used only to refuse a pass that would mislead.
+ */
+/**
+ * Reject a candidate key nobody defines, naming the ones that exist.
+ *
+ * Called at argument-parse time as well as from `requiredKeysFor`, so a typo
+ * costs nothing: on an on-prem system the alternative is connecting, probing,
+ * and only then being told the flag was misspelled — and an on-prem session is
+ * not cheap to repeat.
+ */
+export function assertKnownKeys(keys: string[]): void {
+  const unknown = keys.filter((k) => !CANDIDATES.some((c) => c.key === k));
+  if (unknown.length) {
+    throw new Error(
+      `--require names ${unknown.join(', ')}, which ${unknown.length === 1 ? 'is not a candidate' : 'are not candidates'}. Known: ${CANDIDATES.map((c) => c.key).join(', ')}`,
+    );
+  }
+}
+
+export function requiredKeysFor(
+  explicit: string[] | undefined,
+  isCloud: boolean,
+  logger: ILogger,
+): { keys: string[]; source: string; refuse: boolean } {
+  if (explicit) {
+    assertKnownKeys(explicit);
+    return { keys: explicit, source: '--require', refuse: false };
+  }
+
+  const cloudKeys = CANDIDATES.filter((c) => c.scope === 'cloud').map(
+    (c) => c.key,
+  );
+
+  if (isCloud) {
+    return {
+      keys: cloudKeys,
+      source: 'default for a cloud system',
+      refuse: false,
+    };
+  }
+
+  // Not cloud, and nobody said what to require. The honest answer is that this
+  // probe does not know which types this system can hold — a 7.40 on-prem has
+  // no behaviour definitions, a 7.5x has both those and classic programs — and
+  // guessing produces either a false COMPLETE or a permanent INCOMPLETE.
+  logger.error(
+    'This system does not look like ABAP Cloud, and --require was not given.',
+  );
+  logger.error(
+    `Say what this run must confirm, e.g. --require=${[...cloudKeys, 'program', 'include'].join(',')} on a modern on-prem, or --require=all. Every candidate is probed either way; --require decides what the VERDICT counts.`,
+  );
+  return { keys: cloudKeys, source: 'none given', refuse: true };
+}
+
+/**
+ * The exit code, as a value rather than a side effect.
+ *
+ * Split out because the first version of the refusal was unreachable from a
+ * test: `requiredKeysFor` returned `refuse: true` and `main` acted on it, so
+ * deleting the line that set the exit code broke nothing that anyone checked.
+ * A verdict nobody can act on is the same failure as a verdict that lies —
+ * whatever the log says, `$?` is what a caller and a CI job read.
+ */
+export function exitCodeFor(opts: {
+  unconfirmed: number;
+  refuse: boolean;
+}): 0 | 1 {
+  return opts.unconfirmed > 0 || opts.refuse ? 1 : 0;
 }
 
 function defaultPackageFromTestConfig(logger: ILogger): string | undefined {
@@ -598,7 +715,7 @@ async function main(): Promise<void> {
   // A probe that says nothing while it works is unusable; INFO regardless of
   // the DEBUG_* flags, which gate the library's own loggers.
   const logger: ILogger = new DefaultLogger(LogLevel.INFO);
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseArgsChecked(process.argv.slice(2));
 
   const outDir = path.resolve(process.cwd(), args.outDir);
   fs.mkdirSync(outDir, { recursive: true });
@@ -607,6 +724,22 @@ async function main(): Promise<void> {
   const connection = createAbapConnection(sapConfig, createConnectionLogger());
   await connection.connect();
   logger.info(`Connected to ${sapConfig.url}`);
+
+  // Detection decides nothing on its own; it only lets the probe refuse a pass
+  // that would mislead. A failure to detect is treated as "not cloud", which
+  // errs towards demanding --require rather than towards a clean exit.
+  let isCloud = false;
+  try {
+    isCloud = await isCloudEnvironment(connection);
+  } catch (error) {
+    logger.warn(
+      `Could not tell whether this is a cloud system (${String(error)}) — treating it as not cloud, which asks for --require rather than assuming.`,
+    );
+  }
+  const required = requiredKeysFor(args.require, isCloud, logger);
+  logger.info(
+    `Judged on: ${required.keys.join(', ')} (${required.source}); system looks like ${isCloud ? 'ABAP Cloud' : 'not ABAP Cloud'}.`,
+  );
 
   const rec = new Recorder(connection, outDir, logger);
   const utils = new AdtUtils(connection, logger);
@@ -1519,17 +1652,20 @@ async function main(): Promise<void> {
   const timedOut = (o: ICandidateOutcome) =>
     o.attempts.some((a) => a.status === null);
 
-  // Only cloud-scope candidates can be decided here. A classic program cannot
-  // exist on ABAP Cloud, so counting it against this run would leave the probe
-  // permanently INCOMPLETE and say nothing about the system. Raised in review,
-  // 2026-08-16.
-  const cloudCandidates = outcomes.filter((o) => scopeOf(o.key) === 'cloud');
-  const onpremCandidates = outcomes.filter((o) => scopeOf(o.key) === 'onprem');
-  const confirmed = cloudCandidates.filter((o) => o.confirmed);
-  const unconfirmed = cloudCandidates.filter((o) => !o.confirmed);
+  // What this run is judged on, stated by the caller rather than inferred.
+  const requiredCandidates = outcomes.filter((o) =>
+    required.keys.includes(o.key),
+  );
+  const notCounted = outcomes.filter((o) => !required.keys.includes(o.key));
+  const confirmed = requiredCandidates.filter((o) => o.confirmed);
+  const unconfirmed = requiredCandidates.filter((o) => !o.confirmed);
+  // The counted set is named in the verdict itself. A bare "COMPLETE" is what
+  // made the previous version dangerous on an on-prem run: it was true about
+  // the seven types it counted and silent about the two the run existed for.
+  const countedAs = `${required.keys.length} required type(s) [${required.keys.join(', ')}] — set from ${required.source}`;
   const verdict = unconfirmed.length
-    ? `INCOMPLETE — ${confirmed.length} of ${cloudCandidates.length} cloud candidate types CONFIRMED; unconfirmed: ${unconfirmed.map((o) => `${o.key} [${why(o)}]`).join(', ')}`
-    : `COMPLETE — all ${cloudCandidates.length} cloud candidate types confirmed`;
+    ? `INCOMPLETE — ${confirmed.length} of ${countedAs}; unconfirmed: ${unconfirmed.map((o) => `${o.key} [${why(o)}]`).join(', ')}`
+    : `COMPLETE — all of ${countedAs}`;
 
   // A non-zero triple somewhere is what makes the positions readable at all.
   const nonZeroStats = rec.findingStats.filter(
@@ -1544,6 +1680,9 @@ async function main(): Promise<void> {
 
   rec.flush({
     system: sapConfig.url,
+    looksLikeCloud: isCloud,
+    requiredKeys: required.keys,
+    requiredFrom: required.source,
     checkVariant,
     checkVariantVerb: variantFromGet ? 'GET' : 'POST',
     packageName,
@@ -1576,24 +1715,44 @@ async function main(): Promise<void> {
         : '';
       logger.error(`  ${o.key}: ${why(o)}${transport}${weaker}`);
     }
-    process.exitCode = 1;
   } else {
     logger.info(verdict);
   }
 
-  // Reported, never counted: this system cannot hold these, so nothing here
-  // decides them either way. They widen the union from an on-prem probe.
-  for (const o of onpremCandidates) {
+  // Probed but outside the required set. Said out loud with its status, so a
+  // reader can see what this run touched without counting, rather than having
+  // to infer the gap from the verdict's arithmetic.
+  for (const o of notCounted) {
     logger.info(
-      `on-prem only — ${o.key}: ${why(o)} (not counted against this run)`,
+      `not counted (${scopeOf(o.key)}-scope, not in --require) — ${o.key}: ${why(o)}`,
     );
   }
+
+  // Last, and after the verdict, so it cannot be mistaken for one: a run that
+  // did not say what it required does not get to exit 0, whatever it confirmed.
+  if (required.refuse) {
+    logger.error(
+      'The verdict above counted the default cloud set on a system that is not cloud. Whatever it says, this run did not decide the on-prem-only types. Re-run with --require.',
+    );
+  }
+
+  // One place decides, so the log and `$?` cannot disagree.
+  process.exitCode = exitCodeFor({
+    unconfirmed: unconfirmed.length,
+    refuse: required.refuse,
+  });
+
   logger.info(`Evidence written to ${outDir}`);
 }
 
-main().catch((error) => {
-  // No logger here by design: this is the path where the probe itself broke,
-  // and the process must exit non-zero with the reason visible.
-  process.stderr.write(`probe-atc failed: ${String(error)}\n`);
-  process.exitCode = 1;
-});
+// Guarded so the pure parts of this file can be imported and tested. The
+// verdict is the one thing here that must not lie, and an unimportable module
+// is an untestable one.
+if (require.main === module) {
+  main().catch((error) => {
+    // No logger here by design: this is the path where the probe itself broke,
+    // and the process must exit non-zero with the reason visible.
+    process.stderr.write(`probe-atc failed: ${String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/probe-atc.ts
+++ b/scripts/probe-atc.ts
@@ -579,6 +579,15 @@ function parseArgsChecked(argv: string[]) {
  * not cheap to repeat.
  */
 export function assertKnownKeys(keys: string[]): void {
+  // `--require=` and `--require=,,,` both survive split/trim/filter as an empty
+  // array, which is truthy, so it read as an explicit statement — and a run
+  // required to confirm nothing confirms it, exits 0 and decides nothing. A
+  // caller who passes the flag means to name something.
+  if (keys.length === 0) {
+    throw new Error(
+      `--require was given with no candidate in it. Name at least one, or pass --require=all. Known: ${CANDIDATES.map((c) => c.key).join(', ')}`,
+    );
+  }
   const unknown = keys.filter((k) => !CANDIDATES.some((c) => c.key === k));
   if (unknown.length) {
     throw new Error(
@@ -636,6 +645,38 @@ export function exitCodeFor(opts: {
   refuse: boolean;
 }): 0 | 1 {
   return opts.unconfirmed > 0 || opts.refuse ? 1 : 0;
+}
+
+/**
+ * The verdict line — the one written into `manifest.json` and read by people.
+ *
+ * Pure and tested for the same reason `exitCodeFor` is, and it was missed the
+ * first time: the exit code became a value while this stayed inline, so a run
+ * that refused to judge still wrote `COMPLETE` into the manifest and logged it.
+ * The exit code was 1, but `$?` does not survive into an artefact — the string
+ * does, and a reader or a consumer of the manifest takes it at its word.
+ *
+ * So refusal is a verdict of its own, not a footnote under a good one.
+ */
+export function verdictFor(opts: {
+  requiredKeys: string[];
+  source: string;
+  confirmed: number;
+  unconfirmed: { key: string; why: string }[];
+  refuse: boolean;
+}): string {
+  const countedAs = `${opts.requiredKeys.length} required type(s) [${opts.requiredKeys.join(', ')}] — set from ${opts.source}`;
+  const unconfirmed = opts.unconfirmed.length
+    ? `; unconfirmed: ${opts.unconfirmed.map((o) => `${o.key} [${o.why}]`).join(', ')}`
+    : '';
+
+  if (opts.refuse) {
+    return `REFUSED — this run did not say what it must confirm, and this system is not one whose type inventory the probe knows. ${opts.confirmed} of ${countedAs} confirmed${unconfirmed}. Nothing here decides the on-prem-only types; re-run with --require.`;
+  }
+
+  return opts.unconfirmed.length
+    ? `INCOMPLETE — ${opts.confirmed} of ${countedAs}${unconfirmed}`
+    : `COMPLETE — all of ${countedAs}`;
 }
 
 function defaultPackageFromTestConfig(logger: ILogger): string | undefined {
@@ -1662,10 +1703,13 @@ async function main(): Promise<void> {
   // The counted set is named in the verdict itself. A bare "COMPLETE" is what
   // made the previous version dangerous on an on-prem run: it was true about
   // the seven types it counted and silent about the two the run existed for.
-  const countedAs = `${required.keys.length} required type(s) [${required.keys.join(', ')}] — set from ${required.source}`;
-  const verdict = unconfirmed.length
-    ? `INCOMPLETE — ${confirmed.length} of ${countedAs}; unconfirmed: ${unconfirmed.map((o) => `${o.key} [${why(o)}]`).join(', ')}`
-    : `COMPLETE — all of ${countedAs}`;
+  const verdict = verdictFor({
+    requiredKeys: required.keys,
+    source: required.source,
+    confirmed: confirmed.length,
+    unconfirmed: unconfirmed.map((o) => ({ key: o.key, why: why(o) })),
+    refuse: required.refuse,
+  });
 
   // A non-zero triple somewhere is what makes the positions readable at all.
   const nonZeroStats = rec.findingStats.filter(

--- a/src/__tests__/unit/scripts/probeAtcVerdict.test.ts
+++ b/src/__tests__/unit/scripts/probeAtcVerdict.test.ts
@@ -13,9 +13,11 @@
  */
 
 import {
+  assertKnownKeys,
   CANDIDATES,
   exitCodeFor,
   requiredKeysFor,
+  verdictFor,
 } from '../../../../scripts/probe-atc';
 
 const silentLogger = () => ({
@@ -107,8 +109,82 @@ describe('probe-atc — what the verdict counts', () => {
     ).toThrow(/programs/);
   });
 
+  // `--require=` and `--require=,,,` both reach here as `[]`, which is truthy,
+  // so they read as an explicit statement. A run required to confirm nothing
+  // confirms it and exits 0 — a clean pass that decided nothing, which is the
+  // bug this whole change exists to remove, reachable by a stray keystroke.
+  it.each([
+    [[] as string[]],
+    [[''] as string[]],
+  ])('an empty --require (%p after trimming) throws rather than requiring nothing', (keys) => {
+    const cleaned = keys.map((k) => k.trim()).filter(Boolean);
+
+    expect(() => assertKnownKeys(cleaned)).toThrow(/no candidate/i);
+    expect(() =>
+      requiredKeysFor(cleaned, false, silentLogger() as never),
+    ).toThrow(/no candidate/i);
+  });
+
   it('the candidate set still holds the two types an on-prem run is for', () => {
     expect(ONPREM_KEYS).toEqual(expect.arrayContaining(['program', 'include']));
+  });
+});
+
+/**
+ * The verdict string is what goes into `manifest.json` and what a person reads.
+ * It needs its own tests because the first pass at this fix gave the exit code
+ * a pure function and left this inline: a refusing run still wrote `COMPLETE`
+ * into the artefact. An exit code does not survive into a file; the string does.
+ */
+describe('probe-atc — the verdict line', () => {
+  const base = {
+    requiredKeys: ['class', 'interface'],
+    source: '--require',
+    confirmed: 2,
+    unconfirmed: [],
+    refuse: false,
+  };
+
+  it('a refusing run is never COMPLETE, even with everything it counted confirmed', () => {
+    const verdict = verdictFor({
+      ...base,
+      source: 'none given',
+      refuse: true,
+    });
+
+    expect(verdict).not.toMatch(/COMPLETE/);
+    expect(verdict).toMatch(/^REFUSED/);
+    // And it says how to get an answer, not merely that it has none.
+    expect(verdict).toContain('--require');
+  });
+
+  it('a refusing run still reports what it did confirm, rather than hiding it', () => {
+    const verdict = verdictFor({
+      ...base,
+      source: 'none given',
+      refuse: true,
+    });
+
+    expect(verdict).toContain('2 of 2 required type(s)');
+  });
+
+  it('COMPLETE names the counted set, so it cannot be read wider than it is', () => {
+    const verdict = verdictFor(base);
+
+    expect(verdict).toMatch(/^COMPLETE/);
+    expect(verdict).toContain('[class, interface]');
+    expect(verdict).toContain('set from --require');
+  });
+
+  it('INCOMPLETE names each unconfirmed candidate and why', () => {
+    const verdict = verdictFor({
+      ...base,
+      confirmed: 1,
+      unconfirmed: [{ key: 'interface', why: 'never asked' }],
+    });
+
+    expect(verdict).toMatch(/^INCOMPLETE/);
+    expect(verdict).toContain('interface [never asked]');
   });
 });
 

--- a/src/__tests__/unit/scripts/probeAtcVerdict.test.ts
+++ b/src/__tests__/unit/scripts/probeAtcVerdict.test.ts
@@ -16,6 +16,7 @@ import {
   assertKnownKeys,
   CANDIDATES,
   exitCodeFor,
+  looksUnambiguouslyCloud,
   requiredKeysFor,
   verdictFor,
 } from '../../../../scripts/probe-atc';
@@ -34,6 +35,58 @@ const CLOUD_KEYS = CANDIDATES.filter((c) => c.scope === 'cloud').map(
 const ONPREM_KEYS = CANDIDATES.filter((c) => c.scope === 'onprem').map(
   (c) => c.key,
 );
+
+/**
+ * The permissive branch — "this is cloud, so the cloud default is safe" — is
+ * the only way back to a false COMPLETE, so what opens it has to be proof.
+ *
+ * The first version used `isCloudEnvironment()`, which falls back to asking
+ * whether `/sap/bc/adt/core/http/systeminformation` answers. A **modern
+ * on-prem serves that endpoint too**, so a 7.5x system could be taken for
+ * cloud, get the cloud-only default, and hand back COMPLETE with `program` and
+ * `include` uncounted. The detector would have reintroduced the exact bug.
+ */
+describe('probe-atc — what counts as proof of cloud', () => {
+  it.each([
+    'https://abc.abap.eu10.hana.ondemand.com',
+    'https://x.abap.us21.hana.ondemand.com/sap/bc/adt',
+    'https://tenant.abap.cloud.sap',
+  ])('%s is proof', (url) => {
+    expect(looksUnambiguouslyCloud(url)).toBe(true);
+  });
+
+  it.each([
+    // A modern on-prem, which is what makes the endpoint fallback unusable.
+    ['https://e19.corp.example:44300', 'on-prem host'],
+    ['http://sap-dev:8000', 'on-prem host with a port'],
+    // A host that merely *contains* a cloud domain. `includes` would pass it.
+    ['https://hana.ondemand.com.attacker.example', 'suffix only as substring'],
+    ['https://notondemand.com', 'no dot boundary'],
+    ['not a url at all', 'unparseable'],
+    ['', 'empty'],
+  ])('%s is not proof (%s)', (url) => {
+    expect(looksUnambiguouslyCloud(url)).toBe(false);
+  });
+
+  it('no URL at all is not proof', () => {
+    expect(looksUnambiguouslyCloud(undefined)).toBe(false);
+  });
+
+  // The consequence, stated as its own case: not-proof plus no --require is a
+  // refusal, which is what keeps an unrecognised cloud host safe rather than
+  // silently judged.
+  it('an unrecognised host without --require refuses instead of defaulting', () => {
+    const url = 'https://some-new-cloud-host.example';
+
+    const result = requiredKeysFor(
+      undefined,
+      looksUnambiguouslyCloud(url),
+      silentLogger() as never,
+    );
+
+    expect(result.refuse).toBe(true);
+  });
+});
 
 describe('probe-atc — what the verdict counts', () => {
   // The regression. Before the fix this combination produced a clean pass.

--- a/src/__tests__/unit/scripts/probeAtcVerdict.test.ts
+++ b/src/__tests__/unit/scripts/probeAtcVerdict.test.ts
@@ -1,0 +1,141 @@
+/**
+ * What the ATC probe's verdict is allowed to count.
+ *
+ * The probe is a script rather than library code, and it would normally carry
+ * no test. This part does, because the bug it fixes was a *false pass*: on an
+ * on-prem run the verdict counted the cloud-scope types, printed `COMPLETE`
+ * and exited 0, while `program` and `include` — the two types an on-prem run
+ * exists to settle — were probed and then left out of the arithmetic. A reader
+ * would have concluded the on-prem question was closed.
+ *
+ * So the rule under test is narrow and blunt: **a run that has not said what it
+ * requires does not get to pass on a system this probe cannot reason about.**
+ */
+
+import {
+  CANDIDATES,
+  exitCodeFor,
+  requiredKeysFor,
+} from '../../../../scripts/probe-atc';
+
+const silentLogger = () => ({
+  log: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+});
+
+const CLOUD_KEYS = CANDIDATES.filter((c) => c.scope === 'cloud').map(
+  (c) => c.key,
+);
+const ONPREM_KEYS = CANDIDATES.filter((c) => c.scope === 'onprem').map(
+  (c) => c.key,
+);
+
+describe('probe-atc — what the verdict counts', () => {
+  // The regression. Before the fix this combination produced a clean pass.
+  it('refuses to pass on a non-cloud system when nothing was required', () => {
+    const logger = silentLogger();
+
+    const result = requiredKeysFor(undefined, false, logger as never);
+
+    expect(result.refuse).toBe(true);
+    expect(result.source).toBe('none given');
+    // It must also say what to do, not merely fail.
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('--require'),
+    );
+  });
+
+  it('names the on-prem-only types in the advice, since they are the point', () => {
+    const logger = silentLogger();
+
+    requiredKeysFor(undefined, false, logger as never);
+
+    const advice = logger.error.mock.calls.map((c) => String(c[0])).join(' ');
+    for (const key of ONPREM_KEYS) {
+      expect(advice).toContain(key);
+    }
+  });
+
+  it('on cloud, the default stays what it was and passes', () => {
+    const logger = silentLogger();
+
+    const result = requiredKeysFor(undefined, true, logger as never);
+
+    expect(result.refuse).toBe(false);
+    expect(result.keys).toEqual(CLOUD_KEYS);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  // An explicit set is the caller's statement, and detection does not override
+  // it in either direction — that would be the same silent inference again.
+  it('an explicit --require is honoured on cloud and on anything else', () => {
+    for (const isCloud of [true, false]) {
+      const result = requiredKeysFor(
+        ['class', 'program'],
+        isCloud,
+        silentLogger() as never,
+      );
+
+      expect(result).toMatchObject({
+        keys: ['class', 'program'],
+        source: '--require',
+        refuse: false,
+      });
+    }
+  });
+
+  it('--require=all is every candidate, on-prem-only ones included', () => {
+    // `all` is expanded by the argument parser, so what is asserted here is
+    // that the expansion it produces is accepted whole.
+    const every = CANDIDATES.map((c) => c.key);
+
+    const result = requiredKeysFor(every, false, silentLogger() as never);
+
+    expect(result.refuse).toBe(false);
+    expect(result.keys).toEqual(expect.arrayContaining(ONPREM_KEYS));
+  });
+
+  // A typo in --require must not quietly shrink what the run is judged on:
+  // requiring `programs` and being told COMPLETE is the original bug wearing a
+  // different hat.
+  it('an unknown key throws instead of being dropped', () => {
+    expect(() =>
+      requiredKeysFor(['class', 'programs'], false, silentLogger() as never),
+    ).toThrow(/programs/);
+  });
+
+  it('the candidate set still holds the two types an on-prem run is for', () => {
+    expect(ONPREM_KEYS).toEqual(expect.arrayContaining(['program', 'include']));
+  });
+});
+
+/**
+ * `$?` is what a caller and a CI job read, and it is the half of the fix that
+ * a first pass left untested: the refusal was computed, `main` acted on it, and
+ * deleting the line that set the exit code broke nothing anyone checked.
+ */
+describe('probe-atc — the exit code', () => {
+  it('a refused run exits non-zero even with everything it counted confirmed', () => {
+    expect(exitCodeFor({ unconfirmed: 0, refuse: true })).toBe(1);
+  });
+
+  it('an unconfirmed candidate exits non-zero', () => {
+    expect(exitCodeFor({ unconfirmed: 1, refuse: false })).toBe(1);
+  });
+
+  it('only a run that confirmed what it required, and said so, exits zero', () => {
+    expect(exitCodeFor({ unconfirmed: 0, refuse: false })).toBe(0);
+  });
+
+  /**
+   * **What these tests do not cover**, said out loud rather than left to be
+   * discovered: the single line in `main()` that assigns this function's result
+   * to `process.exitCode`. `main()` needs a live SAP connection, so no unit
+   * test reaches it — replacing that assignment with `process.exitCode = 0`
+   * passes everything here. The decision is tested; the wiring is one line, and
+   * it is on the reviewer.
+   */
+});

--- a/tsconfig.test.integration.json
+++ b/tsconfig.test.integration.json
@@ -1,9 +1,20 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": "."
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/__tests__/e2e/**/*", "src/__tests__/examples/**/*"]
+  "include": [
+    "src/**/*",
+    // Kept in step with tsconfig.test.json, which carries the same two lines
+    // for the same reason: src/__tests__/unit/scripts/ imports the probe's pure
+    // parts, and this config compiles all of src. Change one, change the other.
+    "scripts/probe-atc.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/__tests__/e2e/**/*",
+    "src/__tests__/examples/**/*"
+  ]
 }
-

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -2,10 +2,17 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ]
+    "rootDir": ".",
+    "typeRoots": ["./node_modules/@types"]
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/**/*",
+    // probe-atc only. src/__tests__/unit/scripts/ imports its pure parts, so it
+    // has to be in the program. The other scripts are deliberately NOT here:
+    // several no longer compile against current types, and dragging them in
+    // would fail this config for reasons that have nothing to do with tests.
+    // tsconfig.test.integration.json carries the same line — change both.
+    "scripts/probe-atc.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Found while writing on-prem test instructions for #111/#112: **the ATC probe reports a clean pass on exactly the runs it cannot decide.**

## The bug

`scripts/probe-atc.ts` computed its verdict over the **cloud-scope** candidates only. On the trial that was correct — a classic program cannot exist on ABAP Cloud, and counting it would have left the probe permanently INCOMPLETE, which review said so at the time and the code says in a comment.

Run against **on-prem** it inverts. `program` and `include` are probed, reported on a line of their own (`on-prem only — … (not counted against this run)`), and then left out of the arithmetic. The probe prints

```
COMPLETE — all 7 cloud candidate types confirmed
```

and exits **0** — on the one kind of run whose whole purpose is to settle those two types. Anyone reading that concludes the on-prem question is closed. It is the same shape as the two criteria the ATC work already got wrong twice: *accepted* read as *confirmed*.

It survived because nobody has run this probe on-prem yet. The bug is where the testing was not.

## Why not just detect the system

The obvious fix — "if it's on-prem, count the on-prem types" — trades one silent inference for another. The probe still would not know which types a given system holds: a 7.40 on-prem has no behaviour definitions, a 7.5x has those *and* classic programs. Guessing yields either a false COMPLETE or a permanent INCOMPLETE, and the first is what we are fixing.

**So the caller states it, and detection may only refuse a pass — never allow one.**

That distinction is load-bearing, and the first two rounds of this PR did not honour it. `isCloudEnvironment()` opened the permissive branch, and it falls back to asking whether `/sap/bc/adt/core/http/systeminformation` answers — **an endpoint a modern on-prem also serves**. A 7.5x system could be read as cloud, take the cloud-only default, and hand back `COMPLETE` with `program` and `include` uncounted: this PR's own bug, restored through its own detector.

`looksUnambiguouslyCloud(baseUrl)` replaces it — a host-suffix match against a short list, no request, no fallback. Unknown host, unparseable URL, no URL: all "not proof", all refuse. The costs are not symmetric and that is the argument: a cloud system under an unrecognised host costs one flag, an on-prem system read as cloud costs a wrong answer that reads like a right one. The suffix is matched on a host boundary rather than with `includes`, since `ondemand.com.example` is somebody else's domain.

## What changed

- **`--require=KEYS`** (comma-separated candidate keys, or `all`) — what this run must confirm. **Every candidate is probed either way**; this decides only what the verdict counts.
- Omitted on a cloud system, the previous default stands and nothing changes.
- Omitted on anything else, the probe names the flag to pass and **exits non-zero**. It does not know what that system holds and will not turn that into a pass.
- The verdict **names the set it counted** — `COMPLETE — all of 9 required type(s) [class, …, program, include] — set from --require`. A bare `COMPLETE` was what made the old one dangerous: true about the seven it counted, silent about the two it did not.
- **A refusing run gets its own verdict** (`REFUSED — …`), not a good one with a warning under it.
- Candidates outside the required set are still printed with their status, so a reader sees what was touched without counting.
- An unknown key is rejected **at argument-parse time, before anything connects**. On an on-prem session a wasted round trip is not cheap to repeat.

## Three defects review caught

The third is above. The first two were the same mistake: the exit code got a pure, tested function, and the thing beside it stayed inline and unguarded.

**The verdict still said `COMPLETE` on a run that refused to judge.** `refuse` fed the exit code and nothing else, so a non-cloud run without `--require` that confirmed its seven cloud types wrote `COMPLETE — all of 7 required type(s)` into `manifest.json` and logged it at info level. The process exited 1 — but an exit code does not survive into an artefact. The string does, and whoever reads the `verdict` field takes it at its word. **This PR's own bug, still sitting in the field that carries it.** Refusal is now a verdict of its own, from `verdictFor`, pure and tested; it still reports what the run did confirm, since refusing to judge is no reason to hide the work.

**`--require=` and `--require=,,,` produced a clean pass.** Both survive `split`/`trim`/`filter` as `[]`, which is truthy, so they read as an explicit statement: a run required to confirm nothing confirms it and exits 0. A stray keystroke reproduced exactly the false pass this PR exists to remove. An empty set is now rejected where unknown keys already were — at argument-parse time, before a connection is spent.

## `exitCodeFor`, and why it exists

The first version of this fix was untestable exactly where it mattered. `requiredKeysFor` returned `refuse: true`, `main` acted on it — and a mutation run showed that **deleting the line which set the exit code broke nothing anyone checked**. A verdict nobody can act on fails the same way as one that lies: whatever the log says, `$?` is what a caller and a CI job read.

So the decision is a value now, and it is tested.

## Tests

27 cases over the four pure functions, in `src/__tests__/unit/scripts/probeAtcVerdict.test.ts`. The probe is a script and would normally carry none; this part does, because the bug was a false pass.

**Mutation-checked — 13 mutations, each caught by the test that pins it**: the original bug (`refuse` always false), both halves of the exit code, a verdict that ignores `refuse`, an empty `--require` accepted, an unknown key dropped, detection overriding an explicit set, cloud-by-substring, and an unparseable or missing URL taken for cloud.

**What the tests do not cover is written into the test file**: the one line in `main()` that assigns `exitCodeFor(...)` to `process.exitCode`. `main()` needs a live SAP connection, so replacing it with `process.exitCode = 0` passes everything here. The decision is tested; that line is on the reviewer.

## Also in here

Both test tsconfigs now include `scripts/probe-atc.ts`, since the unit test imports its pure parts, and `main()` is guarded with `require.main === module` so importing the module does not run a probe.

**Only that script is included.** Three others — `read-package-contents.ts`, `show-package-contents.ts`, `test-long-polling-read.ts` — no longer compile against current types (`adtType`, `is_package`, `IAbapConnection.reset` are all gone). That is real and worth fixing, but it is unrelated to this change and would fail these configs for reasons that have nothing to do with tests. Filed separately rather than folded in.

## Verification

`npm run build`, `test:check`, `test:check:integration` all clean; 1024 unit tests pass. The probe was run without SAP configuration to confirm it still executes as a script and exits 1, and with `--require=programs`, `--require=` and `--require=,,,` to confirm each is rejected before connecting. No SAP-touching run is part of this PR — the on-prem run this unblocks is the point, and it has not happened yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
