### PR TITLE
feat(traces)!: the timings are a shape and the entry carries what the feed sends (14.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+## [14.0.0] - 2026-08-29
+
+Requires `@mcp-abap-adt/interfaces@^24.0.0`.
+
+Everything here follows one raw capture — `docs/evidence/2026-08-29-profiler-probe/`,
+the trace feed and all three views as whole files. It closes the two things
+13.0.0 shipped without.
+
+### Changed
+
+- **BREAKING** — `Profiler.list()` returns `IAbapTraceEntry[]`, not
+  `ITraceEntry[]`.
+
+  Ten fields the feed always carried and this library was throwing away:
+  `system`, `client`, `host`, `size`, `runtime`, `runtimeABAP`, `runtimeSystem`,
+  `runtimeDatabase`, `isAggregated`, `amdpFileSize`. Four more — `user`,
+  `objectName`, `state`, `expiresAt` — are no longer optional, because the
+  measurement found them on all sixty entries.
+
+  `client` is a `string`: a client is a code, and `010` is not `10`. Pinned by a
+  test, since a number is the obvious wrong choice.
+
+  **Migration.** Readers gain fields and lose four optionality checks. Code that
+  declared a variable as `ITraceEntry` still compiles — `IAbapTraceEntry`
+  extends it.
+
+- **BREAKING** — `grossTime` and `traceEventNetTime` are `ITraceTiming`
+  (`{ time, percentage }`) instead of whatever the XML parser produced.
+
+  They were handed through unopened while the contract typed them `unknown`.
+  The capture settles the shape: both attributes, in the hit list and the
+  statements, with no variant. The **unit of `time` is still not named** — the
+  wire gives a figure and no unit.
+
+  **Migration.** `entry.grossTime?.time` is a number; no narrowing needed.
+
+- **The entry reader looks only under `trc:extendedData`.**
+
+  It used to look there *and* directly on the entry, because which nesting was
+  real had never been read end to end. It has been now: sixty entries, every
+  `trc:` field inside the container, not one outside it. The second lookup was a
+  placeholder for a measurement and the measurement arrived, so it is gone —
+  keeping it would be reading for a document nobody has seen.
+
+  A test pins the new behaviour by asserting that a `trc:objectName` placed on
+  the entry is **not** read.
+
 ## [13.0.0] - 2026-08-28
 
 Requires `@mcp-abap-adt/interfaces@^23.0.0` — `readWith()` arrives there.

--- a/docs/evidence/2026-08-30-pr121-onprem/README.md
+++ b/docs/evidence/2026-08-30-pr121-onprem/README.md
@@ -1,0 +1,56 @@
+# PR #121 verified on E19 — the four runs, whole
+
+Branch `feat/typed-timings-and-abap-entry` at `99e1b2b`, after the rebase that
+put #120 underneath it. `npm ci`, E19 (`RFCSAPRL 816`, kernel `916`, client
+100), one SAP-touching run at a time, each log kept entire.
+
+| log | command | result |
+|---|---|---|
+| `entry.log` | `npx ts-node scripts/print-trace-entry.ts` | every declared field present |
+| `include-run.log` | `npm test -- integration/core/include` | 1 suite, 2 tests, green |
+| `traces-run.log` | `npm test -- integration/runtime/traces` | 1 suite, 6 tests, green |
+| `executors-run.log` | `npm test -- integration/executors` | 2 suites, 4 tests, green |
+
+## What `entry.log` settles
+
+The release makes fourteen fields typed and four of them required, and nothing
+checks that at runtime — the parser maps, it does not judge. So the round trip
+had to be read off a live feed:
+
+```
+  client             "100"
+  system             "E19"
+  host               "epbyminsd0654"
+  size               8
+  runtime            554
+  isAggregated       false
+```
+
+`client` prints **with quotes**, as do `system` and `host`. Only the counted
+things are numbers. Nothing came back `undefined`, so the contract claims no
+more than the wire gives.
+
+## What `include-run.log` shows
+
+```
+read initial (post-create)  → 52 characters
+read inactive (post-update) → 91
+read active (post-activate) → 91
+```
+
+Before #120 both reads were 52 — the update rewrote the object with the create
+source. This run is also the one that proves #120's delete fix end to end: after
+its cleanup the name `ZAC_INCL01` is free, where every earlier run left an
+editing registration behind.
+
+Not included here: an earlier, pre-rebase run of the same suite that failed on
+those two #120 defects, and one after the rebase that failed on a stale
+`TRDIR ZAC_INCL01` lock left by a run from before #120 was merged. Both are
+described in the PR comment; neither says anything about this branch's changes.
+
+## Noted, and outside this PR
+
+`executors-run.log` is green, and the suite still leaves `E_ABAP_GENPH` locks on
+the generated class-pool parts (`~AC_CLS…HPZ` / `…HCZ`) after deleting its
+objects. This package never takes those locks — `grep -rn "GENPH" src/` is
+empty; they are the kernel's, taken during activation and generation.

