### PR TITLE
test(include): the PROG/I chain gets exercised against a real system

### DIFF
--- a/src/__tests__/helpers/test-config.yaml.template
+++ b/src/__tests__/helpers/test-config.yaml.template
@@ -1000,6 +1000,29 @@ create_program:
           REPORT ZAC_PROG01.
           WRITE: / 'Adt test program - updated'.
 
+# Create standalone PROG/I include
+# Modern on-prem only: discovery gives /sap/bc/adt/programs/includes an
+# app:accept there and nowhere else, and a collection without one is not a POST
+# target. Cloud answers 403 S_DEVELOP for the type.
+create_include:
+  test_cases:
+    - name: "adt_include"
+      enabled: true
+      available_in: ["onprem"]
+      description: "Standalone PROG/I include reserved for AdtInclude tests"
+      params:
+        include_name: "ZAC_INCL01"
+        description: "AdtInclude workflow include"
+        # package_name: "ZAC_PKG01"
+        # transport_request: ""
+        source_code: |
+          * Adt test include
+          DATA lv_adt_include TYPE string.
+        update_source_code: |
+          * Adt test include - updated
+          DATA lv_adt_include TYPE string.
+          lv_adt_include = 'updated'.
+
 # Create Table
 create_table:
   test_cases:

--- a/src/__tests__/helpers/testTemplate.ts
+++ b/src/__tests__/helpers/testTemplate.ts
@@ -1,28 +1,57 @@
 /**
- * Template for integration test files.
- * Copy this structure; the connection comes from createTestConnection().
+ * Templates for integration test files.
+ *
+ * Two shapes, because the tests come in two kinds:
+ *
+ * 1. **A bare test** — it needs a connection and nothing else. Read a standard
+ *    object, probe an endpoint, check a runtime surface. First block below.
+ * 2. **A CRUD-flow test for a core object type** — create, read, update,
+ *    activate, delete, with cleanup and environment gating. Every test under
+ *    `integration/core/` is this shape, and it is `BaseTester` that carries it.
+ *    Second block below.
+ *
+ * The second shape used to be absent here, so each new object type was written
+ * by copying whichever existing test the author happened to open. That is how
+ * conventions drift: `available_in` gating gets forgotten in one file, cleanup
+ * decides absence by HTTP status in another.
+ *
+ * In both, the connection comes from `createTestConnection()` — it takes WHERE
+ * we connect and HOW we authenticate from configuration, and nothing about
+ * either is written into a test.
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type {
   IAbapConnection,
+  IIncludeConfig,
+  IIncludeState,
   ISessionLifecycleAware,
 } from '@mcp-abap-adt/interfaces';
 import * as dotenv from 'dotenv';
+import type { AdtClient } from '../../clients/AdtClient';
+import { getIncludeSource } from '../../core/include';
+import { isCloudEnvironment } from '../../utils/systemInfo';
 import {
+  createTestAdtClient,
   createTestConnection,
   releaseTestConnection,
+  resolveSystemContext,
   skipUnlessConfigured,
 } from '../helpers/sessionConfig';
 import {
   createConnectionLogger,
+  createLibraryLogger,
   createTestsLogger,
 } from '../helpers/testLogger';
+import { BaseTester } from './BaseTester';
+import { logTestSkip } from './testProgressLogger';
 
 const {
   getEnabledTestCase,
   validateTestCaseForUserSpace,
+  resolvePackageName,
+  resolveTransportRequest,
 } = require('./test-helper');
 
 const envPath =
@@ -32,7 +61,11 @@ if (fs.existsSync(envPath)) {
 }
 
 const connectionLogger = createConnectionLogger();
+const libraryLogger = createLibraryLogger();
 const testsLogger = createTestsLogger();
+
+// ---------------------------------------------------------------------------
+// 1. A bare test: a connection and nothing else.
 
 describe('Module - Operation', () => {
   let connection: IAbapConnection & ISessionLifecycleAware;
@@ -70,4 +103,147 @@ describe('Module - Operation', () => {
 
     // Test implementation
   }, 30000);
+});
+
+// ---------------------------------------------------------------------------
+// 2. A CRUD-flow test for a core object type.
+//
+// Worked through `IIncludeConfig` because it is the smallest real one; swap the
+// four strings and the config mapping and the rest is unchanged.
+
+describe('ObjectType (using AdtClient)', () => {
+  let crudConnection: IAbapConnection;
+  let client: AdtClient;
+  let crudHasConfig = false;
+  let isCloudSystem = false;
+  let systemContext: Awaited<ReturnType<typeof resolveSystemContext>>;
+  let tester: BaseTester<IIncludeConfig, IIncludeState>;
+
+  beforeAll(async () => {
+    try {
+      crudConnection = await createTestConnection(connectionLogger);
+      // Stated, never inferred from the URL or the credential.
+      isCloudSystem = await isCloudEnvironment(crudConnection);
+      systemContext = await resolveSystemContext(crudConnection, isCloudSystem);
+      const { client: resolved } = await createTestAdtClient(
+        crudConnection,
+        libraryLogger,
+        systemContext,
+      );
+      client = resolved;
+      crudHasConfig = true;
+
+      tester = new BaseTester<IIncludeConfig, IIncludeState>(
+        client.getInclude(), // the handler under test
+        'ObjectType', // log prefix
+        'create_include', // section in test-config.yaml
+        'adt_include', // test case within that section
+        testsLogger,
+      );
+
+      tester.setup({
+        connection: crudConnection,
+        client,
+        hasConfig: crudHasConfig,
+        isCloudSystem,
+        // Package and transport come from the resolver — never hardcoded, so
+        // one config serves every system.
+        buildConfig: (testCase: any, resolver?: any) => {
+          const params = testCase?.params || {};
+          const packageName =
+            resolver?.getPackageName?.() ||
+            resolvePackageName(params.package_name);
+          if (!packageName) throw new Error('package_name not configured');
+          return {
+            includeName: params.include_name,
+            packageName,
+            transportRequest:
+              resolver?.getTransportRequest?.() ||
+              resolveTransportRequest(params.transport_request),
+            description: params.description,
+            sourceCode: params.source_code,
+          };
+        },
+        // Idempotence: a create test deletes what a previous run left.
+        //
+        // Absence is told by CONTENT, not by status: `source/main` answers 200
+        // with an empty body when the object is not there and never 404s, so a
+        // status check decides wrongly. Measured, and it has bitten before.
+        ensureObjectReady: async (name: string) => {
+          if (!crudConnection) return { success: true };
+          try {
+            const existing = await getIncludeSource(crudConnection, name);
+            if (!String(existing?.data ?? '').trim()) {
+              return { success: true };
+            }
+            const { client: cleanupClient } = await createTestAdtClient(
+              crudConnection,
+              libraryLogger,
+              systemContext,
+            );
+            await cleanupClient.getInclude().delete({
+              includeName: name,
+              transportRequest: tester.getTransportRequest(),
+            });
+            await new Promise((resolve) => setTimeout(resolve, 3000));
+          } catch (error: any) {
+            if (error.response?.status !== 404) {
+              return {
+                success: false,
+                reason: `Cannot verify ${name}: ${error.message}`,
+              };
+            }
+          }
+          return { success: true };
+        },
+      });
+    } catch (error) {
+      crudHasConfig = skipUnlessConfigured(error, testsLogger);
+    }
+  });
+
+  afterAll(() => tester?.afterAll()());
+
+  describe('Full workflow', () => {
+    beforeEach(() => tester?.beforeEach()());
+    afterEach(() => tester?.afterEach()());
+
+    it('should run the full workflow', async () => {
+      if (!tester) return;
+      if (!crudHasConfig) {
+        await tester.flowTestAuto();
+        return;
+      }
+
+      // Gate on the CAPABILITY and name it. A skip that says "not supported"
+      // without saying why is how a gap stays invisible — say what the system
+      // lacks, so a reader can check whether it is still true.
+      if (isCloudSystem) {
+        logTestSkip(
+          testsLogger,
+          'ObjectType - full workflow',
+          'the collection declares no app:accept on this system, so it is not a creation target',
+        );
+        return;
+      }
+
+      const config = tester.getConfig();
+      if (!config) {
+        await tester.flowTestAuto();
+        return;
+      }
+
+      const testCase = tester.getTestCaseDefinition();
+      const sourceCode =
+        testCase?.params?.source_code || config.sourceCode || '';
+
+      await tester.flowTestAuto({
+        sourceCode,
+        updateConfig: {
+          ...config,
+          sourceCode: testCase?.params?.update_source_code || sourceCode,
+        },
+      });
+    }, 900000);
+  });
 });

--- a/src/__tests__/integration/core/include/Include.test.ts
+++ b/src/__tests__/integration/core/include/Include.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Integration test for standalone `PROG/I` includes (AdtInclude).
+ *
+ * **On-prem only, and not by policy — by capability.** Discovery gives the
+ * includes collection an `app:accept` on modern on-prem and on nothing else; a
+ * collection without one is not a POST target, and cloud answers `403
+ * S_DEVELOP` for the type. So this file skips wherever an include cannot be
+ * created, and says which of the two reasons applied.
+ *
+ * The chain it exercises is the one captured from Eclipse: create, lock,
+ * `PUT source/main`, unlock, activate. Nothing here had ever run against a
+ * system before this file existed.
+ *
+ * Enable debug logs:
+ *   DEBUG_ADT_TESTS=true       - Integration test execution logs
+ *   DEBUG_ADT_LIBS=true        - Library logs
+ *   DEBUG_CONNECTORS=true      - Connection logs (@mcp-abap-adt/connection)
+ *
+ * Run: npm test -- --testPathPatterns=include/Include
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type {
+  IAbapConnection,
+  IIncludeConfig,
+  IIncludeState,
+  ILogger,
+} from '@mcp-abap-adt/interfaces';
+import * as dotenv from 'dotenv';
+import type { AdtClient } from '../../../../clients/AdtClient';
+import { getIncludeSource } from '../../../../core/include';
+import { isCloudEnvironment } from '../../../../utils/systemInfo';
+import { BaseTester } from '../../../helpers/BaseTester';
+import {
+  createTestAdtClient,
+  createTestConnection,
+  resolveSystemContext,
+  skipUnlessConfigured,
+} from '../../../helpers/sessionConfig';
+import {
+  createConnectionLogger,
+  createLibraryLogger,
+  createTestsLogger,
+} from '../../../helpers/testLogger';
+import {
+  logTestEnd,
+  logTestError,
+  logTestSkip,
+  logTestStart,
+  logTestSuccess,
+} from '../../../helpers/testProgressLogger';
+
+const {
+  resolvePackageName,
+  resolveTransportRequest,
+  getTimeout,
+} = require('../../../helpers/test-helper');
+
+const envPath =
+  process.env.MCP_ENV_PATH || path.resolve(__dirname, '../../../../.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath, quiet: true });
+}
+
+const connectionLogger: ILogger = createConnectionLogger();
+const libraryLogger: ILogger = createLibraryLogger();
+const testsLogger: ILogger = createTestsLogger();
+
+describe('Include (PROG/I, using AdtClient)', () => {
+  let connection: IAbapConnection;
+  let client: AdtClient;
+  let hasConfig = false;
+  let isCloudSystem = false;
+  let systemContext: Awaited<ReturnType<typeof resolveSystemContext>>;
+  let tester: BaseTester<IIncludeConfig, IIncludeState>;
+
+  beforeAll(async () => {
+    try {
+      connection = await createTestConnection(connectionLogger);
+      isCloudSystem = await isCloudEnvironment(connection);
+      systemContext = await resolveSystemContext(connection, isCloudSystem);
+      const { client: resolvedClient } = await createTestAdtClient(
+        connection,
+        libraryLogger,
+        systemContext,
+      );
+      client = resolvedClient;
+      hasConfig = true;
+
+      tester = new BaseTester<IIncludeConfig, IIncludeState>(
+        client.getInclude(),
+        'Include',
+        'create_include',
+        'adt_include',
+        testsLogger,
+      );
+
+      tester.setup({
+        connection,
+        client,
+        hasConfig,
+        isCloudSystem,
+        buildConfig: (testCase: any, resolver?: any) => {
+          const params = testCase?.params || {};
+          const packageName =
+            resolver?.getPackageName?.() ||
+            resolvePackageName(params.package_name);
+          if (!packageName) throw new Error('package_name not configured');
+          const transportRequest =
+            resolver?.getTransportRequest?.() ||
+            resolveTransportRequest(params.transport_request);
+          return {
+            includeName: params.include_name,
+            packageName,
+            transportRequest,
+            description: params.description,
+            sourceCode: params.source_code,
+          };
+        },
+        ensureObjectReady: async (includeName: string) => {
+          if (!connection) return { success: true };
+          try {
+            const existing = await getIncludeSource(connection, includeName);
+            // `source/main` answers 200 with an empty body when the object is
+            // not there — it never 404s — so absence is told by content.
+            if (!String(existing?.data ?? '').trim()) {
+              return { success: true };
+            }
+            try {
+              const transportRequest = tester.getTransportRequest();
+              const { client: cleanupClient } = await createTestAdtClient(
+                connection,
+                libraryLogger,
+                systemContext,
+              );
+              await cleanupClient
+                .getInclude()
+                .delete({ includeName, transportRequest });
+              await new Promise((resolve) => setTimeout(resolve, 3000));
+            } catch (cleanupError: any) {
+              return {
+                success: false,
+                objectExists: true,
+                reason: `Failed to delete existing include ${includeName}: ${cleanupError.message}`,
+              };
+            }
+          } catch (error: any) {
+            if (error.response?.status !== 404) {
+              return {
+                success: false,
+                reason: `Cannot verify include existence: ${error.message}`,
+              };
+            }
+          }
+          return { success: true };
+        },
+      });
+    } catch (error) {
+      // Skips only when there is no SAP here; anything else fails naming the
+      // reason, instead of passing green having run nothing.
+      hasConfig = skipUnlessConfigured(error, testsLogger);
+    }
+  });
+
+  afterAll(() => tester?.afterAll()());
+
+  describe('Full workflow', () => {
+    beforeEach(() => tester?.beforeEach()());
+    afterEach(() => tester?.afterEach()());
+
+    it(
+      'should create, read, update, activate and delete an include',
+      async () => {
+        if (!tester) {
+          return;
+        }
+        if (!hasConfig) {
+          await tester.flowTestAuto();
+          return;
+        }
+
+        if (isCloudSystem) {
+          // Not a policy skip: discovery gives the includes collection no
+          // `app:accept` on cloud, so it is not a creation target, and the type
+          // answers 403 S_DEVELOP there.
+          logTestSkip(
+            testsLogger,
+            'Include - full workflow',
+            'PROG/I includes cannot be created on cloud: the collection declares no app:accept and the type answers 403 S_DEVELOP',
+          );
+          return;
+        }
+
+        const config = tester.getConfig();
+        if (!config) {
+          await tester.flowTestAuto();
+          return;
+        }
+
+        const testCase = tester.getTestCaseDefinition();
+        const sourceCode =
+          testCase?.params?.source_code || config.sourceCode || '';
+        const updateSourceCode =
+          testCase?.params?.update_source_code || sourceCode;
+
+        await tester.flowTestAuto({
+          sourceCode,
+          updateConfig: {
+            includeName: config.includeName,
+            packageName: config.packageName,
+            description: config.description || '',
+            sourceCode: updateSourceCode,
+          },
+        });
+      },
+      getTimeout('test'),
+    );
+  });
+
+  describe('The document is an include, not a program', () => {
+    it(
+      'reads back include:abapInclude with adtcore:type="PROG/I"',
+      async () => {
+        const testName = 'Include - metadata shape';
+        if (!hasConfig || !tester) {
+          logTestSkip(testsLogger, testName, 'No SAP configuration');
+          return;
+        }
+        if (isCloudSystem) {
+          logTestSkip(
+            testsLogger,
+            testName,
+            'PROG/I includes are not creatable on cloud',
+          );
+          return;
+        }
+
+        const config = tester.getConfig();
+        if (!config?.includeName) {
+          logTestSkip(testsLogger, testName, 'include_name not configured');
+          return;
+        }
+
+        logTestStart(testsLogger, testName, {
+          name: 'metadata_shape',
+          params: { include_name: config.includeName },
+        });
+
+        try {
+          const state = await client
+            .getInclude()
+            .readMetadata({ includeName: config.includeName });
+          const body = String((state?.readResult as any)?.data ?? '');
+
+          // The whole reason this is a separate module: an include answers with
+          // its own root and type, and carries none of the program attributes.
+          expect(body).toContain('include:abapInclude');
+          expect(body).toContain('adtcore:type="PROG/I"');
+          expect(body).not.toContain('program:abapProgram');
+          expect(body).not.toContain('program:programType');
+
+          logTestSuccess(testsLogger, testName);
+        } catch (error) {
+          logTestError(testsLogger, testName, error);
+          throw error;
+        } finally {
+          logTestEnd(testsLogger, testName);
+        }
+      },
+      getTimeout('test'),
+    );
+  });
+});


### PR DESCRIPTION
The `PROG/I` include module shipped in 13.0.0 with unit tests and a compiler, and had never touched SAP. This is the integration test for it.

## What it runs

The chain captured from Eclipse, through `BaseTester`:

```
POST   /programs/includes                                   create
POST   /programs/includes/{name}?_action=LOCK&accessMode=MODIFY
PUT    /programs/includes/{name}/source/main?lockHandle=…    text/plain; charset=utf-8
POST   /programs/includes/{name}?_action=UNLOCK&lockHandle=…
POST   /activation?method=activate&preauditRequested=true
```

`getInclude()` satisfies `TestableObject` exactly — the narrowed return is creatable, readable, modifiable, validatable and activatable, which is what the tester asks for. No cast, no widening.

A second case asserts what the module exists for: the object reads back as `include:abapInclude` with `adtcore:type="PROG/I"`, and carries neither `program:abapProgram` nor `program:programType`. If those ever appear, the module has quietly become a program builder again — the exact defect it replaced.

## Where it can run, and why the skip says so

**Modern on-prem only.** Discovery gives `/sap/bc/adt/programs/includes` an `app:accept` there and on nothing else; a collection without one is not a POST target, and cloud answers `403 S_DEVELOP` for the type. The cloud skip names that capability rather than pretending it is a policy decision — a skip that misstates its reason is how a gap stays invisible.

| system | `app:accept` on the includes collection |
|---|---|
| modern on-prem | `application/vnd.sap.adt.programs.includes.v2+xml` |
| legacy on-prem | none |
| cloud trial | none |
| cloud | none |

## Detail worth reviewing

Cleanup reads the source and treats an **empty body as absence**. `source/main` answers `200` with nothing when the object is not there and never 404s, so a status check would decide wrongly — this is the measured behaviour, not a guess.

## The template was not carrying its weight

`testTemplate.ts` showed a connection being opened and released, and nothing else — while every test under `integration/core/` is a different shape entirely: `BaseTester`, `buildConfig`, `ensureObjectReady`, environment gating. Writing this test I copied `Program.test.ts`, which is the proof that the template did not serve its purpose. Someone adding the next object type would have done the same, and picked up whatever that file happened to get right.

It now carries both shapes, worked through a real type so it compiles rather than being prose. Three things it teaches deliberately, each got wrong here before: package and transport come from the resolver and are never hardcoded; cleanup tells absence by content because `source/main` never 404s; and an environment skip names the missing **capability** rather than saying "not supported".

## Not run

Nothing here has been executed. It needs the on-prem machine, which is the point of the branch.

Unit tests, build, `test:check` and `lint:check` are unaffected and green: 99 suites / 1085 tests, all four exit `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