--- a/docs/evidence/2026-08-30-pr121-onprem/entry.log
+++ b/docs/evidence/2026-08-30-pr121-onprem/entry.log
@@ -1,0 +1,23 @@
+
+61 trace(s) in the feed
+
+  id                 "E8EB2802A1DD11F1B5CA0CC47A1E68C1"
+  recordedAt         "2026-08-27T06:09:50Z"
+  uri                "/sap/bc/adt/runtime/traces/abaptraces/E8EB2802A1DD11F1B5CA0CC47A1E68C1"
+  user               "OKYSLYTSIA"
+  objectName         "ZAC_SHR_RUN01=================CP"
+  state              {"value":"R","text":"Finished"}
+  expiresAt          "2026-09-24T06:09:50Z"
+  system             "E19"
+  client             "100"
+  host               "epbyminsd0654"
+  size               8
+  runtime            554
+  runtimeABAP        553
+  runtimeSystem      1
+  runtimeDatabase    0
+  isAggregated       false
+  amdpFileSize       0
+
+Every field the contract declares was present.
+

--- a/docs/evidence/2026-08-30-pr121-onprem/executors-run.log
+++ b/docs/evidence/2026-08-30-pr121-onprem/executors-run.log
@@ -1,0 +1,66 @@
+
+> @mcp-abap-adt/adt-clients@14.0.0 pretest
+> npm run test:check:integration && npm run --silent check:config
+
+
+> @mcp-abap-adt/adt-clients@14.0.0 test:check:integration
+> npx tsc --noEmit --project tsconfig.test.integration.json
+
+check:config — test-config.yaml carries all 78 sections the template does.
+
+> @mcp-abap-adt/adt-clients@14.0.0 test
+> npx jest --runInBand integration/executors
+
+[globalSetup] Checking SAP connectivity: http://epbyminsd0654.epam.com:8000 (onprem) (up to 30000ms; SKIP_SAP_PREFLIGHT=1 to skip, SAP_PREFLIGHT_TIMEOUT_MS to change) ...
+[globalSetup] session 69588147-4670-4340-a37d-afb8d6316912 — shared by every test file
+[globalSetup] SAP connection OK
+[1] ▶ START ClassExecutor - run :: run
+  → create class ZAC_CLS0236235
+  → update class source
+  → run
+  → run output: ZAC_CLS0236235=>run_probe( ) = 1
+[1] ✓ PASS ClassExecutor - run (4.6s)
+[1] ✓ END ClassExecutor - run
+
+[2] ▶ START ClassExecutor - runWithProfiling :: run_with_profiling
+  → create class ZAC_CLS0230799
+  → update class source
+  → warm-up run before profiling
+  → schedule a trace + run with profiler
+  → run output: ZAC_CLS0230799=>run_probe( ) = 1
+  → wait for the trace this run produced
+  → read all three views
+  → trace 11F98EDDA3E811F1B5CA0CC47A1E68C1: hitlist=11 rows, statements=9, dbAccesses=2
+[2] ✓ PASS ClassExecutor - runWithProfiling (5.3s)
+[2] ✓ END ClassExecutor - runWithProfiling
+
+PASS src/__tests__/integration/executors/class/ClassExecutor.test.ts (16.93 s)
+[1] ▶ START ProgramExecutor - run :: run
+  → create program ZAC_PROG0232480
+  → update program source
+  → run
+  → run output: 29.08.2026 ProgramExecutor integration ZAC_PROG0232480 1 -----------------------------------------------------------------------------------...
+[1] ✓ PASS ProgramExecutor - run (1.4s)
+[1] ✓ END ProgramExecutor - run
+
+[2] ▶ START ProgramExecutor - runWithProfiling :: run_with_profiling
+  → create program ZAC_PROG0233930
+  → update program source
+  → create trace parameters + run with profiler
+  → run output: 29.08.2026 ProgramExecutor integration ZAC_PROG0233930 1 -----------------------------------------------------------------------------------...; profilerId=/sap/bc/adt/runtime/traces/abaptraces/parameters/0CC47A1E68C11FE1A8FD02E40D6415CA
+  → poll for the trace this run produced
+  → traceId=17206B21A3E811F1B5CA0CC47A1E68C1
+  → read all three views
+  → trace 17206B21A3E811F1B5CA0CC47A1E68C1: hitlist=31 rows, statements=28, dbAccesses=2
+[2] ✓ PASS ProgramExecutor - runWithProfiling (2.2s)
+[2] ✓ END ProgramExecutor - runWithProfiling
+
+PASS src/__tests__/integration/executors/program/ProgramExecutor.test.ts (5.897 s)
+
+Test Suites: 2 passed, 2 total
+Tests:       4 passed, 4 total
+Snapshots:   0 total
+Time:        22.894 s, estimated 24 s
+Ran all test suites matching integration/executors.
+[globalTeardown] shared session released
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- a/docs/evidence/2026-08-30-pr121-onprem/include-run.log
+++ b/docs/evidence/2026-08-30-pr121-onprem/include-run.log
@@ -1,0 +1,38 @@
+
+> @mcp-abap-adt/adt-clients@14.0.0 pretest
+> npm run test:check:integration && npm run --silent check:config
+
+
+> @mcp-abap-adt/adt-clients@14.0.0 test:check:integration
+> npx tsc --noEmit --project tsconfig.test.integration.json
+
+check:config — test-config.yaml carries all 78 sections the template does.
+
+> @mcp-abap-adt/adt-clients@14.0.0 test
+> npx jest --runInBand integration/core/include
+
+[globalSetup] Checking SAP connectivity: http://epbyminsd0654.epam.com:8000 (onprem) (up to 30000ms; SKIP_SAP_PREFLIGHT=1 to skip, SAP_PREFLIGHT_TIMEOUT_MS to change) ...
+[globalSetup] session b71065b9-da6f-487e-a9f0-b77f73a1382c — shared by every test file
+[globalSetup] SAP connection OK
+[1] ▶ START Include - Full workflow :: adt_include
+  → validate
+  → create
+  → read (wait for object ready)
+  → read initial (post-create, no version)
+  → read initial (post-create, no version) length: 52 characters
+  → update
+  → read inactive (post-update)
+  → read inactive (post-update) length: 91 characters
+  → activate
+  → read active (post-activate)
+  → read active (post-activate) length: 91 characters
+  → delete (cleanup)
+PASS src/__tests__/integration/core/include/Include.test.ts (21.304 s)
+
+Test Suites: 1 passed, 1 total
+Tests:       2 passed, 2 total
+Snapshots:   0 total
+Time:        21.347 s
+Ran all test suites matching integration/core/include.
+[globalTeardown] shared session released
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- a/docs/evidence/2026-08-30-pr121-onprem/traces-run.log
+++ b/docs/evidence/2026-08-30-pr121-onprem/traces-run.log
@@ -1,0 +1,56 @@
+
+> @mcp-abap-adt/adt-clients@14.0.0 pretest
+> npm run test:check:integration && npm run --silent check:config
+
+
+> @mcp-abap-adt/adt-clients@14.0.0 test:check:integration
+> npx tsc --noEmit --project tsconfig.test.integration.json
+
+check:config — test-config.yaml carries all 78 sections the template does.
+
+> @mcp-abap-adt/adt-clients@14.0.0 test
+> npx jest --runInBand integration/runtime/traces
+
+[globalSetup] Checking SAP connectivity: http://epbyminsd0654.epam.com:8000 (onprem) (up to 30000ms; SKIP_SAP_PREFLIGHT=1 to skip, SAP_PREFLIGHT_TIMEOUT_MS to change) ...
+[globalSetup] session 35d2c0ea-6fef-4951-a18f-9b8b77e7a930 — shared by every test file
+[globalSetup] SAP connection OK
+[1] ▶ START Profiler Traces - list endpoints :: adt_profiler_traces
+  → list profiler traces
+  → list trace requests (the schedule)
+  → list profiler object types
+  → list profiler process types
+[1] ✓ PASS Profiler Traces - list endpoints (0.5s)
+[1] ✓ END Profiler Traces - list endpoints
+
+[2] ▶ START Profiler Traces - create parameters :: adt_profiler_traces
+  → create profiler trace parameters with defaults (POST)
+  → trace request id: /sap/bc/adt/runtime/traces/abaptraces/parameters/0CC47A1E68C11FE1A8FCDDA6F4FE35CA
+[2] ✓ PASS Profiler Traces - create parameters (0.1s)
+[2] ✓ END Profiler Traces - create parameters
+
+[3] ▶ START Profiler Traces - run with profiling :: adt_profiler_traces
+  → run shared class ZAC_SHR_RUN01 with profiling
+  → run output: Hello World 1 Hello World 2 Hello World 3 Hello World 4 Hello World 5
+  → profilerId=/sap/bc/adt/runtime/traces/abaptraces/parameters/0CC47A1E68C11FE1A8FCDDA6F4FE95CA; waiting for the trace
+[3] ✓ PASS Profiler Traces - run with profiling (0.6s)
+[3] ✓ END Profiler Traces - run with profiling
+
+[4] ▶ START Profiler Traces - discover traces :: adt_profiler_traces
+  → using trace id from profiled run: ED37A7F6A3E611F1B5CA0CC47A1E68C1
+[4] ✓ PASS Profiler Traces - discover traces (0.0s)
+[4] ✓ END Profiler Traces - discover traces
+
+[5] ▶ START Profiler Traces - read trace details :: adt_profiler_traces
+  → read trace hitlist for ED37A7F6A3E611F1B5CA0CC47A1E68C1
+  → read trace hitlist with system events for ED37A7F6A3E611F1B5CA0CC47A1E68C1
+  → read trace statements for ED37A7F6A3E611F1B5CA0CC47A1E68C1
+  → read trace db accesses for ED37A7F6A3E611F1B5CA0CC47A1E68C1
+PASS src/__tests__/integration/runtime/traces/ProfilerTraces.test.ts
+
+Test Suites: 1 passed, 1 total
+Tests:       6 passed, 6 total
+Snapshots:   0 total
+Time:        3.015 s, estimated 4 s
+Ran all test suites matching integration/runtime/traces.
+[globalTeardown] shared session released
+Force exiting Jest: Have you considered using `--detectOpenHandles` to detect async operations that kept running after all tests finished?

--- a/docs/usage/CLIENT_API_REFERENCE.md
+++ b/docs/usage/CLIENT_API_REFERENCE.md
@@ -937,8 +937,13 @@ Contract notes:
   document" is a trace chosen at random. Compare `recordedAt`.
 - `scheduleTrace()` answers with the request id and nothing else: reading the
   created parameters resource back gives `200` with an empty body.
-- `grossTime` and `traceEventNetTime` are typed `unknown` — the elements are on
-  every row, but their attributes were never captured, unlike `accessTime`'s.
+- `grossTime` and `traceEventNetTime` are `{ time, percentage }` since 14.0.0,
+  measured from a raw capture. The **unit of `time` is not named** — the wire
+  gives a figure and no unit; `percentage` is of the trace total, which is what
+  makes a row comparable without knowing it.
+- A trace entry carries more than an id: `system`, `client`, `host`, `size`,
+  `runtime` and its three parts, `isAggregated`, `amdpFileSize`. `client` is a
+  **string**, because `010` is not `10`.
 - Comparing `recordedAt` as a **string** is wrong: `09:00:00Z` is later than
   `10:00:00+02:00` and sorts lower as text. Use `compareRecordedAt`, which
   `latestTraceId()` does.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcp-abap-adt/adt-clients",
-      "version": "13.0.0",
+      "version": "14.0.0",
       "license": "MIT",
       "dependencies": {
-        "@mcp-abap-adt/interfaces": "^23.0.0",
+        "@mcp-abap-adt/interfaces": "^24.0.0",
         "@mcp-abap-adt/logger": "^0.1.3",
         "axios": "^1.18.1",
         "fast-xml-parser": "^5.9.3"
@@ -1050,9 +1050,9 @@
       }
     },
     "node_modules/@mcp-abap-adt/interfaces": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-23.0.0.tgz",
-      "integrity": "sha512-eBJKXkzyvukTA2weZDv6EMv38kmlC1whm+4ivPh32/hMFpgdYIJTOVdh5zQoJDuV3SOUVTRt4+ZRDrKVExi8DQ==",
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@mcp-abap-adt/interfaces/-/interfaces-24.0.0.tgz",
+      "integrity": "sha512-KGolHZNQMHqL7biVoCslaK4CzmkJ1mDGBmroas6J8SjBNv6SmPaewTgSGfkAuUbp74ZfUCVYHIi8I6TWw5Yvyw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -106,9 +106,10 @@
     "shared:setup": "npx jest --testPathIgnorePatterns node_modules --testPathPatterns admin/shared-deps/setup",
     "shared:teardown": "npx jest --testPathIgnorePatterns node_modules --testPathPatterns admin/shared-deps/teardown",
     "shared:check": "npx jest --testPathIgnorePatterns node_modules --testPathPatterns admin/shared-deps/check",
-    "pretest": "npm run test:check:integration",
+    "pretest": "npm run test:check:integration && npm run --silent check:config",
     "prepublishOnly": "npm run build",
-    "prepare": "husky"
+    "prepare": "husky",
+    "check:config": "node scripts/check-config-drift.js"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcp-abap-adt/adt-clients",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "ADT clients for SAP ABAP systems - AdtClient and AdtRuntimeClient",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -114,7 +114,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@mcp-abap-adt/interfaces": "^23.0.0",
+    "@mcp-abap-adt/interfaces": "^24.0.0",
     "@mcp-abap-adt/logger": "^0.1.3",
     "axios": "^1.18.1",
     "fast-xml-parser": "^5.9.3"

--- a/scripts/check-config-drift.js
+++ b/scripts/check-config-drift.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * The template is in git; the config is not. Say when they have drifted.
+ *
+ * `test-config.yaml` is gitignored, so a pull that adds a section to
+ * `test-config.yaml.template` leaves every existing checkout behind — silently.
+ * The suite that needs the new section then finds no test case, **skips, and
+ * reports PASS having run nothing**, which is the failure this repository keeps
+ * paying for: a green run that tested nothing looks exactly like a green run
+ * that tested everything.
+ *
+ * So: compare the top-level sections and report what the template has and the
+ * local config does not. It warns rather than fails — the config is the
+ * developer's, and a section they deliberately left out is their business. What
+ * they must not have is *no idea* that it appeared.
+ *
+ * Run: npm run check:config
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const TEMPLATE = path.join(
+  ROOT,
+  'src/__tests__/helpers/test-config.yaml.template',
+);
+const CONFIG = path.join(ROOT, 'src/__tests__/helpers/test-config.yaml');
+
+/**
+ * Top-level keys, read without a YAML parser.
+ *
+ * A dependency is not worth it for "lines that start in column zero and end in
+ * a colon", and this file must run before anything is installed.
+ */
+function sections(file) {
+  const found = new Set();
+  for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+    const match = /^([A-Za-z_][A-Za-z0-9_]*):\s*(#.*)?$/.exec(line);
+    if (match) {
+      found.add(match[1]);
+    }
+  }
+  return found;
+}
+
+if (!fs.existsSync(CONFIG)) {
+  console.log(
+    'check:config — no test-config.yaml yet. Run `npm run test:init` before the integration tests.',
+  );
+  process.exit(0);
+}
+
+const inTemplate = sections(TEMPLATE);
+const inConfig = sections(CONFIG);
+const missing = [...inTemplate].filter((s) => !inConfig.has(s)).sort();
+const extra = [...inConfig].filter((s) => !inTemplate.has(s)).sort();
+
+if (missing.length === 0 && extra.length === 0) {
+  console.log(
+    `check:config — test-config.yaml carries all ${inTemplate.size} sections the template does.`,
+  );
+  process.exit(0);
+}
+
+if (missing.length > 0) {
+  console.warn(
+    `\n⚠️  test-config.yaml is missing ${missing.length} section(s) the template has:\n`,
+  );
+  for (const s of missing) {
+    console.warn(`      ${s}`);
+  }
+  console.warn(
+    '\n   A suite whose section is absent finds no test case, skips, and reports\n' +
+      '   PASS having run nothing. Copy them from the template, or leave them out\n' +
+      '   deliberately — but knowingly.\n',
+  );
+}
+
+if (extra.length > 0) {
+  console.warn(
+    `   ${extra.length} section(s) exist locally and not in the template: ${extra.join(', ')}\n` +
+      '   Harmless, unless one was renamed upstream and yours is now the old name.\n',
+  );
+}
+
+// A warning, not a failure: the config belongs to whoever runs the tests.
+process.exit(0);

--- a/scripts/print-trace-entry.ts
+++ b/scripts/print-trace-entry.ts
@@ -1,0 +1,89 @@
+/**
+ * One parsed trace entry, printed field by field.
+ *
+ * The types say `IAbapTraceEntry` carries fourteen fields and that four of them
+ * are required. Nothing validates that at runtime — this library maps and does
+ * not judge — so a field the wire omits arrives as `undefined` **despite** the
+ * type saying otherwise. Compile-time proof does not reach that far, and the
+ * parser tests are transcribed from a capture rather than taken from a live
+ * read.
+ *
+ * So this prints what a real system actually produced, which is the only way to
+ * tell a typed field from an honoured one.
+ *
+ *   npx ts-node scripts/print-trace-entry.ts
+ *
+ * Credentials and target come from the same `.env` and `test-config.yaml` the
+ * tests use. Read-only: one GET of the trace feed, nothing written.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as dotenv from 'dotenv';
+import {
+  createTestConnection,
+  releaseTestConnection,
+} from '../src/__tests__/helpers/sessionConfig';
+import { refuseWhileRunOwnsSession } from '../src/__tests__/helpers/sharedSession';
+import { createConnectionLogger } from '../src/__tests__/helpers/testLogger';
+import { AdtRuntimeClient } from '../src/clients/AdtRuntimeClient';
+
+const envPath =
+  process.env.MCP_ENV_PATH || path.resolve(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath, quiet: true });
+}
+
+async function main() {
+  refuseWhileRunOwnsSession();
+
+  const logger = createConnectionLogger();
+  const connection = await createTestConnection(logger);
+  try {
+    const profiler = new AdtRuntimeClient(connection, logger).getProfiler();
+    const entries = await profiler.list();
+
+    // biome-ignore lint/suspicious/noConsole: a probe reports to whoever ran it
+    console.log(`\n${entries.length} trace(s) in the feed\n`);
+    if (entries.length === 0) {
+      // biome-ignore lint/suspicious/noConsole: same
+      console.log(
+        'Nothing to print. Run something with profiling first, or widen the user filter.\n',
+      );
+      return;
+    }
+
+    const [entry] = entries;
+    const missing: string[] = [];
+    for (const [field, value] of Object.entries(entry)) {
+      if (value === undefined) {
+        missing.push(field);
+      }
+      // biome-ignore lint/suspicious/noConsole: same
+      console.log(
+        `  ${field.padEnd(18)} ${value === undefined ? '— MISSING —' : JSON.stringify(value)}`,
+      );
+    }
+
+    // biome-ignore lint/suspicious/noConsole: same
+    console.log(
+      missing.length === 0
+        ? '\nEvery field the contract declares was present.\n'
+        : `\nMissing, though the contract declares them: ${missing.join(', ')}\n` +
+            'That is a type claiming more than the wire gives. Report it — the ' +
+            'fix is to relax the contract, not to paper over it here.\n',
+    );
+  } finally {
+    await releaseTestConnection(connection);
+  }
+}
+
+main().catch((error) => {
+  const e = error as { message?: string; response?: { status?: number } };
+  const status = e.response?.status;
+  // biome-ignore lint/suspicious/noConsole: a probe reports its own failure
+  console.error(
+    `\n${status ? `HTTP ${status}: ` : ''}${e.message ?? String(error)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/__tests__/unit/runtime/traceParsing.test.ts
+++ b/src/__tests__/unit/runtime/traceParsing.test.ts
@@ -36,22 +36,53 @@ const TRACE_ID = 'ABCDEF0123456789ABCD';
 
 describe('trace document mapping', () => {
   describe('the trace feed', () => {
-    it('reads the id out of the atom:id URI, and the moment it was recorded', () => {
-      const entries = parseTraceEntries(
-        FEED(
-          `<atom:entry><atom:id>/sap/bc/adt/runtime/traces/abaptraces/${TRACE_ID}</atom:id><atom:published>2026-08-28T10:00:00Z</atom:published></atom:entry>`,
-        ),
-      );
-      expect(entries).toEqual([
+    /** One entry exactly as E19 sends it, field for field. */
+    const REAL_ENTRY =
+      `<atom:entry><atom:author><atom:name>OKYSLYTSIA</atom:name></atom:author>` +
+      `<atom:id>/sap/bc/adt/runtime/traces/abaptraces/${TRACE_ID}</atom:id>` +
+      `<atom:published>2026-08-28T10:00:00Z</atom:published>` +
+      `<trc:extendedData><trc:host>somehost</trc:host><trc:size>8</trc:size>` +
+      `<trc:runtime>554</trc:runtime><trc:runtimeABAP>553</trc:runtimeABAP>` +
+      `<trc:runtimeSystem>1</trc:runtimeSystem><trc:runtimeDatabase>0</trc:runtimeDatabase>` +
+      `<trc:expiration>2026-09-24T06:09:50Z</trc:expiration><trc:system>ABC</trc:system>` +
+      `<trc:client>100</trc:client><trc:user>OKYSLYTSIA</trc:user>` +
+      `<trc:isAggregated>false</trc:isAggregated>` +
+      `<trc:objectName>ZAC_SHR_RUN01=================CP</trc:objectName>` +
+      `<trc:state value="R" text="Finished"/><trc:amdpFileSize>0</trc:amdpFileSize>` +
+      `</trc:extendedData></atom:entry>`;
+
+    it('reads every field the feed carries', () => {
+      // Transcribed from the raw capture rather than trimmed to what the
+      // parser happened to read: the point is that nothing in the document is
+      // dropped on the floor.
+      expect(parseTraceEntries(FEED(REAL_ENTRY))).toEqual([
         {
           id: TRACE_ID,
           recordedAt: '2026-08-28T10:00:00Z',
-          user: undefined,
-          objectName: undefined,
           uri: `/sap/bc/adt/runtime/traces/abaptraces/${TRACE_ID}`,
-          expiresAt: undefined,
+          user: 'OKYSLYTSIA',
+          objectName: 'ZAC_SHR_RUN01=================CP',
+          state: { value: 'R', text: 'Finished' },
+          expiresAt: '2026-09-24T06:09:50Z',
+          system: 'ABC',
+          client: '100',
+          host: 'somehost',
+          size: 8,
+          runtime: 554,
+          runtimeABAP: 553,
+          runtimeSystem: 1,
+          runtimeDatabase: 0,
+          isAggregated: false,
+          amdpFileSize: 0,
         },
       ]);
+    });
+
+    it('keeps the client as a string, because `010` is not `10`', () => {
+      const entries = parseTraceEntries(
+        FEED(REAL_ENTRY.replace('<trc:client>100<', '<trc:client>010<')),
+      );
+      expect(entries[0]?.client).toBe('010');
     });
 
     it('finds the trc: fields under extendedData', () => {
@@ -68,15 +99,17 @@ describe('trace document mapping', () => {
       });
     });
 
-    it('finds them directly on the entry too', () => {
-      // Which of the two nestings the traces feed really uses has never been
-      // read end to end, so the reader looks in both places.
+    it('reads the trc: fields from extendedData and nowhere else', () => {
+      // The reader used to look on the entry as well, because which nesting was
+      // real had never been read end to end. It has been now: sixty entries,
+      // every `trc:` field inside the container and not one outside it. A
+      // second lookup would be reading for a document nobody has seen.
       const entries = parseTraceEntries(
         FEED(
-          `<atom:entry><atom:id>/sap/bc/adt/runtime/traces/abaptraces/${TRACE_ID}</atom:id><atom:published>2026-08-28T10:00:00Z</atom:published><trc:user>SOMEONE</trc:user></atom:entry>`,
+          `<atom:entry><atom:id>/sap/bc/adt/runtime/traces/abaptraces/${TRACE_ID}</atom:id><atom:published>2026-08-28T10:00:00Z</atom:published><trc:objectName>ON_THE_ENTRY</trc:objectName></atom:entry>`,
         ),
       );
-      expect(entries[0]?.user).toBe('SOMEONE');
+      expect(entries[0]?.objectName).toBeUndefined();
     });
 
     it('falls back to atom:author for the user', () => {
@@ -117,6 +150,30 @@ describe('trace document mapping', () => {
       });
     });
 
+    it('reads the timings as a shape, not as whatever parsed', () => {
+      // `ITraceTiming` was `unknown` through two releases because the elements
+      // had been seen while their attributes never had. Both carry `time` and
+      // `percentage`, in the hit list and the statements alike.
+      const parsed = parseHitList(
+        response(
+          '<?xml version="1.0"?><trc:hitlist xmlns:trc="x"><trc:entry trc:index="1"><trc:grossTime time="243" percentage="43.8628"/></trc:entry></trc:hitlist>',
+        ),
+      );
+      expect(parsed.entries[0]?.grossTime).toEqual({
+        time: 243,
+        percentage: 43.8628,
+      });
+    });
+
+    it('leaves a timing absent when the element is', () => {
+      const parsed = parseHitList(
+        response(
+          '<?xml version="1.0"?><trc:hitlist xmlns:trc="x"><trc:entry trc:index="1"/></trc:hitlist>',
+        ),
+      );
+      expect(parsed.entries[0]?.grossTime).toBeUndefined();
+    });
+
     it('maps a statement, keeping the anchor that links it to the hit list', () => {
       const parsed = parseStatements(
         response(
@@ -129,6 +186,18 @@ describe('trace document mapping', () => {
         callLevel: 3,
         hitlistAnchor: 'A1',
         isProcedureLike: true,
+      });
+    });
+
+    it('reads traceEventNetTime the same way', () => {
+      const parsed = parseStatements(
+        response(
+          '<?xml version="1.0"?><trc:statements xmlns:trc="x"><trc:statement trc:id="7" trc:index="2"><trc:traceEventNetTime time="14" percentage="2.53"/></trc:statement></trc:statements>',
+        ),
+      );
+      expect(parsed.statements[0]?.traceEventNetTime).toEqual({
+        time: 14,
+        percentage: 2.53,
       });
     });
 

--- a/src/runtime/traces/ProfilerDomain.ts
+++ b/src/runtime/traces/ProfilerDomain.ts
@@ -1,5 +1,6 @@
 import type {
   IAbapConnection,
+  IAbapTraceEntry,
   IAbapTraceViews,
   IAdtResponse,
   ILogger,
@@ -9,7 +10,6 @@ import type {
   IProfilerTraceHitListOptions,
   IProfilerTraceParameters,
   IProfilerTraceStatementsOptions,
-  ITraceEntry,
   ViewArgs,
   ViewResult,
 } from '@mcp-abap-adt/interfaces';
@@ -50,7 +50,7 @@ export class Profiler implements IProfiler {
    * response is still available through {@link listTraceFilesResponse} for a
    * caller that wants the document itself.
    */
-  async list(options?: IProfilerListOptions): Promise<ITraceEntry[]> {
+  async list(options?: IProfilerListOptions): Promise<IAbapTraceEntry[]> {
     return parseTraceEntries(await this.listTraceFilesResponse(options));
   }
 

--- a/src/runtime/traces/traceParsing.ts
+++ b/src/runtime/traces/traceParsing.ts
@@ -45,15 +45,16 @@ import type {
   IAbapTraceAccessTime,
   IAbapTraceDbAccess,
   IAbapTraceDbAccesses,
+  IAbapTraceEntry,
   IAbapTraceHitList,
   IAbapTraceHitListEntry,
   IAbapTraceStatement,
   IAbapTraceStatements,
   IAdtResponse,
   INamedItem,
-  ITraceEntry,
   ITraceProgramRef,
   ITraceRequestEntry,
+  ITraceTiming,
 } from '@mcp-abap-adt/interfaces';
 import { XMLParser } from 'fast-xml-parser';
 
@@ -168,6 +169,27 @@ function attrBool(node: Node | undefined, name: string): boolean | undefined {
   return booleanOf(attr(node, name));
 }
 
+/**
+ * `trc:grossTime` / `trc:traceEventNetTime`.
+ *
+ * Both carry `time` and `percentage` and nothing else — measured across a whole
+ * hit list and a whole statements document. They were handed through as parsed
+ * while the contract typed them `unknown`; now the contract has a shape, so this
+ * reads it.
+ *
+ * The unit of `time` is not ours to name: the wire gives a figure and no unit.
+ */
+function timing(node: unknown): ITraceTiming | undefined {
+  const t = presentNode(node);
+  if (!t) {
+    return undefined;
+  }
+  return {
+    time: attrNum(t, 'time') as number,
+    percentage: attrNum(t, 'percentage') as number,
+  };
+}
+
 const ID_IN_URI = /abaptraces\/([A-Za-z0-9]{16,})(?:\/|$)/;
 
 /** The fractional digits beyond the millisecond, or '' when there are none. */
@@ -255,35 +277,56 @@ export function compareRecordedAt(
  * entries were minutes old while its last were eight days older. A caller that
  * wants the newest uses {@link compareRecordedAt}.
  */
-export function parseTraceEntries(response: IAdtResponse): ITraceEntry[] {
-  return asList(rootOf(response, 'feed').entry).map((entry): ITraceEntry => {
-    const idText = text(entry.id) ?? '';
-    const selfHref =
-      asList(entry.link)
-        .map((link) => attr(link, 'href') ?? '')
-        .find((href) => ID_IN_URI.test(href)) ?? '';
+export function parseTraceEntries(response: IAdtResponse): IAbapTraceEntry[] {
+  return asList(rootOf(response, 'feed').entry).map(
+    (entry): IAbapTraceEntry => {
+      const idText = text(entry.id) ?? '';
+      const selfHref =
+        asList(entry.link)
+          .map((link) => attr(link, 'href') ?? '')
+          .find((href) => ID_IN_URI.test(href)) ?? '';
 
-    // See the file comment: the `trc:` fields may sit directly on the entry or
-    // under `trc:extendedData`, and only one of those has been read.
-    const extended = presentNode(entry.extendedData) ?? {};
-    const field = (name: string): unknown => entry[name] ?? extended[name];
+      // Under `trc:extendedData`, and only there. The reader used to look on
+      // the entry as well, because which of the two nestings was real had never
+      // been read end to end. It has been now: sixty entries, every `trc:` field
+      // inside the container and not one outside it. The tolerance was a
+      // placeholder for a measurement, and the measurement arrived.
+      const ext = presentNode(entry.extendedData) ?? {};
+      const stateNode = presentNode(ext.state);
 
-    const stateNode = presentNode(field('state'));
-    const stateValue = attr(stateNode, 'value');
+      return {
+        id: (ID_IN_URI.exec(idText)?.[1] ??
+          ID_IN_URI.exec(selfHref)?.[1]) as string,
+        recordedAt: (text(entry.published) ?? text(entry.updated)) as string,
+        uri: idText || selfHref || undefined,
 
-    return {
-      id: (ID_IN_URI.exec(idText)?.[1] ??
-        ID_IN_URI.exec(selfHref)?.[1]) as string,
-      recordedAt: (text(entry.published) ?? text(entry.updated)) as string,
-      user: text(field('user')) ?? text(presentNode(entry.author)?.name),
-      objectName: text(field('objectName')),
-      uri: idText || selfHref || undefined,
-      ...(stateValue !== undefined
-        ? { state: { value: stateValue, text: attr(stateNode, 'text') ?? '' } }
-        : {}),
-      expiresAt: text(field('expiration')) ?? text(field('expires')),
-    };
-  });
+        // `atom:author/atom:name` carries the same name and is the fallback the
+        // feed itself offers.
+        user: (text(ext.user) ??
+          text(presentNode(entry.author)?.name)) as string,
+        objectName: text(ext.objectName) as string,
+        state: {
+          value: attr(stateNode, 'value') as string,
+          text: attr(stateNode, 'text') as string,
+        },
+        expiresAt: text(ext.expiration) as string,
+
+        system: text(ext.system) as string,
+        // A client is a code, not a count: `010` is not `10`.
+        client: text(ext.client) as string,
+        host: text(ext.host) as string,
+
+        size: numberOf(text(ext.size)) as number,
+        runtime: numberOf(text(ext.runtime)) as number,
+        runtimeABAP: numberOf(text(ext.runtimeABAP)) as number,
+        runtimeSystem: numberOf(text(ext.runtimeSystem)) as number,
+        runtimeDatabase: numberOf(text(ext.runtimeDatabase)) as number,
+
+        isAggregated: booleanOf(text(ext.isAggregated)) as boolean,
+        amdpFileSize: numberOf(text(ext.amdpFileSize)) as number,
+      };
+    },
+  );
 }
 
 /** `trc:callingProgram` / `trc:calledProgram`. */
@@ -315,7 +358,7 @@ export function parseHitList(response: IAdtResponse): IAbapTraceHitList {
         proceduralEntryAnchor: attr(row, 'proceduralEntryAnchor'),
         callingProgram: programRef(row.callingProgram),
         calledProgram: programRef(row.calledProgram),
-        grossTime: row.grossTime,
+        grossTime: timing(row.grossTime),
       }),
     ),
   };
@@ -336,8 +379,8 @@ export function parseStatements(response: IAdtResponse): IAbapTraceStatements {
         hitlistAnchor: attr(row, 'hitlistAnchor'),
         isProcedureLike: attrBool(row, 'isProcedureLike'),
         callingProgram: programRef(row.callingProgram),
-        grossTime: row.grossTime,
-        traceEventNetTime: row.traceEventNetTime,
+        grossTime: timing(row.grossTime),
+        traceEventNetTime: timing(row.traceEventNetTime),
       }),
     ),
   };

--- a/src/runtime/traces/traceParsing.ts
+++ b/src/runtime/traces/traceParsing.ts
@@ -312,7 +312,9 @@ export function parseTraceEntries(response: IAdtResponse): IAbapTraceEntry[] {
         expiresAt: text(ext.expiration) as string,
 
         system: text(ext.system) as string,
-        // A client is a code, not a count: `010` is not `10`.
+        // Codes, not counts. A client is `010` and an instance is `00`; the
+        // leading zero is significant and `Number('010')` destroys it
+        // irreversibly. Only what is actually counted is a number below.
         client: text(ext.client) as string,
         host: text(ext.host) as string,
 

--- a/tsconfig.test.integration.json
+++ b/tsconfig.test.integration.json
@@ -12,6 +12,7 @@
     "scripts/probe-atc.ts",
     "scripts/probe-abapunit.ts",
     "scripts/probe-profiler-contract.ts",
+    "scripts/print-trace-entry.ts",
     "scripts/probe-validation-params.ts"
   ],
   "exclude": [

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -17,6 +17,7 @@
     "scripts/probe-atc.ts",
     "scripts/probe-abapunit.ts",
     "scripts/probe-profiler-contract.ts",
+    "scripts/print-trace-entry.ts",
     "scripts/probe-validation-params.ts"
   ],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Follows `@mcp-abap-adt/interfaces@24.0.0`. Both changes come from one raw capture — `docs/evidence/2026-08-29-profiler-probe/`, the trace feed and all three views as whole files — rather than from a summary of one, which is why 13.0.0 shipped without them.

## The timings are a shape

`grossTime` and `traceEventNetTime` were handed through unopened while the contract typed them `unknown`. They carry `time` and `percentage`, in the hit list and the statements alike, with no variant in the documents read.

```ts
entry.grossTime?.time        // number — no narrowing
entry.grossTime?.percentage  // of the trace total
```

**The unit of `time` is still not named.** The wire gives a figure and no unit; `percentage` is what makes a row comparable without knowing it. Naming it `timeMicros` is the one thing the measurement does not license, and a `@ts-expect-error` in the contract's typechecks pins that.

## The entry carries what the feed sends

`Profiler.list()` returns `IAbapTraceEntry[]`. Ten fields the feed always carried and this library was discarding:

`system`, `client`, `host`, `size`, `runtime`, `runtimeABAP`, `runtimeSystem`, `runtimeDatabase`, `isAggregated`, `amdpFileSize`

and four that stop being optional — `user`, `objectName`, `state`, `expiresAt` — because sixty entries out of sixty had them.

`client` is a **string**, pinned by its own test: a client is a code, `010` is not `10`, and a number is the obvious wrong choice.

## The tolerance is gone, because the measurement arrived

The entry reader looked under `trc:extendedData` **and** directly on the entry, because which nesting was real had never been read end to end. It has been now: sixty entries, every `trc:` field inside the container, not one outside it.

The second lookup was a placeholder for a measurement. Keeping it afterwards would be reading for a document nobody has seen — so a test now asserts that a `trc:objectName` placed on the entry is **not** read.

## Migration

Readers gain fields and lose four optionality checks. A variable declared as `ITraceEntry` still compiles, since `IAbapTraceEntry` extends it. `entry.grossTime` no longer needs narrowing.

## Verified

`build`, `test:check` and `lint:check` exit `0`; 99 suites / 1087 unit tests green.

**Not run against SAP.** The three integration suites that touch this code — `integration/runtime/traces`, `integration/core/include`, the executors — passed on E19 at `13.0.0` and have not been re-run since these shapes changed. The parser tests are transcribed from the capture, so the mapping is pinned; what is unproven is the round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
